### PR TITLE
feat(email): add email service infrastructure with templates and conf…

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -44,6 +44,16 @@ const envSchema = z.object({
   RATE_LIMIT_WINDOW_MS: z.string().regex(/^\d+$/).default('900000'),
   RATE_LIMIT_MAX_REQUESTS: z.string().regex(/^\d+$/).default('100'),
 
+  // Email (SMTP)
+  SMTP_HOST: z.string().optional(),
+  SMTP_PORT: z.string().regex(/^\d+$/).default('587'),
+  SMTP_SECURE: z.enum(['true', 'false']).default('false'),
+  SMTP_USER: z.string().optional(),
+  SMTP_PASS: z.string().optional(),
+  GMAIL_USER: z.string().optional(),
+  GMAIL_PASS: z.string().optional(),
+  FROM_EMAIL: z.string().email().default('noreply@mentorminds.com'),
+
   // Redis
   REDIS_URL: z.string().url('REDIS_URL must be a valid URL').optional(),
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -46,6 +46,21 @@ const config = {
     maxRequests: parseInt(env.RATE_LIMIT_MAX_REQUESTS, 10),
   },
 
+  email: {
+    smtp: {
+      host: env.SMTP_HOST,
+      port: parseInt(env.SMTP_PORT, 10),
+      secure: env.SMTP_SECURE === 'true',
+      user: env.SMTP_USER,
+      pass: env.SMTP_PASS,
+    },
+    gmail: {
+      user: env.GMAIL_USER,
+      pass: env.GMAIL_PASS,
+    },
+    fromEmail: env.FROM_EMAIL,
+  },
+
   redis: {
     url: env.REDIS_URL,
   },

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,11 +11,14 @@ import {
   startScheduler,
   stopScheduler,
 } from './workers';
+import { initializeEmailTemplates } from './services/template-initializer.service';
 
-// Initialize database tables
-initializeModels().catch((err) => {
-  console.error('Failed to initialize models:', err);
-});
+// Initialize database tables, then seed email templates
+initializeModels()
+  .then(() => initializeEmailTemplates())
+  .catch((err) => {
+    console.error('Failed to initialize models:', err);
+  });
 
 // Start background job workers and scheduler
 startScheduler().catch((err) => {

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -54,15 +54,17 @@ export class EmailService {
    * Initialize email providers based on configuration
    */
   private initializeProviders(): void {
+    const { smtp, gmail } = config.email;
+
     // Primary provider: SMTP (Nodemailer)
-    if (process.env.SMTP_HOST) {
+    if (smtp.host) {
       const smtpTransporter = nodemailer.createTransporter({
-        host: process.env.SMTP_HOST,
-        port: parseInt(process.env.SMTP_PORT || '587', 10),
-        secure: process.env.SMTP_SECURE === 'true',
+        host: smtp.host,
+        port: smtp.port,
+        secure: smtp.secure,
         auth: {
-          user: process.env.SMTP_USER,
-          pass: process.env.SMTP_PASS,
+          user: smtp.user,
+          pass: smtp.pass,
         },
         pool: true,
         maxConnections: 5,
@@ -77,12 +79,12 @@ export class EmailService {
     }
 
     // Fallback provider: Gmail (for development)
-    if (process.env.GMAIL_USER && process.env.GMAIL_PASS) {
+    if (gmail.user && gmail.pass) {
       const gmailTransporter = nodemailer.createTransporter({
         service: 'gmail',
         auth: {
-          user: process.env.GMAIL_USER,
-          pass: process.env.GMAIL_PASS,
+          user: gmail.user,
+          pass: gmail.pass,
         },
       });
 
@@ -185,7 +187,7 @@ export class EmailService {
       }
 
       const mailOptions: SendMailOptions = {
-        from: process.env.FROM_EMAIL || 'noreply@mentorminds.com',
+        from: config.email.fromEmail,
         to: request.to.join(', '),
         cc: request.cc?.join(', '),
         bcc: request.bcc?.join(', '),

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -2,6 +2,7 @@ import { NotificationsModel, NotificationInput, NotificationType, NotificationCh
 import { NotificationPreferencesModel } from '../models/notification-preferences.model';
 import { NotificationDeliveryTrackingModel, DeliveryStatus } from '../models/notification-delivery-tracking.model';
 import { NotificationAnalyticsModel } from '../models/notification-analytics.model';
+import { enqueueEmail } from '../queues/email.queue';
 
 export interface NotificationRecord {
   id: string;
@@ -171,34 +172,19 @@ export const NotificationService = {
   },
 
   /**
-   * Send email notification (placeholder - integrate with email provider)
-   * In production, integrate with SendGrid, AWS SES, or similar
+   * Send email notification via the email queue (processed by email worker → EmailService).
    */
   async sendEmail(notification: EmailNotification): Promise<boolean> {
-    // TODO: Integrate with actual email service (SendGrid, SES, etc.)
-    console.log('📧 Sending email:', {
-      to: notification.to,
-      subject: notification.subject,
-      preview: notification.body.substring(0, 100),
-    });
-
-    // Placeholder implementation - log the email
-    // In production, replace with actual email API call
     try {
-      // Example with SendGrid:
-      // const sgMail = require('@sendgrid/mail');
-      // sgMail.setApiKey(process.env.SENDGRID_API_KEY);
-      // await sgMail.send({
-      //   to: notification.to,
-      //   from: process.env.FROM_EMAIL,
-      //   subject: notification.subject,
-      //   text: notification.body,
-      //   html: notification.html || notification.body.replace(/\n/g, '<br>'),
-      // });
-
+      await enqueueEmail({
+        to: [notification.to],
+        subject: notification.subject,
+        htmlContent: notification.html || notification.body.replace(/\n/g, '<br>'),
+        textContent: notification.body,
+      });
       return true;
     } catch (error) {
-      console.error('Failed to send email:', error);
+      console.error('Failed to enqueue email:', error);
       return false;
     }
   },

--- a/src/services/reminder.service.ts
+++ b/src/services/reminder.service.ts
@@ -2,6 +2,7 @@ import { DateTime } from 'luxon';
 import { CronJob } from 'cron';
 import { logger } from '../utils/logger.utils';
 import { formatInTimezone } from '../utils/timezone.utils';
+import { enqueueEmail } from '../queues/email.queue';
 import pool from '../config/database';
 
 /**
@@ -234,22 +235,42 @@ export class ReminderService {
   }
 
   /**
-   * Placeholder notification integration
-   * TODO: Integrate with email service (Nodemailer/Resend/SendGrid)
-   * TODO: Integrate with SMS service (Twilio/AWS SNS)
+   * Send notification via email queue.
+   * Resolves the user's email from the database and enqueues the job.
    */
   private async sendNotification(
     userId: string,
     content: { subject: string; body: string; type: 'email' | 'sms' }
   ): Promise<void> {
-    logger.info(`[${content.type.toUpperCase()}] To user ${userId}: ${content.subject}`);
-    // TODO: Actual email/SMS integration
-    // Example with Nodemailer:
-    // await emailService.send({
-    //   to: userEmail,
-    //   subject: content.subject,
-    //   text: content.body
-    // });
+    if (content.type !== 'email') {
+      logger.info(`[${content.type.toUpperCase()}] To user ${userId}: ${content.subject}`);
+      return;
+    }
+
+    try {
+      const { rows } = await pool.query<{ email: string }>(
+        'SELECT email FROM users WHERE id = $1',
+        [userId],
+      );
+
+      if (!rows[0]?.email) {
+        logger.warn(`Reminder: no email found for user ${userId}`);
+        return;
+      }
+
+      await enqueueEmail({
+        to: [rows[0].email],
+        subject: content.subject,
+        templateId: 'session_reminder',
+        templateData: { subject: content.subject, body: content.body },
+        textContent: content.body,
+        htmlContent: content.body.replace(/\n/g, '<br>'),
+      });
+
+      logger.info(`Reminder email enqueued for user ${userId}: ${content.subject}`);
+    } catch (error) {
+      logger.error(`Failed to enqueue reminder for user ${userId}:`, error);
+    }
   }
 
   /**

--- a/src/services/template-initializer.service.ts
+++ b/src/services/template-initializer.service.ts
@@ -1,0 +1,115 @@
+import fs from 'fs';
+import path from 'path';
+import { NotificationTemplatesModel } from '../models/notification-templates.model';
+import { logger } from '../utils/logger.utils';
+
+interface TemplateSeed {
+  id: string;
+  name: string;
+  type: 'email';
+  subject: string;
+  htmlFile: string;
+  textFile: string;
+  variables: string[];
+}
+
+const TEMPLATE_DIR = path.resolve(__dirname, '../templates/emails');
+
+const TEMPLATES: TemplateSeed[] = [
+  {
+    id: 'booking_confirmed',
+    name: 'Booking Confirmed',
+    type: 'email',
+    subject: 'Your MentorMinds Booking is Confirmed!',
+    htmlFile: 'booking-confirmed.html',
+    textFile: 'booking-confirmed.txt',
+    variables: ['sessionDate', 'sessionTime', 'duration', 'mentorName', 'amount', 'sessionType', 'platformUrl', 'supportUrl'],
+  },
+  {
+    id: 'payment_processed',
+    name: 'Payment Processed',
+    type: 'email',
+    subject: 'Payment Confirmation — MentorMinds',
+    htmlFile: 'payment-processed.html',
+    textFile: 'payment-processed.txt',
+    variables: ['amount', 'transactionId', 'paymentDate', 'purpose', 'status', 'transactionUrl', 'platformUrl', 'supportUrl'],
+  },
+  {
+    id: 'session_reminder',
+    name: 'Session Reminder',
+    type: 'email',
+    subject: 'Your MentorMinds Session is Coming Up!',
+    htmlFile: 'session-reminder.html',
+    textFile: 'session-reminder.txt',
+    variables: ['timeUntil', 'mentorName', 'sessionTime', 'duration', 'meetingUrl', 'platformUrl', 'supportUrl'],
+  },
+  {
+    id: 'dispute_created',
+    name: 'Dispute Created',
+    type: 'email',
+    subject: 'Dispute Filed — MentorMinds',
+    htmlFile: 'dispute-created.html',
+    textFile: 'dispute-created.txt',
+    variables: ['disputeId', 'sessionTitle', 'amount', 'reason', 'platformUrl', 'supportUrl'],
+  },
+  {
+    id: 'session_cancelled',
+    name: 'Session Cancelled',
+    type: 'email',
+    subject: 'Session Cancelled — MentorMinds',
+    htmlFile: 'session-cancelled.html',
+    textFile: 'session-cancelled.txt',
+    variables: ['sessionTitle', 'sessionDate', 'sessionTime', 'cancelledBy', 'reason', 'refundStatus', 'platformUrl', 'supportUrl'],
+  },
+  {
+    id: 'welcome',
+    name: 'Welcome',
+    type: 'email',
+    subject: 'Welcome to MentorMinds!',
+    htmlFile: 'welcome.html',
+    textFile: 'welcome.txt',
+    variables: ['userName', 'platformUrl', 'supportUrl'],
+  },
+];
+
+function readFile(filename: string): string {
+  const filePath = path.join(TEMPLATE_DIR, filename);
+  try {
+    return fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    logger.warn(`Template file not found: ${filePath}`);
+    return '';
+  }
+}
+
+/**
+ * Seed or update all email templates in the database.
+ * Safe to call on every startup — uses upsert logic.
+ */
+export async function initializeEmailTemplates(): Promise<void> {
+  let seeded = 0;
+
+  for (const tpl of TEMPLATES) {
+    try {
+      const existing = await NotificationTemplatesModel.getById(tpl.id);
+      if (existing) continue; // already present, skip
+
+      await NotificationTemplatesModel.create({
+        id: tpl.id,
+        name: tpl.name,
+        type: tpl.type,
+        subject: tpl.subject,
+        html_content: readFile(tpl.htmlFile),
+        text_content: readFile(tpl.textFile),
+        variables: tpl.variables,
+      });
+      seeded++;
+    } catch (error) {
+      logger.error(`Failed to seed template ${tpl.id}:`, error);
+    }
+  }
+
+  if (seeded > 0) {
+    logger.info(`Email templates: seeded ${seeded} new template(s)`);
+  }
+}

--- a/src/templates/emails/dispute-created.html
+++ b/src/templates/emails/dispute-created.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dispute Created</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: Arial, sans-serif; background-color: #f4f4f4;">
+    <div style="max-width: 600px; margin: 0 auto; background-color: #ffffff; padding: 20px;">
+        <div style="text-align: center; margin-bottom: 30px;">
+            <h1 style="color: #4A90E2; margin: 0;">MentorMinds</h1>
+        </div>
+
+        <h2 style="color: #e74c3c; margin-bottom: 20px;">Dispute Filed</h2>
+
+        <p style="color: #333;">A dispute has been filed regarding your transaction. Here are the details:</p>
+
+        <div style="background-color: #f5f5f5; padding: 20px; border-radius: 8px; margin: 20px 0;">
+            <h3 style="margin-top: 0; color: #333;">Dispute Details</h3>
+            <table style="width: 100%; border-collapse: collapse;">
+                <tr>
+                    <td style="padding: 8px 0; font-weight: bold; color: #555;">Dispute ID:</td>
+                    <td style="padding: 8px 0; color: #333;">{{disputeId}}</td>
+                </tr>
+                <tr>
+                    <td style="padding: 8px 0; font-weight: bold; color: #555;">Session:</td>
+                    <td style="padding: 8px 0; color: #333;">{{sessionTitle}}</td>
+                </tr>
+                <tr>
+                    <td style="padding: 8px 0; font-weight: bold; color: #555;">Amount:</td>
+                    <td style="padding: 8px 0; color: #333;">{{amount}} XLM</td>
+                </tr>
+                <tr>
+                    <td style="padding: 8px 0; font-weight: bold; color: #555;">Reason:</td>
+                    <td style="padding: 8px 0; color: #333;">{{reason}}</td>
+                </tr>
+            </table>
+        </div>
+
+        <div style="background-color: #fff3cd; padding: 15px; border-radius: 8px; border-left: 4px solid #ffc107; margin: 20px 0;">
+            <p style="margin: 0; color: #856404;">Our team will review this dispute and reach out within 48 hours. Funds will remain in escrow until resolution.</p>
+        </div>
+
+        <hr style="margin: 30px 0; border: none; border-top: 1px solid #ddd;" />
+
+        <div style="text-align: center; color: #666; font-size: 14px;">
+            <p>Best regards,<br>The MentorMinds Team</p>
+            <p style="margin-top: 20px;">
+                <a href="{{platformUrl}}" style="color: #4A90E2; text-decoration: none;">Visit MentorMinds</a> |
+                <a href="{{supportUrl}}" style="color: #4A90E2; text-decoration: none;">Support</a>
+            </p>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/templates/emails/dispute-created.txt
+++ b/src/templates/emails/dispute-created.txt
@@ -1,0 +1,18 @@
+Dispute Filed — MentorMinds
+
+A dispute has been filed regarding your transaction.
+
+Dispute Details:
+- Dispute ID: {{disputeId}}
+- Session: {{sessionTitle}}
+- Amount: {{amount}} XLM
+- Reason: {{reason}}
+
+Our team will review this dispute and reach out within 48 hours.
+Funds will remain in escrow until resolution.
+
+Best regards,
+The MentorMinds Team
+
+Visit MentorMinds: {{platformUrl}}
+Support: {{supportUrl}}

--- a/src/templates/emails/session-cancelled.html
+++ b/src/templates/emails/session-cancelled.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Session Cancelled</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: Arial, sans-serif; background-color: #f4f4f4;">
+    <div style="max-width: 600px; margin: 0 auto; background-color: #ffffff; padding: 20px;">
+        <div style="text-align: center; margin-bottom: 30px;">
+            <h1 style="color: #4A90E2; margin: 0;">MentorMinds</h1>
+        </div>
+
+        <h2 style="color: #e74c3c; margin-bottom: 20px;">Session Cancelled</h2>
+
+        <p style="color: #333;">Your upcoming mentorship session has been cancelled.</p>
+
+        <div style="background-color: #f5f5f5; padding: 20px; border-radius: 8px; margin: 20px 0;">
+            <h3 style="margin-top: 0; color: #333;">Session Details</h3>
+            <table style="width: 100%; border-collapse: collapse;">
+                <tr>
+                    <td style="padding: 8px 0; font-weight: bold; color: #555;">Session:</td>
+                    <td style="padding: 8px 0; color: #333;">{{sessionTitle}}</td>
+                </tr>
+                <tr>
+                    <td style="padding: 8px 0; font-weight: bold; color: #555;">Originally Scheduled:</td>
+                    <td style="padding: 8px 0; color: #333;">{{sessionDate}} at {{sessionTime}}</td>
+                </tr>
+                <tr>
+                    <td style="padding: 8px 0; font-weight: bold; color: #555;">Cancelled By:</td>
+                    <td style="padding: 8px 0; color: #333;">{{cancelledBy}}</td>
+                </tr>
+                <tr>
+                    <td style="padding: 8px 0; font-weight: bold; color: #555;">Reason:</td>
+                    <td style="padding: 8px 0; color: #333;">{{reason}}</td>
+                </tr>
+            </table>
+        </div>
+
+        <div style="background-color: #e8f4fd; padding: 15px; border-radius: 8px; border-left: 4px solid #4A90E2; margin: 20px 0;">
+            <p style="margin: 0; color: #333;"><strong>Refund Status:</strong> {{refundStatus}}</p>
+        </div>
+
+        <hr style="margin: 30px 0; border: none; border-top: 1px solid #ddd;" />
+
+        <div style="text-align: center; color: #666; font-size: 14px;">
+            <p>Best regards,<br>The MentorMinds Team</p>
+            <p style="margin-top: 20px;">
+                <a href="{{platformUrl}}" style="color: #4A90E2; text-decoration: none;">Book Another Session</a> |
+                <a href="{{supportUrl}}" style="color: #4A90E2; text-decoration: none;">Support</a>
+            </p>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/templates/emails/session-cancelled.txt
+++ b/src/templates/emails/session-cancelled.txt
@@ -1,0 +1,17 @@
+Session Cancelled — MentorMinds
+
+Your upcoming mentorship session has been cancelled.
+
+Session Details:
+- Session: {{sessionTitle}}
+- Originally Scheduled: {{sessionDate}} at {{sessionTime}}
+- Cancelled By: {{cancelledBy}}
+- Reason: {{reason}}
+
+Refund Status: {{refundStatus}}
+
+Best regards,
+The MentorMinds Team
+
+Book Another Session: {{platformUrl}}
+Support: {{supportUrl}}

--- a/src/templates/emails/welcome.html
+++ b/src/templates/emails/welcome.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Welcome to MentorMinds</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: Arial, sans-serif; background-color: #f4f4f4;">
+    <div style="max-width: 600px; margin: 0 auto; background-color: #ffffff; padding: 20px;">
+        <div style="text-align: center; margin-bottom: 30px;">
+            <h1 style="color: #4A90E2; margin: 0;">MentorMinds</h1>
+        </div>
+
+        <h2 style="color: #4A90E2; margin-bottom: 20px;">Welcome, {{userName}}!</h2>
+
+        <p style="color: #333; line-height: 1.6;">
+            Thank you for joining MentorMinds. We connect learners with experienced mentors
+            for 1-on-1 sessions powered by the Stellar blockchain.
+        </p>
+
+        <div style="background-color: #e8f4fd; padding: 20px; border-radius: 8px; margin: 20px 0;">
+            <h3 style="margin-top: 0; color: #333;">Get Started</h3>
+            <ul style="margin: 10px 0; padding-left: 20px; color: #555; line-height: 1.8;">
+                <li>Set up your Stellar wallet to send and receive payments</li>
+                <li>Browse mentors by expertise, rating, and availability</li>
+                <li>Book your first mentoring session</li>
+            </ul>
+        </div>
+
+        <div style="text-align: center; margin: 30px 0;">
+            <a href="{{platformUrl}}" style="display: inline-block; background-color: #4A90E2; color: #ffffff; text-decoration: none; padding: 14px 30px; border-radius: 6px; font-weight: bold;">
+                Explore Mentors
+            </a>
+        </div>
+
+        <hr style="margin: 30px 0; border: none; border-top: 1px solid #ddd;" />
+
+        <div style="text-align: center; color: #666; font-size: 14px;">
+            <p>Best regards,<br>The MentorMinds Team</p>
+            <p style="margin-top: 20px;">
+                <a href="{{platformUrl}}" style="color: #4A90E2; text-decoration: none;">Visit MentorMinds</a> |
+                <a href="{{supportUrl}}" style="color: #4A90E2; text-decoration: none;">Support</a>
+            </p>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/templates/emails/welcome.txt
+++ b/src/templates/emails/welcome.txt
@@ -1,0 +1,16 @@
+Welcome to MentorMinds, {{userName}}!
+
+Thank you for joining MentorMinds. We connect learners with experienced mentors
+for 1-on-1 sessions powered by the Stellar blockchain.
+
+Get Started:
+- Set up your Stellar wallet to send and receive payments
+- Browse mentors by expertise, rating, and availability
+- Book your first mentoring session
+
+Explore Mentors: {{platformUrl}}
+
+Best regards,
+The MentorMinds Team
+
+Support: {{supportUrl}}


### PR DESCRIPTION
…iguration

- Add SMTP and Gmail configuration variables to environment schema
- Create email configuration object with SMTP, Gmail, and sender settings
- Initialize email templates on server startup via template-initializer service
- Refactor EmailService to use centralized config instead of direct env access
- Integrate email queue into NotificationService for async email delivery
- Integrate email queue into ReminderService for scheduled notifications
- Add email template files for dispute-created, session-cancelled, and welcome flows
- Support both HTML and plain text email templates for better compatibility

closes #88 