### PR TITLE
feat: expose /health and /metrics on main Express app (#210)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,24 +1,31 @@
-import express, { Application } from 'express';
-import swaggerJsdoc from 'swagger-jsdoc';
-import swaggerUi from 'swagger-ui-express';
-import config from './config';
-import { corsMiddleware } from './middleware/cors.middleware';
-import { securityMiddleware, sanitizeInput } from './middleware/security.middleware';
-import { tracingMiddleware } from './middleware/tracing.middleware';
-import { requestLoggerMiddleware } from './middleware/request-logger.middleware';
-import { generalLimiter } from './middleware/rate-limit.middleware';
-import { errorHandler } from './middleware/errorHandler';
-import { notFoundHandler } from './middleware/notFoundHandler';
-import { swaggerOptions } from './config/swagger';
-import { blocklistMiddleware } from './middleware/ipFilter.middleware';
-import routes from './routes';
-import v1Router from './routes/v1';
-import v2Router from './routes/v2';
-import HealthService from './services/health.service';
-import { metricsMiddleware } from './middleware/metrics.middleware';
-import { versioningMiddleware } from './middleware/versioning.middleware';
-import { CURRENT_VERSION, API_VERSIONS, SUPPORTED_VERSIONS } from './config/api-versions.config';
-import { logger } from './utils/logger';
+import express, { Application } from "express";
+import swaggerJsdoc from "swagger-jsdoc";
+import swaggerUi from "swagger-ui-express";
+import config from "./config";
+import { corsMiddleware } from "./middleware/cors.middleware";
+import {
+  securityMiddleware,
+  sanitizeInput,
+} from "./middleware/security.middleware";
+import { tracingMiddleware } from "./middleware/tracing.middleware";
+import { requestLoggerMiddleware } from "./middleware/request-logger.middleware";
+import { generalLimiter } from "./middleware/rate-limit.middleware";
+import { errorHandler } from "./middleware/errorHandler";
+import { notFoundHandler } from "./middleware/notFoundHandler";
+import { swaggerOptions } from "./config/swagger";
+import { blocklistMiddleware } from "./middleware/ipFilter.middleware";
+import routes from "./routes";
+import v1Router from "./routes/v1";
+import v2Router from "./routes/v2";
+import HealthService from "./services/health.service";
+import { metricsMiddleware } from "./middleware/metrics.middleware";
+import { versioningMiddleware } from "./middleware/versioning.middleware";
+import {
+  CURRENT_VERSION,
+  API_VERSIONS,
+  SUPPORTED_VERSIONS,
+} from "./config/api-versions.config";
+import { logger } from "./utils/logger";
 
 const app: Application = express();
 const { apiVersion } = config.server;
@@ -34,14 +41,14 @@ app.use(corsMiddleware);
 app.use(requestLoggerMiddleware);
 
 // Body parsing
-app.use(express.json({ limit: '10mb' }));
-app.use(express.urlencoded({ extended: true, limit: '10mb' }));
+app.use(express.json({ limit: "10mb" }));
+app.use(express.urlencoded({ extended: true, limit: "10mb" }));
 
 app.use(sanitizeInput);
 app.use(generalLimiter);
 app.use(metricsMiddleware);
 app.use(versioningMiddleware);
-app.set('trust proxy', 1);
+app.set("trust proxy", 1);
 
 // Swagger docs (served on the current default version)
 const swaggerSpec = swaggerJsdoc(swaggerOptions);
@@ -49,37 +56,39 @@ app.use(
   `/api/${resolvedApiVersion}/docs`,
   swaggerUi.serve,
   swaggerUi.setup(swaggerSpec, {
-    customCss: '.swagger-ui .topbar { display: none }',
-    customSiteTitle: 'MentorMinds API Documentation',
+    customCss: ".swagger-ui .topbar { display: none }",
+    customSiteTitle: "MentorMinds API Documentation",
     swaggerOptions: { persistAuthorization: true },
   }),
 );
 app.get(`/api/${resolvedApiVersion}/docs/spec.json`, (_req, res) => {
-  res.setHeader('Content-Type', 'application/json');
+  res.setHeader("Content-Type", "application/json");
   res.send(swaggerSpec);
 });
 
 // Initialize health service
 HealthService.initialize().catch((err) => {
-  logger.error('HealthService initialization failed', { error: err });
+  logger.error("HealthService initialization failed", { error: err });
 });
 
 // ─── GET /api/versions ────────────────────────────────────────────────────────
-app.get('/api/versions', (_req, res) => {
+app.get("/api/versions", (_req, res) => {
   const versions = Object.values(API_VERSIONS).map((v) => ({
     version: (v as any).version,
     active: (v as any).active,
     current: (v as any).version === CURRENT_VERSION,
     ...((v as any).deprecatedAt && { deprecatedAt: (v as any).deprecatedAt }),
     ...((v as any).sunsetAt && { sunsetAt: (v as any).sunsetAt }),
-    ...((v as any).deprecationMessage && { deprecationMessage: (v as any).deprecationMessage }),
+    ...((v as any).deprecationMessage && {
+      deprecationMessage: (v as any).deprecationMessage,
+    }),
     links: {
       docs: (v as any).active ? `/api/${(v as any).version}/docs` : null,
     },
   }));
 
   res.json({
-    status: 'success',
+    status: "success",
     data: {
       current: CURRENT_VERSION,
       supported: SUPPORTED_VERSIONS,
@@ -90,39 +99,48 @@ app.get('/api/versions', (_req, res) => {
 
 // ─── Versioned API routes ─────────────────────────────────────────────────────
 // v1 — stable, always active
-app.use('/api/v1', v1Router);
+app.use("/api/v1", v1Router);
 
 // v2 — mounted only when marked active in api-versions.config.ts
 if (API_VERSIONS.v2?.active) {
-  app.use('/api/v2', v2Router);
+  app.use("/api/v2", v2Router);
 }
 
 // Legacy mount: honours the API_VERSION env var (defaults to v1)
 // Kept for backwards compatibility with deployments that set API_VERSION=v1
-if (resolvedApiVersion !== 'v1' && resolvedApiVersion !== 'v2') {
+if (resolvedApiVersion !== "v1" && resolvedApiVersion !== "v2") {
   app.use(`/api/${resolvedApiVersion}`, routes);
 }
 
-import HealthController from './controllers/health.controller';
-import { requireAdmin } from './middleware/admin-auth.middleware';
-import { authenticate } from './middleware/auth.middleware';
+import HealthController from "./controllers/health.controller";
+import { requireAdmin } from "./middleware/admin-auth.middleware";
+import { authenticate } from "./middleware/auth.middleware";
+import { registerMetricsRoute } from "./middleware/metrics.middleware";
 
 // ─── Health Routes ───────────────────────────────────────────────────────────
-app.get('/health/live', HealthController.getLive);
-app.get('/health/ready', HealthController.getReady);
-app.get('/health/detailed', authenticate as any, requireAdmin as any, HealthController.getDetailed);
-app.get('/health', (_req, res) => res.redirect('/health/ready'));
+app.get("/health/live", HealthController.getLive);
+app.get("/health/ready", HealthController.getReady);
+app.get(
+  "/health/detailed",
+  authenticate as any,
+  requireAdmin as any,
+  HealthController.getDetailed,
+);
+app.get("/health", (_req, res) => res.redirect("/health/ready"));
+
+// ─── Metrics Route ───────────────────────────────────────────────────────────
+registerMetricsRoute(app);
 
 // ─── Root info ────────────────────────────────────────────────────────────────
-app.get('/', (_req, res) => {
+app.get("/", (_req, res) => {
   res.json({
-    status: 'success',
-    message: 'MentorMinds Stellar API',
+    status: "success",
+    message: "MentorMinds Stellar API",
     currentVersion: CURRENT_VERSION,
     supportedVersions: SUPPORTED_VERSIONS,
     documentation: `/api/${CURRENT_VERSION}/docs`,
-    versions: '/api/versions',
-    health: '/health/ready',
+    versions: "/api/versions",
+    health: "/health/ready",
   });
 });
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -22,9 +22,10 @@ import {
 } from "../config/api-versions.config";
 import { asyncHandler } from "../utils/asyncHandler.utils";
 import { HealthController } from "../controllers/health.controller";
-import { HealthService } from "../services/health.service";
 import { logger } from "../utils/logger.utils";
 import { JwksController } from "../controllers/jwks.controller";
+import { metricsRegistry } from "../config/metrics";
+import { monitoringConfig } from "../config/monitoring.config";
 
 const router = Router();
 
@@ -98,5 +99,20 @@ router.get("/", (_req, res) => {
 
 // ── Health ───────────────────────────────────────────────────────────────────
 // Health routes moved to app.ts for global accessibility
+router.get("/health/live", asyncHandler(HealthController.getLive));
+router.get("/health/ready", asyncHandler(HealthController.getReady));
+router.get("/health", (_req, res) => res.redirect("/health/ready"));
+
+// ── Metrics ──────────────────────────────────────────────────────────────────
+const metricsEndpoint = monitoringConfig.prometheus.endpoint || "/metrics";
+router.get(metricsEndpoint, async (_req, res) => {
+  try {
+    const output = await metricsRegistry.metrics();
+    res.setHeader("Content-Type", metricsRegistry.contentType);
+    res.send(output);
+  } catch {
+    res.status(500).send("Error collecting metrics");
+  }
+});
 
 export default router;


### PR DESCRIPTION
- Register GET /metrics on the Express app via registerMetricsRoute(app) in app.ts
- Add /health/live, /health/ready, /health routes to versioned router in routes/index.ts
- Add /metrics route to versioned router using metricsRegistry and monitoringConfig
- What                                                                           
                                                                                 
  Hooks up the existing health controller and Prometheus metrics registry to the 
  Express app and versioned router — both were implemented but never wired in.   
                                                                                 
  Changes                                                                        
                                                                                 
  `src/app.ts`                                                                   
                                                                                 
  - Import and call registerMetricsRoute(app) to expose GET /metrics on the main 
  Express app                                                                    
                                                                                 
  `src/routes/index.ts`                                                          
                                                                                 
  - Map GET /health, /health/live, /health/ready to HealthController             
  - Map GET /metrics to the Prometheus registry output with correct Content-Type 
  - Remove pre-existing unused HealthService import (lint)                       
                                                                                 
  Acceptance Criteria                                                            
                                                                                 
  - [x] Metrics middleware already in base middleware stack                      
  (app.use(metricsMiddleware) — pre-existing)                                    
  - [x] /health and /metrics paths mapped in src/routes/index.ts                 
  - [x] GET /metrics returns Prometheus text format with `Content-Type:          
  text/plain; version=0.0.4                                                      
                                                                                 
  Testing                                                                        
                                                                                 
  # Health check                                                                 
  curl http://localhost:5000/health/ready                                        
                                                                                 
  # Prometheus scrape                                                            
  curl http://localhost:5000/metrics                                             
  # Expected: # HELP / # TYPE lines followed by metric samples

closes #210 