### PR TITLE
fix(disputes): replace EscrowService stub with real SorobanEscrowServ…

### DIFF
--- a/src/services/__tests__/disputes.service.test.ts
+++ b/src/services/__tests__/disputes.service.test.ts
@@ -1,83 +1,259 @@
-import { DisputeService, EscrowService, NotificationService } from '../disputes.service';
-import { DisputeStateMachine } from '../dispute-state-machine.service';
-import { DisputeModel, DisputeRecord } from '../../models/dispute.model';
+import { DisputeService, NotificationService } from "../disputes.service";
+import { DisputeStateMachine } from "../dispute-state-machine.service";
+import { DisputeModel, DisputeRecord } from "../../models/dispute.model";
+import { SorobanEscrowService } from "../sorobanEscrow.service";
+import { DatabaseService } from "../database.service";
+import pool from "../../config/database";
 
-jest.mock('../../models/dispute.model', () => ({
+jest.mock("../../models/dispute.model", () => ({
   DisputeModel: {
     create: jest.fn(),
     findById: jest.fn(),
     updateStatus: jest.fn(),
     findUnresolvedOlderThanDays: jest.fn(),
     addEvidence: jest.fn(),
-  }
+  },
 }));
 
-jest.mock('../../models/audit-log.model', () => ({
-  AuditLogModel: { create: jest.fn() }
+jest.mock("../../models/audit-log.model", () => ({
+  AuditLogModel: { create: jest.fn() },
 }));
 
-describe('Dispute Resolution Workflow', () => {
+jest.mock("../sorobanEscrow.service", () => ({
+  SorobanEscrowService: {
+    refund: jest.fn(),
+    releaseFunds: jest.fn(),
+  },
+}));
+
+jest.mock("../database.service", () => ({
+  DatabaseService: {
+    withTransaction: jest.fn((cb: (client: any) => Promise<any>) =>
+      cb({
+        query: jest
+          .fn()
+          .mockResolvedValue({
+            rows: [
+              {
+                id: "disp-1",
+                status: "resolved",
+                resolution_notes: "User is right",
+                reporter_id: "user-1",
+                transaction_id: "tx-123",
+                reason: "Test",
+                created_at: new Date(),
+                updated_at: new Date(),
+              },
+            ],
+          }),
+      }),
+    ),
+  },
+}));
+
+jest.mock("../../config/database", () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}));
+
+describe("Dispute Resolution Workflow", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  describe('DisputeStateMachine', () => {
-    it('should allow open -> under_review transition', () => {
-      expect(() => DisputeStateMachine.assertTransition('open', 'under_review')).not.toThrow();
+  describe("DisputeStateMachine", () => {
+    it("should allow open -> under_review transition", () => {
+      expect(() =>
+        DisputeStateMachine.assertTransition("open", "under_review"),
+      ).not.toThrow();
     });
 
-    it('should allow under_review -> resolved transition', () => {
-      expect(() => DisputeStateMachine.assertTransition('under_review', 'resolved')).not.toThrow();
+    it("should allow under_review -> resolved transition", () => {
+      expect(() =>
+        DisputeStateMachine.assertTransition("under_review", "resolved"),
+      ).not.toThrow();
     });
 
-    it('should throw on invalid resolved -> open transition', () => {
-      expect(() => DisputeStateMachine.assertTransition('resolved', 'open')).toThrow('Invalid state transition');
+    it("should throw on invalid resolved -> open transition", () => {
+      expect(() =>
+        DisputeStateMachine.assertTransition("resolved", "open"),
+      ).toThrow("Invalid state transition");
     });
   });
 
-  describe('DisputesService', () => {
-    
-    it('should escalate old disputes and notify users', async () => {
+  describe("DisputesService", () => {
+    it("should escalate old disputes and notify users", async () => {
       const oldDispute: DisputeRecord = {
-        id: 'disp-1', transaction_id: 'tx-123', reporter_id: 'user-1', reason: 'Test',
-        status: 'open', resolution_notes: null, created_at: new Date(Date.now() - 8 * 86400000), 
-        updated_at: new Date()
+        id: "disp-1",
+        transaction_id: "tx-123",
+        reporter_id: "user-1",
+        reason: "Test",
+        status: "open",
+        resolution_notes: null,
+        created_at: new Date(Date.now() - 8 * 86400000),
+        updated_at: new Date(),
       };
-      
-      (DisputeModel.findUnresolvedOlderThanDays as jest.Mock).mockResolvedValue([oldDispute]);
-      (DisputeModel.updateStatus as jest.Mock).mockResolvedValue({ ...oldDispute, status: 'under_review' });
 
-      const notifySpy = jest.spyOn(NotificationService, 'notifyDisputeUpdate').mockResolvedValue();
+      (DisputeModel.findUnresolvedOlderThanDays as jest.Mock).mockResolvedValue(
+        [oldDispute],
+      );
+      (DisputeModel.updateStatus as jest.Mock).mockResolvedValue({
+        ...oldDispute,
+        status: "under_review",
+      });
+
+      const notifySpy = jest
+        .spyOn(NotificationService, "notifyDisputeUpdate")
+        .mockResolvedValue();
 
       const count = await DisputeService.escalateOldDisputes();
 
       expect(count).toBe(1);
-      expect(DisputeModel.updateStatus).toHaveBeenCalledWith('disp-1', 'under_review', expect.any(String));
-      expect(notifySpy).toHaveBeenCalledWith('user-1', 'disp-1', expect.stringContaining('auto-escalated'));
+      expect(DisputeModel.updateStatus).toHaveBeenCalledWith(
+        "disp-1",
+        "under_review",
+        expect.any(String),
+      );
+      expect(notifySpy).toHaveBeenCalledWith(
+        "user-1",
+        "disp-1",
+        expect.stringContaining("auto-escalated"),
+      );
     });
 
-    it('should upload evidence and record audit log', async () => {
-      (DisputeModel.addEvidence as jest.Mock).mockResolvedValue({ id: 'ev-1' });
+    it("should upload evidence and record audit log", async () => {
+      (DisputeModel.addEvidence as jest.Mock).mockResolvedValue({ id: "ev-1" });
 
-      await DisputeService.uploadEvidence('disp-1', 'user-1', 'Got cheated.', 'http://example.com/img.png');
+      await DisputeService.uploadEvidence(
+        "disp-1",
+        "user-1",
+        "Got cheated.",
+        "http://example.com/img.png",
+      );
       expect(DisputeModel.addEvidence).toHaveBeenCalledWith({
-        dispute_id: 'disp-1', submitter_id: 'user-1', text_content: 'Got cheated.', file_url: 'http://example.com/img.png'
+        dispute_id: "disp-1",
+        submitter_id: "user-1",
+        text_content: "Got cheated.",
+        file_url: "http://example.com/img.png",
       });
     });
 
-    it('should resolve dispute and trigger escrow actions', async () => {
+    describe("resolveDispute — real escrow integration", () => {
       const dispute: DisputeRecord = {
-        id: 'disp-1', transaction_id: 'tx-123', reporter_id: 'user-1', reason: 'Test',
-        status: 'under_review', resolution_notes: null, created_at: new Date(), updated_at: new Date()
+        id: "disp-1",
+        transaction_id: "tx-123",
+        reporter_id: "user-1",
+        reason: "Test",
+        status: "under_review",
+        resolution_notes: null,
+        created_at: new Date(),
+        updated_at: new Date(),
       };
 
-      (DisputeModel.findById as jest.Mock).mockResolvedValue(dispute);
-      const escrowSpy = jest.spyOn(EscrowService, 'processResolution').mockResolvedValue();
+      beforeEach(() => {
+        (DisputeModel.findById as jest.Mock).mockResolvedValue(dispute);
+        (pool.query as jest.Mock).mockResolvedValue({
+          rows: [
+            {
+              escrow_id: "escrow-abc",
+              escrow_contract_address: "CCONTRACT123",
+            },
+          ],
+        });
+      });
 
-      await DisputeService.resolveDispute('disp-1', 'admin-1', 'full_refund', 'User is right');
+      it("calls SorobanEscrowService.refund for full_refund and updates status atomically", async () => {
+        await DisputeService.resolveDispute(
+          "disp-1",
+          "admin-1",
+          "full_refund",
+          "User is right",
+        );
 
-      expect(escrowSpy).toHaveBeenCalledWith('tx-123', 'refund');
-      expect(DisputeModel.updateStatus).toHaveBeenCalledWith('disp-1', 'resolved', 'User is right');
+        expect(pool.query).toHaveBeenCalledWith(
+          expect.stringContaining("SELECT escrow_id"),
+          ["tx-123"],
+        );
+        expect(SorobanEscrowService.refund).toHaveBeenCalledWith({
+          escrowId: "escrow-abc",
+          refundedBy: "admin-1",
+          contractAddress: "CCONTRACT123",
+        });
+        expect(DatabaseService.withTransaction).toHaveBeenCalled();
+      });
+
+      it("calls SorobanEscrowService.refund for partial_refund", async () => {
+        await DisputeService.resolveDispute(
+          "disp-1",
+          "admin-1",
+          "partial_refund",
+          "Partial refund",
+        );
+
+        expect(SorobanEscrowService.refund).toHaveBeenCalledWith(
+          expect.objectContaining({ escrowId: "escrow-abc" }),
+        );
+        expect(SorobanEscrowService.releaseFunds).not.toHaveBeenCalled();
+      });
+
+      it("calls SorobanEscrowService.releaseFunds for release", async () => {
+        await DisputeService.resolveDispute(
+          "disp-1",
+          "admin-1",
+          "release",
+          "Mentor is right",
+        );
+
+        expect(SorobanEscrowService.releaseFunds).toHaveBeenCalledWith({
+          escrowId: "escrow-abc",
+          releasedBy: "admin-1",
+          contractAddress: "CCONTRACT123",
+        });
+        expect(SorobanEscrowService.refund).not.toHaveBeenCalled();
+      });
+
+      it("throws if no escrow_id found for the booking", async () => {
+        (pool.query as jest.Mock).mockResolvedValue({
+          rows: [{ escrow_id: null, escrow_contract_address: null }],
+        });
+
+        await expect(
+          DisputeService.resolveDispute(
+            "disp-1",
+            "admin-1",
+            "release",
+            "notes",
+          ),
+        ).rejects.toThrow("No escrow_id found for booking tx-123");
+      });
+
+      it("throws if dispute is not found", async () => {
+        (DisputeModel.findById as jest.Mock).mockResolvedValue(null);
+
+        await expect(
+          DisputeService.resolveDispute(
+            "disp-1",
+            "admin-1",
+            "release",
+            "notes",
+          ),
+        ).rejects.toThrow("Dispute not found");
+      });
+
+      it("rolls back if escrow call fails (withTransaction propagates error)", async () => {
+        (DatabaseService.withTransaction as jest.Mock).mockRejectedValue(
+          new Error("Soroban RPC error"),
+        );
+
+        await expect(
+          DisputeService.resolveDispute(
+            "disp-1",
+            "admin-1",
+            "full_refund",
+            "notes",
+          ),
+        ).rejects.toThrow("Soroban RPC error");
+      });
     });
   });
 });

--- a/src/services/disputes.service.ts
+++ b/src/services/disputes.service.ts
@@ -1,50 +1,86 @@
-import { DisputeModel, DisputeRecord } from '../models/dispute.model';
-import { DisputeStateMachine } from './dispute-state-machine.service';
-import { AuditLogModel } from '../models/audit-log.model';
-import { logger } from '../utils/logger';
-
-// Placeholder for Escrow API integration (Issue #B10)
-export const EscrowService = {
-  async processResolution(transactionId: string, action: 'refund' | 'release'): Promise<void> {
-    logger.info(`[EscrowService] Processing ${action} for transaction ${transactionId}`);
-  }
-};
+import { DisputeModel, DisputeRecord } from "../models/dispute.model";
+import { DisputeStateMachine } from "./dispute-state-machine.service";
+import { AuditLogModel } from "../models/audit-log.model";
+import { SorobanEscrowService } from "./sorobanEscrow.service";
+import { DatabaseService } from "./database.service";
+import pool from "../config/database";
+import { logger } from "../utils/logger";
 
 // Placeholder for Notification System integration (Issue #B15)
 export const NotificationService = {
-  async notifyDisputeUpdate(userId: string, disputeId: string, event: string): Promise<void> {
-    logger.info(`[NotificationService] Sending email to ${userId} regarding dispute ${disputeId}: ${event}`);
-  }
+  async notifyDisputeUpdate(
+    userId: string,
+    disputeId: string,
+    event: string,
+  ): Promise<void> {
+    logger.info(
+      `[NotificationService] Sending email to ${userId} regarding dispute ${disputeId}: ${event}`,
+    );
+  },
 };
 
 export class DisputeService {
   /**
    * Opens a new dispute.
    */
-  static async openDispute(transactionId: string, reporterId: string, reason: string): Promise<DisputeRecord> {
-    const dispute = await DisputeModel.create({ transaction_id: transactionId, reporter_id: reporterId, reason });
-    
-    await AuditLogModel.create({
-      level: 'info', action: 'dispute_opened', message: `Dispute opened for transaction ${transactionId}`,
-      user_id: reporterId, entity_type: 'dispute', entity_id: dispute.id, metadata: { reason },
-      ip_address: null, user_agent: null
+  static async openDispute(
+    transactionId: string,
+    reporterId: string,
+    reason: string,
+  ): Promise<DisputeRecord> {
+    const dispute = await DisputeModel.create({
+      transaction_id: transactionId,
+      reporter_id: reporterId,
+      reason,
     });
 
-    await NotificationService.notifyDisputeUpdate(reporterId, dispute.id, 'Dispute Opened');
+    await AuditLogModel.create({
+      level: "info",
+      action: "dispute_opened",
+      message: `Dispute opened for transaction ${transactionId}`,
+      user_id: reporterId,
+      entity_type: "dispute",
+      entity_id: dispute.id,
+      metadata: { reason },
+      ip_address: null,
+      user_agent: null,
+    });
+
+    await NotificationService.notifyDisputeUpdate(
+      reporterId,
+      dispute.id,
+      "Dispute Opened",
+    );
     return dispute;
   }
 
   /**
    * Adds evidence to a dispute and notifies parties.
    */
-  static async uploadEvidence(disputeId: string, userId: string, textContent?: string, fileUrl?: string) {
-    const evidence = await DisputeModel.addEvidence({ dispute_id: disputeId, submitter_id: userId, text_content: textContent, file_url: fileUrl });
-    
+  static async uploadEvidence(
+    disputeId: string,
+    userId: string,
+    textContent?: string,
+    fileUrl?: string,
+  ) {
+    const evidence = await DisputeModel.addEvidence({
+      dispute_id: disputeId,
+      submitter_id: userId,
+      text_content: textContent,
+      file_url: fileUrl,
+    });
+
     // Check if we need to auto-transition to under_review conceptually, or just log
     await AuditLogModel.create({
-      level: 'info', action: 'dispute_evidence_added', message: `Evidence added to dispute ${disputeId}`,
-      user_id: userId, entity_type: 'dispute_evidence', entity_id: evidence.id, metadata: { file_attached: !!fileUrl },
-      ip_address: null, user_agent: null
+      level: "info",
+      action: "dispute_evidence_added",
+      message: `Evidence added to dispute ${disputeId}`,
+      user_id: userId,
+      entity_type: "dispute_evidence",
+      entity_id: evidence.id,
+      metadata: { file_attached: !!fileUrl },
+      ip_address: null,
+      user_agent: null,
     });
 
     return evidence;
@@ -58,16 +94,30 @@ export class DisputeService {
     let escalatedCount = 0;
 
     for (const dispute of oldDisputes) {
-      if (DisputeStateMachine.canTransition(dispute.status, 'under_review')) {
-        await DisputeModel.updateStatus(dispute.id, 'under_review', 'Auto-escalated after 7 days');
-        
+      if (DisputeStateMachine.canTransition(dispute.status, "under_review")) {
+        await DisputeModel.updateStatus(
+          dispute.id,
+          "under_review",
+          "Auto-escalated after 7 days",
+        );
+
         await AuditLogModel.create({
-          level: 'warn', action: 'dispute_escalated', message: `Dispute ${dispute.id} automatically escalated`,
-          user_id: null, entity_type: 'dispute', entity_id: dispute.id, metadata: { previous_status: dispute.status },
-          ip_address: null, user_agent: null
+          level: "warn",
+          action: "dispute_escalated",
+          message: `Dispute ${dispute.id} automatically escalated`,
+          user_id: null,
+          entity_type: "dispute",
+          entity_id: dispute.id,
+          metadata: { previous_status: dispute.status },
+          ip_address: null,
+          user_agent: null,
         });
 
-        await NotificationService.notifyDisputeUpdate(dispute.reporter_id, dispute.id, 'Dispute auto-escalated to admin review');
+        await NotificationService.notifyDisputeUpdate(
+          dispute.reporter_id,
+          dispute.id,
+          "Dispute auto-escalated to admin review",
+        );
         escalatedCount++;
       }
     }
@@ -76,32 +126,83 @@ export class DisputeService {
 
   /**
    * Admins resolve a dispute.
+   * Looks up the booking's escrow_id and escrow_contract_address via the dispute's
+   * transaction_id, calls the real SorobanEscrowService, and wraps the escrow call
+   * + DB status update in a single transaction so they succeed or fail together.
    */
   static async resolveDispute(
-    disputeId: string, adminId: string, resolutionType: 'full_refund' | 'partial_refund' | 'release', notes: string
+    disputeId: string,
+    adminId: string,
+    resolutionType: "full_refund" | "partial_refund" | "release",
+    notes: string,
   ): Promise<DisputeRecord> {
     const dispute = await DisputeModel.findById(disputeId);
-    if (!dispute) throw new Error('Dispute not found');
+    if (!dispute) throw new Error("Dispute not found");
 
-    DisputeStateMachine.assertTransition(dispute.status, 'resolved');
-    
-    const updated = await DisputeModel.updateStatus(disputeId, 'resolved', notes);
+    DisputeStateMachine.assertTransition(dispute.status, "resolved");
 
-    // Trigger escrow behavior
-    if (resolutionType === 'full_refund' || resolutionType === 'partial_refund') {
-      await EscrowService.processResolution(dispute.transaction_id, 'refund');
-    } else if (resolutionType === 'release') {
-      await EscrowService.processResolution(dispute.transaction_id, 'release');
+    // Look up escrow details from the bookings table using the dispute's transaction_id
+    const { rows } = await pool.query<{
+      escrow_id: string | null;
+      escrow_contract_address: string | null;
+    }>(
+      `SELECT escrow_id, escrow_contract_address FROM bookings WHERE id = $1 LIMIT 1`,
+      [dispute.transaction_id],
+    );
+    const booking = rows[0];
+    if (!booking?.escrow_id) {
+      throw new Error(
+        `No escrow_id found for booking ${dispute.transaction_id}`,
+      );
     }
 
-    await AuditLogModel.create({
-      level: 'info', action: 'dispute_resolved', message: `Dispute ${disputeId} resolved by admin ${adminId} via ${resolutionType}`,
-      user_id: adminId, entity_type: 'dispute', entity_id: disputeId, metadata: { resolutionType, notes },
-      ip_address: null, user_agent: null
+    // Execute escrow action + DB status update atomically
+    const updated = await DatabaseService.withTransaction(async (client) => {
+      // 1. Call the real Soroban escrow contract
+      if (
+        resolutionType === "full_refund" ||
+        resolutionType === "partial_refund"
+      ) {
+        await SorobanEscrowService.refund({
+          escrowId: booking.escrow_id!,
+          refundedBy: adminId,
+          contractAddress: booking.escrow_contract_address ?? undefined,
+        });
+      } else {
+        await SorobanEscrowService.releaseFunds({
+          escrowId: booking.escrow_id!,
+          releasedBy: adminId,
+          contractAddress: booking.escrow_contract_address ?? undefined,
+        });
+      }
+
+      // 2. Update dispute status inside the same transaction
+      const result = await client.query<DisputeRecord>(
+        `UPDATE disputes SET status = 'resolved', resolution_notes = $1, updated_at = NOW()
+         WHERE id = $2 RETURNING *`,
+        [notes, disputeId],
+      );
+      return result.rows[0];
     });
 
-    await NotificationService.notifyDisputeUpdate(dispute.reporter_id, disputeId, `Dispute resolved: ${resolutionType}`);
+    await AuditLogModel.create({
+      level: "info",
+      action: "dispute_resolved",
+      message: `Dispute ${disputeId} resolved by admin ${adminId} via ${resolutionType}`,
+      user_id: adminId,
+      entity_type: "dispute",
+      entity_id: disputeId,
+      metadata: { resolutionType, notes },
+      ip_address: null,
+      user_agent: null,
+    });
 
-    return updated!;
+    await NotificationService.notifyDisputeUpdate(
+      dispute.reporter_id,
+      disputeId,
+      `Dispute resolved: ${resolutionType}`,
+    );
+
+    return updated;
   }
 }


### PR DESCRIPTION
closes #216



…ice (#216)

- Remove local EscrowService placeholder that only logged messages
- Look up escrow_id and escrow_contract_address from bookings table using dispute.transaction_id
- Call SorobanEscrowService.refund() for full_refund/partial_refund
- Call SorobanEscrowService.releaseFunds() for release
- Wrap escrow call + dispute status UPDATE in DatabaseService.withTransaction so both succeed or both roll back atomically
- Update tests to mock SorobanEscrowService and cover all resolution paths