### PR TITLE
Private Interface Exposed Publicly

### DIFF
--- a/src/config/socket.ts
+++ b/src/config/socket.ts
@@ -1,31 +1,68 @@
-import { Server as SocketIOServer } from 'socket.io';
+import { Server as SocketIOServer, Socket } from 'socket.io';
 import { Server as HTTPServer } from 'http';
 import jwt from 'jsonwebtoken';
 import { env } from './env';
 import { logger } from '../utils/logger.utils';
 import { SocketService } from '../services/socket.service';
+import { PresenceService } from '../services/presence.service';
+import { redis } from './redis';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
 
 export interface AuthenticatedSocket extends Socket {
   userId: string;
   role: string;
 }
 
-export interface AuthenticatedSocket extends Socket {
-  userId: string;
-  role: string;
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Must match client-side heartbeat interval (20 s). */
+const HEARTBEAT_INTERVAL_MS = 20_000;
+
+// ─── Module-level singletons ──────────────────────────────────────────────────
+
+let io: SocketIOServer;
+const presenceService = new PresenceService(redis);
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Emit a presence event to every peer who shares a confirmed/in-progress
+ * session with `userId`. Uses personal rooms (`user:{peerId}`) so only
+ * relevant sockets receive the event.
+ */
+async function broadcastPresence(
+  userId: string,
+  event: 'user:online' | 'user:offline'
+): Promise<void> {
+  const audienceIds = await presenceService.getPresenceAudience(userId);
+
+  for (const peerId of audienceIds) {
+    io.to(`user:${peerId}`).emit(event, {
+      userId,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  logger.info(`Socket.IO: Broadcast ${event}`, { userId, audienceSize: audienceIds.length });
 }
+
+// ─── Factory ──────────────────────────────────────────────────────────────────
 
 export function createSocketServer(httpServer: HTTPServer): SocketIOServer {
-  const io = new SocketIOServer(httpServer, {
+  io = new SocketIOServer(httpServer, {
     path: '/socket.io',
     cors: {
       origin: env.CORS_ORIGIN?.split(',') || ['http://localhost:3000'],
       methods: ['GET', 'POST'],
       credentials: true,
     },
+    // Transport-level ping/pong (distinct from application heartbeat)
+    pingTimeout: 10_000,
+    pingInterval: 25_000,
   });
 
-  // JWT authentication middleware
+  // ── JWT authentication middleware ──────────────────────────────────────────
   io.use((socket: any, next) => {
     const token = socket.handshake.auth?.token || socket.handshake.query?.token;
 
@@ -37,11 +74,11 @@ export function createSocketServer(httpServer: HTTPServer): SocketIOServer {
     try {
       const decoded = jwt.verify(token, env.JWT_SECRET) as any;
       socket.userId = decoded.userId;
-      socket.role = decoded.role;
+      socket.role   = decoded.role;
       logger.info('Socket.IO: User authenticated', {
         socketId: socket.id,
-        userId: socket.userId,
-        role: socket.role,
+        userId:   socket.userId,
+        role:     socket.role,
       });
       next();
     } catch (err) {
@@ -50,29 +87,43 @@ export function createSocketServer(httpServer: HTTPServer): SocketIOServer {
     }
   });
 
-  io.on('connection', (socket: AuthenticatedSocket) => {
+  // ── Connection handler ─────────────────────────────────────────────────────
+  io.on('connection', async (rawSocket) => {
+    const socket = rawSocket as AuthenticatedSocket;
     const { userId, role } = socket;
 
-    // Join user to personal room
+    // Each socket joins a personal room for targeted emissions
     socket.join(`user:${userId}`);
 
-    logger.info('Socket.IO: Client connected', {
-      socketId: socket.id,
-      userId,
-      role,
+    logger.info('Socket.IO: Client connected', { socketId: socket.id, userId, role });
+
+    // Mark online; broadcast user:online only on a fresh offline→online transition
+    const isNewlyOnline = await presenceService.markOnline(userId);
+    if (isNewlyOnline) {
+      await broadcastPresence(userId, 'user:online');
+    }
+
+    // ── Application-level heartbeat ──────────────────────────────────────────
+    // Client must emit 'heartbeat' every 20 s. Each ping refreshes the Redis
+    // TTL (SET online:{userId} 1 EX 30). If the client stops pinging the key
+    // expires and the user is considered offline for subsequent status queries.
+    socket.on('heartbeat', async () => {
+      await presenceService.markOnline(userId);
     });
 
-    // Handle disconnection
-    socket.on('disconnect', (reason) => {
-      logger.info('Socket.IO: Client disconnected', {
-        socketId: socket.id,
-        userId,
-        role,
-        reason,
-      });
-    });
+    // ── Server-side staleness check ──────────────────────────────────────────
+    // Catches clients whose JS was suspended (background tab, device sleep)
+    // without a clean WebSocket disconnect.
+    const heartbeatTimer = setInterval(async () => {
+      const { online } = await presenceService.getStatus(userId);
+      if (!online) {
+        clearInterval(heartbeatTimer);
+        await broadcastPresence(userId, 'user:offline');
+        socket.disconnect(true);
+      }
+    }, HEARTBEAT_INTERVAL_MS + 5_000); // check 5 s after expected ping
 
-    // Handle reconnection - replay last 5 missed events
+    // ── Reconnection — replay missed events ──────────────────────────────────
     socket.on('reconnect', () => {
       logger.info('Socket.IO: Client reconnected, replaying missed events', {
         socketId: socket.id,
@@ -80,7 +131,34 @@ export function createSocketServer(httpServer: HTTPServer): SocketIOServer {
       });
       SocketService.replayMissedEvents(userId);
     });
+
+    // ── Disconnect ───────────────────────────────────────────────────────────
+    socket.on('disconnect', async (reason) => {
+      clearInterval(heartbeatTimer);
+
+      logger.info('Socket.IO: Client disconnected', {
+        socketId: socket.id,
+        userId,
+        role,
+        reason,
+      });
+
+      // Mark offline; broadcast user:offline only on a fresh online→offline transition
+      const isNewlyOffline = await presenceService.markOffline(userId);
+      if (isNewlyOffline) {
+        await broadcastPresence(userId, 'user:offline');
+      }
+    });
   });
 
+  return io;
+}
+
+/**
+ * Access the Socket.IO instance from other modules (e.g. booking service)
+ * without creating circular imports.
+ */
+export function getIO(): SocketIOServer {
+  if (!io) throw new Error('Socket.IO not initialised — call createSocketServer first');
   return io;
 }

--- a/src/controllers/presence.controller.ts
+++ b/src/controllers/presence.controller.ts
@@ -1,0 +1,123 @@
+import { Request, Response, NextFunction } from "express";
+import { z } from "zod";
+import { PresenceService } from "../services/presence.service";
+import { redis } from "../config/redis"; // your existing ioredis instance
+
+const presenceService = new PresenceService(redis);
+
+// ─── Validation schemas ───────────────────────────────────────────────────────
+
+const batchStatusSchema = z.object({
+  userIds: z
+    .array(z.string().uuid())
+    .min(1, "At least one userId required")
+    .max(100, "Maximum 100 userIds per request"),
+});
+
+// ─── Controllers ─────────────────────────────────────────────────────────────
+
+/**
+ * GET /api/v1/users/:id/online
+ *
+ * Returns the online status of a single user.
+ * Privacy check: requester must share a confirmed/in-progress session
+ * with the target, or be the target themselves.
+ *
+ * Response 200:
+ *   { online: boolean, last_seen: string | null }
+ *
+ * Response 403:
+ *   { message: "Not authorised to view this user's online status" }
+ */
+export async function getUserOnlineStatus(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const requesterId = req.user!.userId; // set by JWT auth middleware
+    const targetId = req.params.id;
+
+    const allowed = await presenceService.canViewStatus(requesterId, targetId);
+    if (!allowed) {
+      res.status(403).json({
+        message: "Not authorised to view this user's online status",
+      });
+      return;
+    }
+
+    const status = await presenceService.getStatus(targetId);
+
+    res.status(200).json({
+      online: status.online,
+      last_seen: status.last_seen,
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * POST /api/v1/users/online-status
+ *
+ * Batch query: returns online status for an array of user IDs.
+ * User IDs that the requester is not authorised to see are silently omitted
+ * from the response rather than returning a 403 for the whole request.
+ *
+ * Request body:
+ *   { userIds: string[] }   (UUIDs, max 100)
+ *
+ * Response 200:
+ *   { statuses: Array<{ userId, online, last_seen }> }
+ */
+export async function getBatchOnlineStatus(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const parsed = batchStatusSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(422).json({ errors: parsed.error.flatten().fieldErrors });
+      return;
+    }
+
+    const requesterId = req.user!.userId;
+    const { userIds } = parsed.data;
+
+    // Privacy: silently filter to only authorised targets
+    const authorised = await presenceService.filterAuthorised(
+      requesterId,
+      userIds
+    );
+
+    const statuses = await presenceService.getBatchStatus(authorised);
+
+    res.status(200).json({ statuses });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * POST /api/v1/presence/heartbeat
+ *
+ * Called by the client every 20 seconds to keep the presence key alive.
+ * Also accepts a WebSocket ping (handled in socket.ts), but this REST
+ * fallback supports clients that cannot maintain a WebSocket connection.
+ *
+ * Response 204: No Content
+ */
+export async function heartbeat(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const userId = req.user!.userId;
+    await presenceService.markOnline(userId);
+    res.status(204).send();
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/services/presence.service.ts
+++ b/src/services/presence.service.ts
@@ -1,0 +1,186 @@
+import { Redis } from "ioredis";
+import { pool } from "../config/database";
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/** TTL in seconds for the presence key — client heartbeat is every 20 s,
+ *  so 30 s gives one missed beat before the key expires naturally. */
+const PRESENCE_TTL_SEC = 30;
+
+/** Redis key helpers */
+const presenceKey = (userId: string) => `online:${userId}`;
+const lastSeenKey = (userId: string) => `last_seen:${userId}`;
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface OnlineStatus {
+  userId: string;
+  online: boolean;
+  last_seen: string | null; // ISO-8601 or null if never seen
+}
+
+// ─── Service ─────────────────────────────────────────────────────────────────
+
+export class PresenceService {
+  constructor(private readonly redis: Redis) {}
+
+  // ── Heartbeat / mark online ────────────────────────────────────────────────
+
+  /**
+   * Mark a user as online. Call on every client heartbeat (every 20 s).
+   * Refreshes the TTL so the key expires 30 s after the *last* heartbeat.
+   *
+   * Returns `true` if this is a fresh transition (was offline → now online),
+   * so the caller can emit `user:online` events only on real state changes.
+   */
+  async markOnline(userId: string): Promise<boolean> {
+    const wasOnline = await this.redis.exists(presenceKey(userId));
+
+    const now = new Date().toISOString();
+    await Promise.all([
+      this.redis.set(presenceKey(userId), "1", "EX", PRESENCE_TTL_SEC),
+      this.redis.set(lastSeenKey(userId), now),
+    ]);
+
+    return wasOnline === 0; // true = fresh transition
+  }
+
+  /**
+   * Explicitly mark a user as offline (e.g. on clean disconnect).
+   *
+   * Returns `true` if this is a fresh transition (was online → now offline).
+   */
+  async markOffline(userId: string): Promise<boolean> {
+    const wasOnline = await this.redis.exists(presenceKey(userId));
+
+    const now = new Date().toISOString();
+    await Promise.all([
+      this.redis.del(presenceKey(userId)),
+      this.redis.set(lastSeenKey(userId), now),
+    ]);
+
+    return wasOnline === 1; // true = fresh transition
+  }
+
+  // ── Status queries ─────────────────────────────────────────────────────────
+
+  /** Get online status for a single user. */
+  async getStatus(userId: string): Promise<OnlineStatus> {
+    const [online, lastSeen] = await Promise.all([
+      this.redis.exists(presenceKey(userId)),
+      this.redis.get(lastSeenKey(userId)),
+    ]);
+
+    return {
+      userId,
+      online: online === 1,
+      last_seen: lastSeen ?? null,
+    };
+  }
+
+  /**
+   * Batch status query — returns status for multiple user IDs in one round-trip.
+   * Uses a pipeline to keep Redis round-trips to 1 (exists) + 1 (mget).
+   */
+  async getBatchStatus(userIds: string[]): Promise<OnlineStatus[]> {
+    if (userIds.length === 0) return [];
+
+    const pipeline = this.redis.pipeline();
+    for (const id of userIds) pipeline.exists(presenceKey(id));
+    const existsResults = await pipeline.exec(); // [[null, 0|1], ...]
+
+    const lastSeenValues = await this.redis.mget(
+      ...userIds.map((id) => lastSeenKey(id))
+    );
+
+    return userIds.map((userId, i) => ({
+      userId,
+      online: (existsResults?.[i]?.[1] as number) === 1,
+      last_seen: lastSeenValues[i] ?? null,
+    }));
+  }
+
+  // ── Privacy gate ───────────────────────────────────────────────────────────
+
+  /**
+   * Returns true if `requesterId` is allowed to see `targetId`'s online status.
+   * The rule: they must share at least one upcoming (or in-progress) session.
+   */
+  async canViewStatus(
+    requesterId: string,
+    targetId: string
+  ): Promise<boolean> {
+    if (requesterId === targetId) return true;
+
+    const { rows } = await pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count
+         FROM sessions
+        WHERE status IN ('confirmed', 'in_progress')
+          AND (
+                (mentor_id = $1 AND mentee_id = $2)
+             OR (mentor_id = $2 AND mentee_id = $1)
+              )`,
+      [requesterId, targetId]
+    );
+
+    return parseInt(rows[0]?.count ?? "0", 10) > 0;
+  }
+
+  /**
+   * Filter a list of userIds down to those the requester is allowed to query.
+   * Used by the batch endpoint to silently omit unauthorised targets.
+   */
+  async filterAuthorised(
+    requesterId: string,
+    targetIds: string[]
+  ): Promise<string[]> {
+    if (targetIds.length === 0) return [];
+
+    // Build a single query that checks all targets at once.
+    const placeholders = targetIds
+      .map((_, i) => `$${i + 2}`)
+      .join(", ");
+
+    const { rows } = await pool.query<{ user_id: string }>(
+      `SELECT DISTINCT
+              CASE
+                WHEN mentor_id = $1 THEN mentee_id
+                ELSE mentor_id
+              END AS user_id
+         FROM sessions
+        WHERE status IN ('confirmed', 'in_progress')
+          AND (mentor_id = $1 OR mentee_id = $1)
+          AND (mentor_id IN (${placeholders}) OR mentee_id IN (${placeholders}))`,
+      [requesterId, ...targetIds, ...targetIds]
+    );
+
+    const allowed = new Set<string>([
+      requesterId,
+      ...rows.map((r) => r.user_id),
+    ]);
+
+    return targetIds.filter((id) => allowed.has(id));
+  }
+
+  // ── Room membership helpers (used by socket layer) ────────────────────────
+
+  /**
+   * Returns all user IDs that should receive presence updates for `userId`.
+   * That is: everyone who shares a confirmed/in-progress session with `userId`.
+   */
+  async getPresenceAudience(userId: string): Promise<string[]> {
+    const { rows } = await pool.query<{ peer_id: string }>(
+      `SELECT DISTINCT
+              CASE
+                WHEN mentor_id = $1 THEN mentee_id
+                ELSE mentor_id
+              END AS peer_id
+         FROM sessions
+        WHERE status IN ('confirmed', 'in_progress')
+          AND (mentor_id = $1 OR mentee_id = $1)`,
+      [userId]
+    );
+
+    return rows.map((r) => r.peer_id);
+  }
+}


### PR DESCRIPTION
close #84 

<html><head></head><body><h1>[Feature] Presence &amp; Online Status</h1>
<p><img src="https://img.shields.io/badge/Issue-%2384-0E7C86" alt="Issue"> <img src="https://img.shields.io/badge/Scope-Backend-1A3A5C" alt="Scope"> <img src="https://img.shields.io/badge/Type-Feature-217A3C" alt="Type"> <img src="https://img.shields.io/badge/Priority-Medium-B45309" alt="Priority"> <img src="https://img.shields.io/badge/Labels-websocket%20%7C%20presence%20%7C%20real--time-6B7F8A" alt="Labels"></p>
<hr>
<h2>Summary</h2>
<p>Implements real-time user presence tracking for the MentorMinds Stellar platform. Mentors and learners can now see whether the other party is currently active before a session begins. Online status is stored in Redis using a heartbeat pattern, broadcast over Socket.IO to privacy-scoped rooms, and exposed via two REST endpoints. Status is only visible between users who share a <code>confirmed</code> or <code>in_progress</code> session.</p>
<hr>
<h2>PR Metadata</h2>

Field | Details
-- | --
Repository | MentorsMind / MentorsMind-Backend
Issue | #84 — Presence & Online Status
Files Created | src/services/presence.service.ts, src/controllers/presence.controller.ts
Files Updated | src/config/socket.ts
Scope | Backend only — no frontend changes
Breaking Change | No
New Dependencies | None — uses existing ioredis, socket.io, zod, jsonwebtoken


<hr>
<h2>Testing</h2>
<h3>Manual Verification</h3>
<pre><code class="language-bash"># 1. Ensure User A and User B share a confirmed session in the DB

# 2. Connect both via WebSocket
wscat -c "ws://localhost:5000/socket.io/?token=&lt;token_A&gt;"
wscat -c "ws://localhost:5000/socket.io/?token=&lt;token_B&gt;"
# User B should immediately receive: { event: "user:online", data: { userId: "&lt;A&gt;", ... } }

# 3. Single status
curl -H "Authorization: Bearer &lt;token_B&gt;" \
  http://localhost:5000/api/v1/users/&lt;user_A_id&gt;/online
# → { "online": true, "last_seen": "..." }

# 4. Batch status — include an unrelated user ID to verify silent omission
curl -X POST -H "Authorization: Bearer &lt;token_B&gt;" \
  -H "Content-Type: application/json" \
  -d '{"userIds":["&lt;user_A_id&gt;","&lt;unrelated_id&gt;"]}' \
  http://localhost:5000/api/v1/users/online-status
# → { "statuses": [ { "userId": "&lt;user_A_id&gt;", ... } ] }  — unrelated_id absent

# 5. Stop heartbeating from User A (don't disconnect)
#    After ~35 s User B should receive: { event: "user:offline", data: { userId: "&lt;A&gt;", ... } }

# 6. Reconnect User A — User B should receive user:online again
</code></pre>
<h3>Key Test Cases</h3>
<ul>
<li><code>markOnline</code> called twice rapidly → <code>user:online</code> emitted exactly once</li>
<li><code>markOffline</code> called when user already offline → <code>user:offline</code> not re-emitted</li>
<li><code>heartbeatTimer</code> cleared on clean disconnect → no <code>setInterval</code> leak</li>
<li>Peer with no shared session → not in <code>getPresenceAudience</code>, receives no events</li>
<li><code>GET /users/:id/online</code> for unrelated user → <code>403</code></li>
<li><code>POST /users/online-status</code> with invalid UUID → <code>422</code> with field errors</li>
<li><code>getIO()</code> called before <code>createSocketServer</code> → throws with clear message</li>
<li>Staleness interval fires after key expiry → <code>user:offline</code> + <code>socket.disconnect(true)</code></li>
</ul>
<hr>
<h2>Merge Safety</h2>
<blockquote>
<p>All new logic is isolated in two new files (<code>presence.service.ts</code>, <code>presence.controller.ts</code>). The <code>socket.ts</code> changes are purely additive inside the existing <code>connection</code> handler — no existing event names, middleware, function signatures, or log shapes were modified. The <code>getIO()</code> export is new; no existing import sites are affected.</p>
</blockquote>
<p>The <code>AuthenticatedSocket</code> deduplication is a compile-time fix only — runtime behaviour is identical.</p>
<hr>
<h2>Reviewer Checklist</h2>
<ul>
<li>[ ] <code>heartbeatTimer</code> <code>clearInterval</code> called in <strong>both</strong> the <code>disconnect</code> handler and the staleness branch (no timer leak)</li>
<li>[ ] <code>user:online</code> / <code>user:offline</code> only emitted when transition flag is <code>true</code></li>
<li>[ ] <code>env.JWT_SECRET</code> used throughout (not <code>process.env.JWT_SECRET</code>)</li>
<li>[ ] <code>SocketService.replayMissedEvents</code> preserved on <code>reconnect</code></li>
<li>[ ] No duplicate <code>AuthenticatedSocket</code> interface in final file</li>
<li>[ ] <code>redis</code> import resolves to the shared <code>ioredis</code> instance (not a new connection)</li>
<li>[ ] Batch endpoint silently omits — not 403s — unauthorised IDs</li>
<li>[ ] Privacy SQL covers both <code>mentor_id</code> and <code>mentee_id</code> directions</li>
<li>[ ] New routes registered in the router with <code>authenticate</code> middleware before merge</li>
<li>[ ] <code>getIO()</code> error message references <code>createSocketServer</code> (not <code>initSocket</code>)</li>
</ul>
<hr>
<p><em>Generated for <code>MentorsMind/MentorsMind-Backend</code> · Issue #84 · March 2026</em></p></body></html>

