### PR TITLE
feat: process Stellar refund via Soroban escrow on booking cancellati…

### DIFF
--- a/src/services/bookings.service.ts
+++ b/src/services/bookings.service.ts
@@ -10,10 +10,8 @@ import {
 import { SocketService } from "./socket.service";
 import pool from "../config/database";
 import { CalendarService } from "./calendar.service";
-import { SorobanEscrowService } from './sorobanEscrow.service';
-import videoSessionService from "./videoSession.service";
-import { PaymentsService } from './payments.service';
-import { QueueService } from './queue.service';
+import { SorobanEscrowService } from "./sorobanEscrow.service";
+import { QueueService } from "./queue.service";
 
 export interface CreateBookingData {
   menteeId: string;
@@ -35,8 +33,6 @@ interface BookingEscrowMetadata {
   escrow_id: string | null;
   escrow_contract_address: string | null;
 }
-
-
 
 async function getBookingEscrowMetadata(
   bookingId: string,
@@ -246,9 +242,11 @@ export const BookingsService = {
       throw createError("Payment must be completed before confirmation", 400);
     }
 
-    let onChainEscrow:
-      | { contractAddress: string; escrowId: string; txHash: string | null }
-      | null = null;
+    let onChainEscrow: {
+      contractAddress: string;
+      escrowId: string;
+      txHash: string | null;
+    } | null = null;
 
     if (SorobanEscrowService.isConfigured()) {
       onChainEscrow = await SorobanEscrowService.createEscrow({
@@ -260,7 +258,9 @@ export const BookingsService = {
       });
     }
 
-    const updated = await BookingModel.update(bookingId, { status: 'confirmed' });
+    const updated = await BookingModel.update(bookingId, {
+      status: "confirmed",
+    });
 
     if (!updated) {
       throw createError("Failed to confirm booking", 500);
@@ -269,7 +269,7 @@ export const BookingsService = {
     // Invalidate session list cache for both users
     await CacheService.del(CacheKeys.sessionList(booking.mentee_id));
     await CacheService.del(CacheKeys.sessionList(booking.mentor_id));
-    logger.debug('Booking cache invalidated on confirmation', { bookingId });
+    logger.debug("Booking cache invalidated on confirmation", { bookingId });
 
     if (onChainEscrow) {
       await setBookingEscrowMetadata(
@@ -332,13 +332,18 @@ export const BookingsService = {
           contractAddress: metadata.escrow_contract_address || undefined,
         });
       } else {
-        logger.warn('Skipping Soroban release_funds: no escrow metadata on booking', {
-          bookingId,
-        });
+        logger.warn(
+          "Skipping Soroban release_funds: no escrow metadata on booking",
+          {
+            bookingId,
+          },
+        );
       }
     }
 
-    const updated = await BookingModel.update(bookingId, { status: 'completed' });
+    const updated = await BookingModel.update(bookingId, {
+      status: "completed",
+    });
 
     if (!updated) {
       throw createError("Failed to complete booking", 500);
@@ -347,12 +352,12 @@ export const BookingsService = {
     // Invalidate session list cache for both users
     await CacheService.del(CacheKeys.sessionList(booking.mentee_id));
     await CacheService.del(CacheKeys.sessionList(booking.mentor_id));
-    
+
     // Invalidate learner progress cache for the mentee
-    const { LearnerService } = await import('./learners.service');
+    const { LearnerService } = await import("./learners.service");
     await LearnerService.invalidateCache(booking.mentee_id);
 
-    logger.debug('Booking cache invalidated on completion', { bookingId });
+    logger.debug("Booking cache invalidated on completion", { bookingId });
     // Emit session:updated event to both mentor and mentee
     SocketService.emitToUser(booking.mentor_id, "session:updated", {
       bookingId,
@@ -382,19 +387,38 @@ export const BookingsService = {
     // Calculate refund eligibility
     const refundInfo = calculateRefundEligibility(booking.scheduled_at);
 
-    if (isCancelledBeforeSession(booking) && SorobanEscrowService.isConfigured()) {
+    let sorobanRefunded = false;
+
+    if (
+      isCancelledBeforeSession(booking) &&
+      SorobanEscrowService.isConfigured()
+    ) {
       const metadata = await getBookingEscrowMetadata(bookingId);
       if (metadata.escrow_id) {
-        await SorobanEscrowService.refund({
+        const refundResult = await SorobanEscrowService.refund({
           escrowId: metadata.escrow_id,
           refundedBy: userId,
           contractAddress: metadata.escrow_contract_address || undefined,
-          amount: refundInfo.eligible ? String(parseFloat(booking.amount) * (refundInfo.refundPercentage / 100)) : undefined,
+          amount: refundInfo.eligible
+            ? String(
+                parseFloat(booking.amount) *
+                  (refundInfo.refundPercentage / 100),
+              )
+            : undefined,
         });
-        // Update booking payment_status to 'refunded' after Soroban refund
-        await BookingModel.update(bookingId, { paymentStatus: 'refunded' });
+        await BookingModel.update(bookingId, {
+          paymentStatus: "refunded",
+          ...(refundResult.txHash
+            ? { stellarTxHash: refundResult.txHash }
+            : {}),
+        });
+        sorobanRefunded = true;
+        logger.info("Soroban refund successful", {
+          bookingId,
+          txHash: refundResult.txHash,
+        });
       } else {
-        logger.warn('Skipping Soroban refund: no escrow metadata on booking', {
+        logger.warn("Skipping Soroban refund: no escrow metadata on booking", {
           bookingId,
         });
       }
@@ -403,7 +427,11 @@ export const BookingsService = {
     const updated = await BookingModel.update(bookingId, {
       status: "cancelled",
       cancellationReason: reason || "No reason provided",
-      paymentStatus: refundInfo.eligible ? "refund_pending" : booking.payment_status,
+      ...(!sorobanRefunded && {
+        paymentStatus: refundInfo.eligible
+          ? "refund_pending"
+          : booking.payment_status,
+      }),
     });
 
     if (!updated) {
@@ -415,16 +443,18 @@ export const BookingsService = {
     await CacheService.del(CacheKeys.sessionList(booking.mentor_id));
     logger.debug("Booking cache invalidated on cancellation", { bookingId });
 
-    if (refundInfo.eligible && booking.transaction_id) {
+    if (!sorobanRefunded && refundInfo.eligible && booking.transaction_id) {
       await QueueService.submitStellarTx({
-        type: 'refund',
-        paymentId: booking.transaction_id, // This needs to be the original transaction ID
-        amount: String(parseFloat(booking.amount) * (refundInfo.refundPercentage / 100)),
+        type: "refund",
+        paymentId: booking.transaction_id,
+        amount: String(
+          parseFloat(booking.amount) * (refundInfo.refundPercentage / 100),
+        ),
         currency: booking.currency,
         userId: booking.mentee_id,
         description: refundInfo.reason,
       });
-      logger.info('Refund job enqueued', { bookingId, refundInfo });
+      logger.info("Refund job enqueued", { bookingId, refundInfo });
     }
 
     // Emit session:updated event to both mentor and mentee


### PR DESCRIPTION
…on (#206)

- Capture txHash from SorobanEscrowService.refund() and persist it as stellar_tx_hash
- Guard outer BookingModel.update from overwriting paymentStatus='refunded' when Soroban already handled the refund (sorobanRefunded flag)
- Skip QueueService.submitStellarTx fallback when Soroban refund succeeded
- DB record is only updated after successful blockchain invocation
- Remove unused videoSessionService and PaymentsService imports
- What                                                                           
                                                                                 
  The Soroban refund call existed but its result was silently discarded. The     
  outer DB update then overwrote payment_status back to refund_pending, and the  
  queue-based fallback fired regardless — meaning the blockchain transaction had 
  no effect on the final record state.                                           
                                                                                 
  Changes                                                                        
                                                                                 
  `src/services/bookings.service.ts`                                             
                                                                                 
  - Capture txHash from SorobanEscrowService.refund() and persist it as          
  stellar_tx_hash                                                                
  - Introduce sorobanRefunded flag — set only after the blockchain await resolves
  successfully                                                                   
  - Guard the outer BookingModel.update from overwriting                         
  payment_status='refunded' when Soroban already handled it                      
  - Skip QueueService.submitStellarTx fallback when Soroban refund succeeded     
  (non-escrow bookings still use the queue path)                                 
  - Remove unused videoSessionService and PaymentsService imports (pre-existing  
  lint errors)                                                                   
                                                                                 
  Acceptance Criteria                                                            
                                                                                 
  - [x] Refund transaction initiated via Soroban SDK                             
  (SorobanEscrowService.refund())                                                
  - [x] Network failure propagates as a thrown error — DB record is not updated  
  if blockchain call fails                                                       
  - [x] DB record updated only after successful blockchain processing            
  (sorobanRefunded=true gate)

closes #206 