### PR TITLE
Fix/issues 236 238 243 245

### DIFF
--- a/src/__tests__/controllers/auth.controller.test.ts
+++ b/src/__tests__/controllers/auth.controller.test.ts
@@ -1,0 +1,66 @@
+import { Request, Response } from 'express';
+import { AuthController } from '../../controllers/auth.controller';
+import { AuthService } from '../../services/auth.service';
+import { AuditLogService } from '../../services/auditLog.service';
+import { LoginAttemptsService } from '../../services/loginAttempts.service';
+
+jest.mock('../../services/auth.service');
+jest.mock('../../services/auditLog.service');
+jest.mock('../../services/loginAttempts.service');
+jest.mock('../../validators/auth.validator', () => ({
+  forgotPasswordSchema: { parse: jest.fn() },
+  registerSchema: { parse: jest.fn() },
+  loginSchema: { parse: jest.fn(), safeParse: jest.fn() },
+  resetPasswordSchema: { parse: jest.fn() },
+  refreshTokenSchema: { parse: jest.fn() },
+}));
+
+import {
+  forgotPasswordSchema,
+} from '../../validators/auth.validator';
+
+const mockAuthService = AuthService as jest.Mocked<typeof AuthService>;
+const mockForgotPasswordSchema = forgotPasswordSchema as jest.Mocked<typeof forgotPasswordSchema>;
+
+describe('AuthController.forgotPassword', () => {
+  let mockReq: Partial<Request>;
+  let mockRes: Partial<Response>;
+  let jsonMock: jest.Mock;
+  let statusMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jsonMock = jest.fn().mockReturnThis();
+    statusMock = jest.fn().mockReturnValue({ json: jsonMock });
+    mockRes = { status: statusMock, json: jsonMock };
+    mockReq = { body: { email: 'user@example.com' } };
+
+    (mockForgotPasswordSchema.parse as jest.Mock).mockReturnValue({
+      body: { email: 'user@example.com' },
+    });
+  });
+
+  it('should not include token in response body', async () => {
+    mockAuthService.forgotPassword.mockResolvedValue('some-secret-token');
+
+    await AuthController.forgotPassword(mockReq as Request, mockRes as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(200);
+    const responseBody = jsonMock.mock.calls[0][0];
+    expect(responseBody).not.toHaveProperty('data');
+    expect(JSON.stringify(responseBody)).not.toContain('token');
+    expect(responseBody.success).toBe(true);
+    expect(responseBody.message).toBeDefined();
+  });
+
+  it('should return success message even when email does not exist', async () => {
+    mockAuthService.forgotPassword.mockResolvedValue('');
+
+    await AuthController.forgotPassword(mockReq as Request, mockRes as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(200);
+    const responseBody = jsonMock.mock.calls[0][0];
+    expect(responseBody.success).toBe(true);
+    expect(responseBody).not.toHaveProperty('data');
+  });
+});

--- a/src/__tests__/middleware/cache.middleware.test.ts
+++ b/src/__tests__/middleware/cache.middleware.test.ts
@@ -1,0 +1,124 @@
+import { Request, Response, NextFunction } from 'express';
+import { cacheMiddleware } from '../../middleware/cache.middleware';
+import { CacheService } from '../../services/cache.service';
+
+jest.mock('../../services/cache.service');
+
+const mockCacheService = CacheService as jest.Mocked<typeof CacheService>;
+
+describe('cacheMiddleware with cacheAuthenticated: true', () => {
+  let mockReq: Partial<Request>;
+  let mockRes: Partial<Response>;
+  let mockNext: NextFunction;
+  let jsonMock: jest.Mock;
+  let statusMock: jest.Mock;
+  let setHeaderMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jsonMock = jest.fn().mockReturnThis();
+    statusMock = jest.fn().mockReturnValue({ json: jsonMock });
+    setHeaderMock = jest.fn();
+    mockRes = {
+      status: statusMock,
+      json: jsonMock,
+      setHeader: setHeaderMock,
+      statusCode: 200,
+    };
+    mockNext = jest.fn();
+  });
+
+  it('should include userId in cache key when cacheAuthenticated is true', async () => {
+    mockReq = {
+      method: 'GET',
+      originalUrl: '/api/v1/users/me',
+      user: { userId: 'user-123', email: 'test@example.com', role: 'user' },
+    } as any;
+
+    mockCacheService.get.mockResolvedValue(null);
+    mockCacheService.set.mockResolvedValue(undefined);
+
+    const middleware = cacheMiddleware({ cacheAuthenticated: true, ttl: 60 });
+    await middleware(mockReq as Request, mockRes as Response, mockNext);
+
+    expect(mockNext).toHaveBeenCalled();
+    expect(mockCacheService.get).toHaveBeenCalledWith('mm:http:user-123:/api/v1/users/me');
+  });
+
+  it('should use different cache keys for different users on the same URL', async () => {
+    const user1Req = {
+      method: 'GET',
+      originalUrl: '/api/v1/users/me',
+      user: { userId: 'user-1', email: 'user1@example.com', role: 'user' },
+    } as any;
+
+    const user2Req = {
+      method: 'GET',
+      originalUrl: '/api/v1/users/me',
+      user: { userId: 'user-2', email: 'user2@example.com', role: 'user' },
+    } as any;
+
+    mockCacheService.get.mockResolvedValue(null);
+    mockCacheService.set.mockResolvedValue(undefined);
+
+    const middleware = cacheMiddleware({ cacheAuthenticated: true, ttl: 60 });
+
+    await middleware(user1Req as Request, mockRes as Response, mockNext);
+    const key1 = mockCacheService.get.mock.calls[0][0];
+
+    jest.clearAllMocks();
+    mockCacheService.get.mockResolvedValue(null);
+
+    await middleware(user2Req as Request, mockRes as Response, mockNext);
+    const key2 = mockCacheService.get.mock.calls[0][0];
+
+    expect(key1).toBe('mm:http:user-1:/api/v1/users/me');
+    expect(key2).toBe('mm:http:user-2:/api/v1/users/me');
+    expect(key1).not.toBe(key2);
+  });
+
+  it('should not cache when cacheAuthenticated is true but user is missing', async () => {
+    mockReq = {
+      method: 'GET',
+      originalUrl: '/api/v1/users/me',
+    } as any;
+
+    const middleware = cacheMiddleware({ cacheAuthenticated: true, ttl: 60 });
+    await middleware(mockReq as Request, mockRes as Response, mockNext);
+
+    expect(mockNext).toHaveBeenCalled();
+    expect(mockCacheService.get).not.toHaveBeenCalled();
+  });
+
+  it('should allow custom keyFn to override default user-scoped key', async () => {
+    mockReq = {
+      method: 'GET',
+      originalUrl: '/api/v1/users/me',
+      user: { userId: 'user-123', email: 'test@example.com', role: 'user' },
+    } as any;
+
+    mockCacheService.get.mockResolvedValue(null);
+    mockCacheService.set.mockResolvedValue(undefined);
+
+    const customKeyFn = (req: Request) => `custom:${(req as any).user.userId}:${req.originalUrl}`;
+    const middleware = cacheMiddleware({ cacheAuthenticated: true, ttl: 60, keyFn: customKeyFn });
+    await middleware(mockReq as Request, mockRes as Response, mockNext);
+
+    expect(mockCacheService.get).toHaveBeenCalledWith('custom:user-123:/api/v1/users/me');
+  });
+
+  it('should not include userId when cacheAuthenticated is false', async () => {
+    mockReq = {
+      method: 'GET',
+      originalUrl: '/api/v1/mentors',
+      user: { userId: 'user-123', email: 'test@example.com', role: 'user' },
+    } as any;
+
+    const middleware = cacheMiddleware({ cacheAuthenticated: false, ttl: 60 });
+    await middleware(mockReq as Request, mockRes as Response, mockNext);
+
+    // Should skip caching for authenticated requests when cacheAuthenticated is false
+    expect(mockNext).toHaveBeenCalled();
+    expect(mockCacheService.get).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/unit/search.service.test.ts
+++ b/src/__tests__/unit/search.service.test.ts
@@ -1,13 +1,13 @@
-import db from "../../config/db";
+import pool from "../../config/database";
 import { SearchService } from "../../services/search.service";
 import { CacheService } from "../../services/cache.service";
 import { buildSearchQuery } from "../../utils/query-builder.utils";
 
-jest.mock("../../config/db");
+jest.mock("../../config/database");
 jest.mock("../../services/cache.service");
 jest.mock("../../utils/query-builder.utils");
 
-const mockDb = db as unknown as { query: jest.Mock };
+const mockDb = pool as unknown as { query: jest.Mock };
 const mockCache = CacheService as jest.Mocked<typeof CacheService>;
 const mockBuildSearchQuery = buildSearchQuery as jest.MockedFunction<
   typeof buildSearchQuery

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -200,11 +200,10 @@ export const AuthController = {
   async forgotPassword(req: Request, res: Response) {
     try {
       const validatedData = forgotPasswordSchema.parse(req).body;
-      const token = await AuthService.forgotPassword(validatedData.email);
+      await AuthService.forgotPassword(validatedData.email);
       return res.status(200).json({
         success: true,
         message: 'If the email exists, a reset link has been generated.',
-        data: { token },
       });
     } catch (error: any) {
       if (error instanceof ZodError) {

--- a/src/middleware/cache.middleware.ts
+++ b/src/middleware/cache.middleware.ts
@@ -38,7 +38,15 @@ export function cacheMiddleware(options: {
     const isAuthed = !!(req as any).user;
     if (isAuthed && !cacheAuthenticated) return next();
 
-    const key = keyFn ? keyFn(req) : `mm:http:${req.originalUrl}`;
+    // When caching authenticated responses, scope the key to the user to
+    // prevent one user's private data from being served to another user.
+    const userId = (req as any).user?.userId ?? (req as any).user?.id;
+    if (cacheAuthenticated && !userId) return next();
+
+    const defaultKey = cacheAuthenticated
+      ? `mm:http:${userId}:${req.originalUrl}`
+      : `mm:http:${req.originalUrl}`;
+    const key = keyFn ? keyFn(req) : defaultKey;
     const cached = await CacheService.get<{ status: number; body: unknown }>(
       key,
     );

--- a/src/services/mentors.service.ts
+++ b/src/services/mentors.service.ts
@@ -379,14 +379,13 @@ export const MentorsService = {
   async getEarnings(id: string, query: GetMentorEarningsQuery): Promise<EarningsSummary> {
     const { from, to, groupBy } = query;
 
-    const conditions: string[] = ["s.mentor_id = $1", "s.status = 'completed'"];
     const values: unknown[] = [id];
     let idx = 2;
 
-    if (from) { conditions.push(`s.scheduled_at >= $${idx++}`); values.push(from); }
-    if (to) { conditions.push(`s.scheduled_at <= $${idx++}`); values.push(to); }
-
-    const whereClause = `WHERE ${conditions.join(' AND ')}`;
+    const dateFilters: string[] = [];
+    if (from) { dateFilters.push(`AND b.created_at >= $${idx++}`); values.push(from); }
+    if (to) { dateFilters.push(`AND b.created_at <= $${idx++}`); values.push(to); }
+    const dateFilterClause = dateFilters.join(' ');
 
     const allowedUnits: Record<string, string> = { day: 'day', week: 'week', month: 'month' };
     const truncUnit = allowedUnits[groupBy];
@@ -394,25 +393,25 @@ export const MentorsService = {
       throw new Error(`Invalid groupBy value: ${groupBy}`);
     }
 
+    const baseWhere = `WHERE b.mentor_id = $1 AND b.status = 'completed' AND b.payment_status = 'released' ${dateFilterClause}`;
+
     const [summaryResult, breakdownResult] = await Promise.all([
       pool.query<{ total_earnings: string; total_sessions: string }>(
         `SELECT
-           COALESCE(SUM(u.hourly_rate * (s.duration_minutes / 60.0)), 0) AS total_earnings,
-           COUNT(s.id) AS total_sessions
-         FROM sessions s
-         JOIN users u ON u.id = s.mentor_id
-         ${whereClause}`,
+           COALESCE(SUM(b.mentor_payout), 0) AS total_earnings,
+           COUNT(b.id) AS total_sessions
+         FROM bookings b
+         ${baseWhere}`,
         values,
       ),
       pool.query<{ period: string; earnings: string; sessions: string }>(
         `SELECT
-           DATE_TRUNC($${idx}, s.scheduled_at)::text AS period,
-           COALESCE(SUM(u.hourly_rate * (s.duration_minutes / 60.0)), 0) AS earnings,
-           COUNT(s.id) AS sessions
-         FROM sessions s
-         JOIN users u ON u.id = s.mentor_id
-         ${whereClause}
-         GROUP BY DATE_TRUNC($${idx}, s.scheduled_at)
+           DATE_TRUNC($${idx}, b.created_at)::text AS period,
+           COALESCE(SUM(b.mentor_payout), 0) AS earnings,
+           COUNT(b.id) AS sessions
+         FROM bookings b
+         ${baseWhere}
+         GROUP BY DATE_TRUNC($${idx}, b.created_at)
          ORDER BY period DESC`,
         [...values, truncUnit],
       ),

--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -1,25 +1,29 @@
-import db from '../config/db';
+import pool from '../config/database';
 import { CacheService } from './cache.service';
-import { CacheKeys, CacheTTL } from '../utils/cache-key.utils';
+import { CacheTTL } from '../utils/cache-key.utils';
 import { buildSearchQuery } from '../utils/query-builder.utils';
+import crypto from 'crypto';
+
+function hashParams(params: Record<string, any>): string {
+  return crypto.createHash('md5').update(JSON.stringify(params)).digest('hex').substring(0, 8);
+}
 
 export class SearchService {
   /**
-   * Search mentors with caching
-   * Results are cached for 60 seconds based on filter parameters
+   * Search mentors with caching.
+   * Uses a distinct cache namespace (mm:search:mentors:v1:*) to avoid
+   * collisions with MentorsService.list which returns a different response shape.
    */
   static async searchMentors(filters: any) {
-    const cacheKey = CacheKeys.mentorSearch(filters);
+    const cacheKey = `mm:search:mentors:v1:${hashParams(filters)}`;
 
-    // Use cache-aside pattern
     const cached = await CacheService.get<any>(cacheKey);
     if (cached !== null) {
       return cached;
     }
 
-    // Execute search query
     const { query, values } = buildSearchQuery(filters);
-    const result = await db.query(query, values);
+    const result = await pool.query(query, values);
     const totalCount = result.rows[0]?.total_count || 0;
 
     const searchResult = {
@@ -31,7 +35,6 @@ export class SearchService {
       },
     };
 
-    // Cache the result for 60 seconds
     await CacheService.set(cacheKey, searchResult, CacheTTL.short);
 
     return searchResult;

--- a/src/utils/cache-key.utils.ts
+++ b/src/utils/cache-key.utils.ts
@@ -24,11 +24,11 @@ export const CacheKeys = {
   mentorProfile: (id: string) => `mm:mentor:${id}`,
   mentorList: (page: number, limit: number) => `mm:mentors:${page}:${limit}`,
   /**
-   * Cache key for mentor search results
+   * Cache key for mentor search results (used by MentorsService.list)
    * Uses hash of query parameters to create compact, unique keys
    * @example CacheKeys.mentorSearch({ search: 'John', expertise: 'React', minRate: 50 })
    */
-  mentorSearch: (params: Record<string, any>) => `mm:mentors:search:${hashParams(params)}`,
+  mentorSearch: (params: Record<string, any>) => `mm:mentors:list:v1:${hashParams(params)}`,
 
   // Session cache keys
   /**


### PR DESCRIPTION

fix: resolve security, data integrity, and cache correctness issues (#236, #238, #243, #245)

This PR addresses four issues spanning a security vulnerability, a data
integrity bug, a cache key collision, and a private data leak via shared
cache entries.

---

## Changes

### #236 — forgotPassword leaks reset token in API response (Security · High)

**File:** `src/controllers/auth.controller.ts`

The `forgotPassword` handler was returning the raw reset token in the
response body (`data: { token }`), completely defeating the purpose of
the email-based reset flow. Any observer of the HTTP response (logging
proxy, XSS, compromised frontend) could obtain the token without access
to the user's email.

- Removed `data: { token }` from the response entirely
- The return value of `AuthService.forgotPassword` is now discarded at
  the controller level; the token travels exclusively via the email link
- Added `src/__tests__/controllers/auth.controller.test.ts` with tests
  asserting the response body contains no `data` or `token` field under
  any condition

---

### #238 — Mentor earnings query uses hourly_rate instead of actual booking amount (Bug · High)

**File:** `src/services/mentors.service.ts` (lines 377–440)

The `getEarnings()` method was calculating earnings by joining `sessions`
with `users` and multiplying the mentor's *current* `hourly_rate` by
session duration. This caused all historical earnings to be retroactively
recalculated whenever a mentor updated their rate, producing incorrect
financial data.

- Rewrote both the summary and breakdown queries to use
  `SUM(b.mentor_payout) FROM bookings b` — the actual amount recorded
  at the time of booking
- Filters on `status = 'completed'` and `payment_status = 'released'`
  to count only finalized payouts
- Removed the now-unnecessary `JOIN users` and `sessions` table references
  from the earnings queries

---

### #243 — SearchService and MentorsService.list share the same cache key (Medium)

**Files:** `src/services/search.service.ts`, `src/utils/cache-key.utils.ts`,
`src/__tests__/unit/search.service.test.ts`

`SearchService.searchMentors` and `MentorsService.list` were both using
`CacheKeys.mentorSearch(filters)` as their cache key, but return
incompatible response shapes:
- `SearchService` returns `{ mentors, meta: { total, page, limit } }`
- `MentorsService.list` returns `{ mentors, next_cursor, has_more, total }`

A cache hit from one service could be served to a caller expecting the
other's shape, causing runtime errors on the frontend.

Additionally, `search.service.ts` was importing from `../config/db` while
`mentors.service.ts` used `../config/database` — two separate pool
configurations pointing at the same database.

- `search.service.ts`: replaced `import db from '../config/db'` with
  `import pool from '../config/database'` (single shared pool)
- `search.service.ts`: now uses its own distinct cache namespace
  `mm:search:mentors:v1:{hash}` instead of the shared `mm:mentors:search:{hash}`
- `cache-key.utils.ts`: renamed `mentorSearch` key to `mm:mentors:list:v1:{hash}`
  to clearly scope it to `MentorsService.list`
- Updated the search service unit test to mock `config/database` instead of `config/db`

---

### #245 — cacheMiddleware caches authenticated responses without user scoping (Security · High)

**File:** `src/middleware/cache.middleware.ts`

When `cacheAuthenticated: true` was set, the middleware built the cache
key using only the URL (`mm:http:/api/v1/users/me`). This meant the first
authenticated user's response was cached and served to all subsequent
users hitting the same endpoint — leaking private profile data across users.

- When `cacheAuthenticated: true`, the default cache key now includes the
  user ID: `mm:http:{userId}:{url}`
- If `cacheAuthenticated: true` but no authenticated user is present on
  the request, caching is skipped entirely
- Custom `keyFn` still overrides the default behavior when provided
- Audited all routes: no routes currently use `cacheAuthenticated: true`,
  confirming no active data leaks in production
- Added `src/__tests__/middleware/cache.middleware.test.ts` with 5 tests:
  - User-scoped key is generated correctly
  - Different users receive different cache keys for the same URL
  - Missing user causes caching to be skipped
  - Unauthenticated routes are unaffected
  - Custom `keyFn` overrides the default key

---

## Testing

- New test file: `src/__tests__/controllers/auth.controller.test.ts`
- New test file: `src/__tests__/middleware/cache.middleware.test.ts`
- Updated: `src/__tests__/unit/search.service.test.ts` (mock path fix)

---

Closes #236
Closes #238
Closes #243
Closes #245
