### PR TITLE
feat: PostgreSQL-backed idempotency key support on payment/booking/es…

### DIFF
--- a/database/migrations/023_create_idempotency_keys.sql
+++ b/database/migrations/023_create_idempotency_keys.sql
@@ -1,0 +1,15 @@
+-- Migration 023: idempotency_keys table
+-- Stores processed request responses to prevent duplicate mutations.
+
+CREATE TABLE IF NOT EXISTS idempotency_keys (
+  key          TEXT        NOT NULL,
+  user_id      UUID        NOT NULL,
+  endpoint     TEXT        NOT NULL,
+  response_body JSONB      NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (key, user_id)
+);
+
+-- Auto-expire rows older than 24 hours via a scheduled cleanup or pg_cron.
+-- Index for fast lookup and cleanup of expired rows.
+CREATE INDEX IF NOT EXISTS idx_idempotency_keys_created_at ON idempotency_keys (created_at);

--- a/jest.unit.config.ts
+++ b/jest.unit.config.ts
@@ -1,39 +1,40 @@
-import type { Config } from 'jest';
+import type { Config } from "jest";
 
 /**
  * Jest config for unit tests that don't require a database connection.
  * Used for queue, worker, logging, database, and env config unit tests.
  */
 const config: Config = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  rootDir: '.',
-  roots: ['<rootDir>/src'],
+  preset: "ts-jest",
+  testEnvironment: "node",
+  rootDir: ".",
+  roots: ["<rootDir>/src"],
   testMatch: [
-    '**/__tests__/**/*.unit.test.ts',
-    '**/queues/__tests__/**/*.test.ts',
-    '**/workers/__tests__/**/*.test.ts',
+    "**/__tests__/**/*.unit.test.ts",
+    "**/queues/__tests__/**/*.test.ts",
+    "**/workers/__tests__/**/*.test.ts",
     // Logging infrastructure unit tests (no DB required)
-    '**/utils/__tests__/logger.test.ts',
-    '**/middleware/__tests__/correlation-id.middleware.test.ts',
-    '**/middleware/__tests__/request-logger.middleware.test.ts',
+    "**/utils/__tests__/logger.test.ts",
+    "**/middleware/__tests__/correlation-id.middleware.test.ts",
+    "**/middleware/__tests__/request-logger.middleware.test.ts",
+    "**/middleware/__tests__/idempotency.middleware.test.ts",
     // Database unit tests (no live DB — all mocked)
-    '**/utils/__tests__/database.utils.test.ts',
-    '**/services/__tests__/database.service.test.ts',
+    "**/utils/__tests__/database.utils.test.ts",
+    "**/services/__tests__/database.service.test.ts",
     // Environment config unit tests
-    '**/config/__tests__/env.test.ts',
+    "**/config/__tests__/env.test.ts",
     // Session reminder and verification unit tests
-    '**/__tests__/jobs/**/*.unit.test.ts',
-    '**/__tests__/services/**/*.unit.test.ts',
+    "**/__tests__/jobs/**/*.unit.test.ts",
+    "**/__tests__/services/**/*.unit.test.ts",
   ],
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
   transform: {
-    '^.+\\.ts$': [
-      'ts-jest',
+    "^.+\\.ts$": [
+      "ts-jest",
       {
         tsconfig: {
-          target: 'ES2022',
-          module: 'commonjs',
+          target: "ES2022",
+          module: "commonjs",
           strict: false,
           esModuleInterop: true,
           skipLibCheck: true,
@@ -49,14 +50,14 @@ const config: Config = {
   forceExit: true,
   testTimeout: 30000,
   collectCoverageFrom: [
-    'src/**/*.ts',
-    '!src/**/*.d.ts',
-    '!src/**/index.ts',
-    '!src/tests/**',
-    '!src/docs/**',
+    "src/**/*.ts",
+    "!src/**/*.d.ts",
+    "!src/**/index.ts",
+    "!src/tests/**",
+    "!src/docs/**",
   ],
-  coverageDirectory: 'coverage',
-  coverageReporters: ['text', 'lcov', 'html', 'json-summary'],
+  coverageDirectory: "coverage",
+  coverageReporters: ["text", "lcov", "html", "json-summary"],
   coverageThreshold: {
     global: {
       statements: 80,

--- a/src/controllers/bookings.controller.ts
+++ b/src/controllers/bookings.controller.ts
@@ -1,16 +1,25 @@
-import { Request, Response } from 'express';
-import { SessionModel } from '../models/session.model';
-import { UsersService } from '../services/users.service';
-import { MeetingService } from '../services/meeting.service';
-import { NotificationService } from '../services/notification.service';
-import { ResponseUtil } from '../utils/response.utils';
-import { asyncHandler } from '../utils/asyncHandler.utils';
-import { logger } from '../utils/logger';
+import { Request, Response } from "express";
+import { SessionModel } from "../models/session.model";
+import { UsersService } from "../services/users.service";
+import { MeetingService } from "../services/meeting.service";
+import { NotificationService } from "../services/notification.service";
+import { ResponseUtil } from "../utils/response.utils";
+import { asyncHandler } from "../utils/asyncHandler.utils";
+import { logger } from "../utils/logger";
 
 /**
  * Bookings Controller - Handles session booking operations with meeting URL generation
  */
 export const BookingsController = {
+  /**
+   * Create a new booking
+   * POST /api/v1/bookings
+   */
+  createBooking: asyncHandler(async (_req: Request, res: Response) => {
+    // TODO: implement booking creation logic
+    res.status(501).json({ success: false, error: "Not implemented" });
+  }),
+
   /**
    * Confirm a booking and generate meeting URL
    * POST /api/v1/bookings/:id/confirm
@@ -19,19 +28,19 @@ export const BookingsController = {
     const { id } = req.params;
 
     if (Array.isArray(id)) {
-      return ResponseUtil.error(res, 'Invalid session ID', 400);
+      return ResponseUtil.error(res, "Invalid session ID", 400);
     }
 
     // Find the session
     const session = await SessionModel.findById(id);
-    
+
     if (!session) {
-      return ResponseUtil.error(res, 'Session not found', 404);
+      return ResponseUtil.error(res, "Session not found", 404);
     }
 
     // Check if already confirmed
-    if (session.status === 'confirmed') {
-      return ResponseUtil.error(res, 'Session is already confirmed', 400);
+    if (session.status === "confirmed") {
+      return ResponseUtil.error(res, "Session is already confirmed", 400);
     }
 
     // Get mentor and mentee details
@@ -41,7 +50,7 @@ export const BookingsController = {
     ]);
 
     if (!mentor || !mentee) {
-      return ResponseUtil.error(res, 'Invalid participant information', 400);
+      return ResponseUtil.error(res, "Invalid participant information", 400);
     }
 
     try {
@@ -63,11 +72,11 @@ export const BookingsController = {
       });
 
       if (!updatedSession) {
-        throw new Error('Failed to update session with meeting URL');
+        throw new Error("Failed to update session with meeting URL");
       }
 
       // Update session status to confirmed
-      await SessionModel.updateStatus(session.id, 'confirmed');
+      await SessionModel.updateStatus(session.id, "confirmed");
 
       // Send notifications to both participants
       try {
@@ -81,40 +90,53 @@ export const BookingsController = {
           meetingResult.meetingUrl,
           session.scheduled_at,
           session.duration_minutes,
-          meetingResult.expiresAt
+          meetingResult.expiresAt,
         );
       } catch (notificationError) {
         // Log notification error but don't fail the booking
-        logger.error('Failed to send meeting notifications:', notificationError);
+        logger.error(
+          "Failed to send meeting notifications:",
+          notificationError,
+        );
       }
 
       // Return updated session with meeting URL
-      ResponseUtil.success(res, {
-        session: {
-          ...updatedSession,
-          meeting_url: updatedSession.meeting_url,
-          meeting_provider: updatedSession.meeting_provider,
-          meeting_expires_at: updatedSession.meeting_expires_at,
+      ResponseUtil.success(
+        res,
+        {
+          session: {
+            ...updatedSession,
+            meeting_url: updatedSession.meeting_url,
+            meeting_provider: updatedSession.meeting_provider,
+            meeting_expires_at: updatedSession.meeting_expires_at,
+          },
         },
-      }, 'Booking confirmed and meeting room created successfully');
-
+        "Booking confirmed and meeting room created successfully",
+      );
     } catch (error) {
       // Handle meeting creation failure
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error";
+
       // Mark session for manual intervention
       await SessionModel.markForManualIntervention(session.id);
 
-      logger.error('Failed to create meeting room:', errorMessage);
+      logger.error("Failed to create meeting room:", errorMessage);
 
       // Still confirm the booking but flag the issue
-      await SessionModel.updateStatus(session.id, 'confirmed');
+      await SessionModel.updateStatus(session.id, "confirmed");
 
-      ResponseUtil.success(res, {
-        session: await SessionModel.findById(session.id),
-        warning: 'Meeting room creation failed. Manual intervention required.',
-        details: errorMessage,
-      }, 'Booking confirmed but meeting URL could not be generated', 200);
+      ResponseUtil.success(
+        res,
+        {
+          session: await SessionModel.findById(session.id),
+          warning:
+            "Meeting room creation failed. Manual intervention required.",
+          details: errorMessage,
+        },
+        "Booking confirmed but meeting URL could not be generated",
+        200,
+      );
     }
   }),
 
@@ -126,23 +148,26 @@ export const BookingsController = {
     const { id } = req.params;
 
     if (Array.isArray(id)) {
-      return ResponseUtil.error(res, 'Invalid session ID', 400);
+      return ResponseUtil.error(res, "Invalid session ID", 400);
     }
 
     const session = await SessionModel.findById(id);
-    
+
     if (!session) {
-      return ResponseUtil.error(res, 'Session not found', 404);
+      return ResponseUtil.error(res, "Session not found", 404);
     }
 
     // Only include meeting URL if session is confirmed
     const sessionData = {
       ...session,
       // Hide meeting details if not confirmed
-      meeting_url: session.status === 'confirmed' ? session.meeting_url : null,
-      meeting_provider: session.status === 'confirmed' ? session.meeting_provider : null,
-      meeting_expires_at: session.status === 'confirmed' ? session.meeting_expires_at : null,
-      meeting_room_id: session.status === 'confirmed' ? session.meeting_room_id : null,
+      meeting_url: session.status === "confirmed" ? session.meeting_url : null,
+      meeting_provider:
+        session.status === "confirmed" ? session.meeting_provider : null,
+      meeting_expires_at:
+        session.status === "confirmed" ? session.meeting_expires_at : null,
+      meeting_room_id:
+        session.status === "confirmed" ? session.meeting_room_id : null,
     };
 
     ResponseUtil.success(res, { session: sessionData });
@@ -156,24 +181,26 @@ export const BookingsController = {
     const userId = (req as any).user?.id; // Assuming auth middleware sets req.user
 
     if (!userId) {
-      return ResponseUtil.error(res, 'Unauthorized', 401);
+      return ResponseUtil.error(res, "Unauthorized", 401);
     }
 
     const { upcoming } = req.query;
     let sessions;
 
-    if (upcoming === 'true') {
+    if (upcoming === "true") {
       sessions = await SessionModel.findUpcomingByUserId(userId);
     } else {
       sessions = await SessionModel.findByUserId(userId);
     }
 
     // Filter meeting URLs based on confirmation status
-    const sessionsData = sessions.map(session => ({
+    const sessionsData = sessions.map((session) => ({
       ...session,
-      meeting_url: session.status === 'confirmed' ? session.meeting_url : null,
-      meeting_provider: session.status === 'confirmed' ? session.meeting_provider : null,
-      meeting_expires_at: session.status === 'confirmed' ? session.meeting_expires_at : null,
+      meeting_url: session.status === "confirmed" ? session.meeting_url : null,
+      meeting_provider:
+        session.status === "confirmed" ? session.meeting_provider : null,
+      meeting_expires_at:
+        session.status === "confirmed" ? session.meeting_expires_at : null,
     }));
 
     ResponseUtil.success(res, { sessions: sessionsData });
@@ -187,23 +214,23 @@ export const BookingsController = {
     const { id } = req.params;
 
     if (Array.isArray(id)) {
-      return ResponseUtil.error(res, 'Invalid session ID', 400);
+      return ResponseUtil.error(res, "Invalid session ID", 400);
     }
 
     const session = await SessionModel.findById(id);
-    
+
     if (!session) {
-      return ResponseUtil.error(res, 'Session not found', 404);
+      return ResponseUtil.error(res, "Session not found", 404);
     }
 
     // Can only cancel pending or confirmed sessions
-    if (!['pending', 'confirmed'].includes(session.status)) {
-      return ResponseUtil.error(res, 'Cannot cancel this session', 400);
+    if (!["pending", "confirmed"].includes(session.status)) {
+      return ResponseUtil.error(res, "Cannot cancel this session", 400);
     }
 
-    await SessionModel.updateStatus(id, 'cancelled');
+    await SessionModel.updateStatus(id, "cancelled");
 
-    ResponseUtil.success(res, { message: 'Booking cancelled successfully' });
+    ResponseUtil.success(res, { message: "Booking cancelled successfully" });
   }),
 
   /**
@@ -211,11 +238,17 @@ export const BookingsController = {
    * GET /api/v1/bookings/manual-intervention
    * (Admin-only endpoint)
    */
-  getManualInterventionSessions: asyncHandler(async (_req: Request, res: Response) => {
-    const sessions = await SessionModel.findNeedingManualIntervention();
+  getManualInterventionSessions: asyncHandler(
+    async (_req: Request, res: Response) => {
+      const sessions = await SessionModel.findNeedingManualIntervention();
 
-    ResponseUtil.success(res, { sessions }, 'Sessions requiring manual meeting setup');
-  }),
+      ResponseUtil.success(
+        res,
+        { sessions },
+        "Sessions requiring manual meeting setup",
+      );
+    },
+  ),
 };
 
 export default BookingsController;

--- a/src/middleware/__tests__/idempotency.middleware.test.ts
+++ b/src/middleware/__tests__/idempotency.middleware.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Unit tests for idempotency middleware.
+ *
+ * Covers:
+ *  - Missing / invalid Idempotency-Key → 400
+ *  - Unauthenticated request → 401
+ *  - First request: processes normally and persists response
+ *  - Duplicate request (same key + user + endpoint): returns cached response
+ *  - Expired key: re-processes as fresh
+ *  - Same key, different endpoint: 409 Conflict
+ */
+
+import { Request, Response, NextFunction } from "express";
+
+// ---------------------------------------------------------------------------
+// Mock uuid so tests are deterministic
+// ---------------------------------------------------------------------------
+jest.mock("uuid", () => ({ v4: () => "00000000-0000-4000-a000-000000000000" }));
+
+// ---------------------------------------------------------------------------
+// Mock the DB pool
+// ---------------------------------------------------------------------------
+const mockQuery = jest.fn();
+jest.mock("../../config/database", () => ({
+  default: { query: mockQuery },
+  query: mockQuery,
+}));
+
+// ---------------------------------------------------------------------------
+// Mock logger
+// ---------------------------------------------------------------------------
+jest.mock("../../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { idempotency } from "../idempotency.middleware";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const VALID_KEY = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+function makeReq(overrides: Partial<Request> = {}): Request {
+  return {
+    headers: { "idempotency-key": VALID_KEY },
+    method: "POST",
+    path: "/api/v1/payments",
+    route: { path: "/api/v1/payments" },
+    user: { userId: "user-uuid-1", role: "user" },
+    ...overrides,
+  } as unknown as Request;
+}
+
+function makeRes(): {
+  res: Response;
+  jsonMock: jest.Mock;
+  statusMock: jest.Mock;
+} {
+  const jsonMock = jest.fn().mockReturnThis();
+  const statusMock = jest.fn().mockReturnThis();
+  const setHeaderMock = jest.fn();
+  const res = {
+    json: jsonMock,
+    status: statusMock,
+    statusCode: 201,
+    setHeader: setHeaderMock,
+  } as unknown as Response;
+  // Make status().json() chain work
+  (statusMock as jest.Mock).mockReturnValue(res);
+  return { res, jsonMock, statusMock };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("idempotency middleware", () => {
+  let next: NextFunction;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    next = jest.fn();
+  });
+
+  it("returns 400 when Idempotency-Key header is missing", async () => {
+    const req = makeReq({ headers: {} });
+    const { res, statusMock, jsonMock } = makeRes();
+
+    await idempotency(req, res, next);
+
+    expect(statusMock).toHaveBeenCalledWith(400);
+    expect(jsonMock).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false }),
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when Idempotency-Key is not a valid UUID", async () => {
+    const req = makeReq({ headers: { "idempotency-key": "not-a-uuid" } });
+    const { res, statusMock } = makeRes();
+
+    await idempotency(req, res, next);
+
+    expect(statusMock).toHaveBeenCalledWith(400);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    const req = makeReq({ user: undefined } as any);
+    const { res, statusMock } = makeRes();
+
+    await idempotency(req, res, next);
+
+    expect(statusMock).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("first request: calls next() and intercepts res.json to persist response", async () => {
+    // No existing record
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // INSERT succeeds
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const req = makeReq();
+    const { res } = makeRes();
+
+    await idempotency(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+
+    // Simulate the handler calling res.json
+    (res as any).json({ success: true, data: { id: "123" } });
+
+    // Give the async INSERT a tick to run
+    await Promise.resolve();
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO idempotency_keys"),
+      expect.arrayContaining([VALID_KEY, "user-uuid-1"]),
+    );
+  });
+
+  it("duplicate request: returns cached response without calling next()", async () => {
+    const now = new Date();
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          endpoint: "POST /api/v1/payments",
+          response_body: {
+            __status: 201,
+            __body: { success: true, data: { id: "123" } },
+          },
+          created_at: now,
+        },
+      ],
+    });
+
+    const req = makeReq();
+    const { res, statusMock, jsonMock } = makeRes();
+
+    await idempotency(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(statusMock).toHaveBeenCalledWith(201);
+    expect(jsonMock).toHaveBeenCalledWith({
+      success: true,
+      data: { id: "123" },
+    });
+    expect(res.setHeader).toHaveBeenCalledWith(
+      "X-Idempotency-Replayed",
+      "true",
+    );
+  });
+
+  it("expired key: deletes record and calls next() to re-process", async () => {
+    const expired = new Date(Date.now() - 25 * 3_600_000); // 25 hours ago
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          endpoint: "POST /api/v1/payments",
+          response_body: { __status: 201, __body: {} },
+          created_at: expired,
+        },
+      ],
+    });
+    // DELETE
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const req = makeReq();
+    const { res } = makeRes();
+
+    await idempotency(req, res, next);
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("DELETE FROM idempotency_keys"),
+      expect.arrayContaining([VALID_KEY, "user-uuid-1"]),
+    );
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("same key, different endpoint: returns 409 Conflict", async () => {
+    const now = new Date();
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          endpoint: "POST /api/v1/bookings", // different endpoint
+          response_body: { __status: 201, __body: {} },
+          created_at: now,
+        },
+      ],
+    });
+
+    const req = makeReq(); // endpoint is POST /api/v1/payments
+    const { res, statusMock, jsonMock } = makeRes();
+
+    await idempotency(req, res, next);
+
+    expect(statusMock).toHaveBeenCalledWith(409);
+    expect(jsonMock).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false }),
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("fails open when DB throws — calls next()", async () => {
+    mockQuery.mockRejectedValueOnce(new Error("DB down"));
+
+    const req = makeReq();
+    const { res } = makeRes();
+
+    await idempotency(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/src/middleware/idempotency.middleware.ts
+++ b/src/middleware/idempotency.middleware.ts
@@ -1,69 +1,122 @@
 /**
  * Idempotency Middleware
  *
- * Prevents duplicate payment processing by caching responses keyed on
- * the `Idempotency-Key` header. Responses are stored for 24 hours.
+ * Prevents duplicate mutations on payment/booking/escrow endpoints.
+ * Clients send `Idempotency-Key: <uuid>` on POST requests.
  *
- * Usage: add `idempotency` middleware before payment mutation handlers.
- * Clients must send a unique `Idempotency-Key` (UUID) per request.
+ * Behaviour:
+ *  - First request  → process normally, persist response in DB
+ *  - Duplicate key  → return stored response immediately (X-Idempotency-Replayed: true)
+ *  - Same key, different endpoint → 409 Conflict
+ *  - Keys expire after 24 hours (re-processed as fresh)
  */
 
-import { Request, Response, NextFunction } from 'express';
-import { CacheService } from '../services/cache.service';
-import { ResponseUtil } from '../utils/response.utils';
-import { logger } from '../utils/logger.utils';
+import { Request, Response, NextFunction } from "express";
+import pool from "../config/database";
+import { logger } from "../utils/logger";
 
-const IDEMPOTENCY_TTL = 86_400; // 24 hours
-const KEY_PREFIX = 'idempotency:';
+const TTL_HOURS = 24;
 
 export const idempotency = async (
   req: Request,
   res: Response,
   next: NextFunction,
 ): Promise<void> => {
-  const idempotencyKey = req.headers['idempotency-key'] as string | undefined;
+  const idempotencyKey = req.headers["idempotency-key"] as string | undefined;
 
   if (!idempotencyKey) {
-    ResponseUtil.error(res, 'Idempotency-Key header is required', 400);
+    res
+      .status(400)
+      .json({ success: false, error: "Idempotency-Key header is required" });
     return;
   }
 
   if (!/^[0-9a-f-]{36}$/i.test(idempotencyKey)) {
-    ResponseUtil.error(res, 'Idempotency-Key must be a valid UUID', 400);
+    res
+      .status(400)
+      .json({ success: false, error: "Idempotency-Key must be a valid UUID" });
     return;
   }
 
-  const cacheKey = `${KEY_PREFIX}${idempotencyKey}`;
+  const userId = (req as any).user?.userId;
+  if (!userId) {
+    // Auth middleware should have already rejected unauthenticated requests
+    res.status(401).json({ success: false, error: "Authentication required" });
+    return;
+  }
+
+  const endpoint = `${req.method} ${req.route?.path ?? req.path}`;
 
   try {
-    const cached = await CacheService.get<{ status: number; body: unknown }>(cacheKey);
+    const { rows } = await pool.query<{
+      endpoint: string;
+      response_body: unknown;
+      created_at: Date;
+    }>(
+      `SELECT endpoint, response_body, created_at
+         FROM idempotency_keys
+        WHERE key = $1 AND user_id = $2`,
+      [idempotencyKey, userId],
+    );
 
-    if (cached) {
-      logger.info('Idempotency cache hit', { idempotencyKey });
-      res.setHeader('X-Idempotency-Replayed', 'true');
-      res.status(cached.status).json(cached.body);
-      return;
+    if (rows.length > 0) {
+      const record = rows[0];
+      const ageMs = Date.now() - new Date(record.created_at).getTime();
+
+      // Expired — delete and fall through to process fresh
+      if (ageMs > TTL_HOURS * 3_600_000) {
+        await pool.query(
+          `DELETE FROM idempotency_keys WHERE key = $1 AND user_id = $2`,
+          [idempotencyKey, userId],
+        );
+      } else if (record.endpoint !== endpoint) {
+        // Same key, different endpoint → conflict
+        res.status(409).json({
+          success: false,
+          error: `Idempotency-Key already used for ${record.endpoint}`,
+        });
+        return;
+      } else {
+        // Valid cache hit — replay stored response
+        logger.info({ idempotencyKey, endpoint }, "Idempotency cache hit");
+        res.setHeader("X-Idempotency-Replayed", "true");
+        res
+          .status((record.response_body as any).__status ?? 200)
+          .json((record.response_body as any).__body);
+        return;
+      }
     }
 
-    // Intercept the response to cache it
+    // Intercept res.json to persist the response after it is sent
     const originalJson = res.json.bind(res);
     res.json = (body: unknown) => {
-      const statusCode = res.statusCode;
-      // Only cache successful responses (2xx)
-      if (statusCode >= 200 && statusCode < 300) {
-        CacheService.set(cacheKey, { status: statusCode, body }, IDEMPOTENCY_TTL).catch(
-          (err) => logger.warn('Failed to cache idempotency response', { error: err.message }),
-        );
+      const status = res.statusCode;
+      if (status >= 200 && status < 300) {
+        pool
+          .query(
+            `INSERT INTO idempotency_keys (key, user_id, endpoint, response_body)
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT (key, user_id) DO NOTHING`,
+            [
+              idempotencyKey,
+              userId,
+              endpoint,
+              JSON.stringify({ __status: status, __body: body }),
+            ],
+          )
+          .catch((err) =>
+            logger.warn(
+              { err, idempotencyKey },
+              "Failed to persist idempotency key",
+            ),
+          );
       }
       return originalJson(body);
     };
 
     next();
   } catch (err) {
-    logger.warn('Idempotency middleware error', {
-      error: err instanceof Error ? err.message : err,
-    });
-    // Fail open — let the request through if cache is unavailable
+    logger.warn({ err }, "Idempotency middleware error — failing open");
     next();
   }
 };

--- a/src/routes/bookings.routes.ts
+++ b/src/routes/bookings.routes.ts
@@ -1,7 +1,8 @@
-import { Router } from 'express';
-import { BookingsController } from '../controllers/bookings.controller';
-import { authenticate } from '../middleware/auth.middleware';
-import { requireRole } from '../middleware/rbac.middleware';
+import { Router } from "express";
+import { BookingsController } from "../controllers/bookings.controller";
+import { authenticate } from "../middleware/auth.middleware";
+import { requireRole } from "../middleware/rbac.middleware";
+import { idempotency } from "../middleware/idempotency.middleware";
 
 const router = Router();
 
@@ -11,6 +12,26 @@ const router = Router();
  *   name: Bookings
  *   description: Session booking and meeting room management endpoints
  */
+
+/**
+ * @swagger
+ * /api/v1/bookings:
+ *   post:
+ *     summary: Create a new booking
+ *     tags: [Bookings]
+ *     security:
+ *       - bearerAuth: true
+ *     parameters:
+ *       - in: header
+ *         name: Idempotency-Key
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *         description: Unique key to prevent duplicate bookings
+ *     responses:
+ *       201:
+ *         description: Booking created
+ */
+router.post("/", authenticate, idempotency, BookingsController.createBooking);
 
 /**
  * @swagger
@@ -45,7 +66,7 @@ const router = Router();
  *                       items:
  *                         $ref: '#/components/schemas/Session'
  */
-router.get('/', authenticate, BookingsController.listBookings);
+router.get("/", authenticate, BookingsController.listBookings);
 
 /**
  * @swagger
@@ -74,7 +95,12 @@ router.get('/', authenticate, BookingsController.listBookings);
  *                       items:
  *                         $ref: '#/components/schemas/Session'
  */
-router.get('/manual-intervention', authenticate, requireRole('admin'), BookingsController.getManualInterventionSessions);
+router.get(
+  "/manual-intervention",
+  authenticate,
+  requireRole("admin"),
+  BookingsController.getManualInterventionSessions,
+);
 
 /**
  * @swagger
@@ -109,7 +135,7 @@ router.get('/manual-intervention', authenticate, requireRole('admin'), BookingsC
  *                     session:
  *                       $ref: '#/components/schemas/Session'
  */
-router.get('/:id', authenticate, BookingsController.getSession);
+router.get("/:id", authenticate, BookingsController.getSession);
 
 /**
  * @swagger
@@ -135,7 +161,7 @@ router.get('/:id', authenticate, BookingsController.getSession);
  *       404:
  *         description: Session not found
  */
-router.delete('/:id/cancel', authenticate, BookingsController.cancelBooking);
+router.delete("/:id/cancel", authenticate, BookingsController.cancelBooking);
 
 /**
  * @swagger
@@ -194,6 +220,6 @@ router.delete('/:id/cancel', authenticate, BookingsController.cancelBooking);
  *                       type: string
  *                       example: Meeting room creation failed. Manual intervention required.
  */
-router.post('/:id/confirm', authenticate, BookingsController.confirmBooking);
+router.post("/:id/confirm", authenticate, BookingsController.confirmBooking);
 
 export default router;

--- a/src/routes/escrow.routes.ts
+++ b/src/routes/escrow.routes.ts
@@ -1,6 +1,13 @@
-import { Router } from 'express';
+import { Router } from "express";
+import { authenticate } from "../middleware/auth.middleware";
+import { idempotency } from "../middleware/idempotency.middleware";
 
-/** Escrow HTTP routes (scaffold — mount under /escrow when implemented). */
+/** Escrow HTTP routes */
 const router = Router();
+
+// POST /escrow — idempotency guard applied; handler to be implemented
+router.post("/", authenticate, idempotency, (_req, res) => {
+  res.status(501).json({ success: false, error: "Not implemented" });
+});
 
 export default router;


### PR DESCRIPTION
## PostgreSQL-Backed Idempotency Key Support

### What
Adds idempotency key enforcement on all payment, booking, and escrow creation endpoints so network retries and duplicate requests never 
create duplicate records.

### How it works
1. Client sends Idempotency-Key: <uuid> header on POST requests
2. First request — processes normally, stores the response in the DB
3. Duplicate request (same key + user + endpoint) — returns the stored response immediately with X-Idempotency-Replayed: true
4. Same key, different endpoint — 409 Conflict
5. Keys expire after 24 hours and are re-processed as fresh

### Changes

New files
- database/migrations/023_create_idempotency_keys.sql — table with composite PK (key, user_id), endpoint, response_body jsonb, created_at 
with index for expiry cleanup
- src/middleware/__tests__/idempotency.middleware.test.ts — 8 unit tests

Updated files
- src/middleware/idempotency.middleware.ts — rewritten from Redis-only to PostgreSQL-backed; handles expiry, endpoint conflict, fail-open on
DB error
- src/routes/payments.routes.ts — idempotency already applied to POST /
- src/routes/bookings.routes.ts — added POST / with idempotency + createBooking stub
- src/routes/escrow.routes.ts — added POST / with idempotency
- jest.unit.config.ts — registered new test file

### Test coverage
| Scenario | Expected |
|----------|----------|
| Missing header | 400 |
| Invalid UUID | 400 |
| Unauthenticated | 401 |
| First request | calls next, persists response |
| Duplicate request | replays cached response |
| Expired key (>24h) | deletes record, re-processes |
| Same key, different endpoint | 409 Conflict |
| DB unavailable | fails open, calls next |

closes #122 