### PR TITLE
fix(workers): rename payments→transactions table in all worker SQL qu…

### DIFF
--- a/src/jobs/stellarTx.worker.ts
+++ b/src/jobs/stellarTx.worker.ts
@@ -13,7 +13,15 @@ import { PaymentsService } from "../services/payments.service";
 import type { StellarTxJobData } from "../queues/stellar-tx.queue";
 
 async function processStellarTx(job: Job<StellarTxJobData>): Promise<void> {
-  const { txEnvelopeXdr, userId, paymentId, type, amount, currency, description } = job.data;
+  const {
+    txEnvelopeXdr,
+    userId,
+    paymentId,
+    type,
+    amount,
+    currency,
+    description,
+  } = job.data;
 
   logger.info("Stellar TX job started", {
     jobId: job.id,
@@ -24,19 +32,26 @@ async function processStellarTx(job: Job<StellarTxJobData>): Promise<void> {
   });
 
   let xdr = txEnvelopeXdr;
-  if (!xdr && type === 'refund' && paymentId && amount && currency) {
+  if (!xdr && type === "refund" && paymentId && amount && currency) {
     // Build refund XDR
-    const payment = await pool.query('SELECT from_address FROM transactions WHERE id = $1', [paymentId]);
+    const payment = await pool.query(
+      "SELECT from_address FROM transactions WHERE id = $1",
+      [paymentId],
+    );
     if (!payment.rows[0]?.from_address) {
-      throw new Error('No from_address found for refund');
+      throw new Error("No from_address found for refund");
     }
     const toPublicKey = payment.rows[0].from_address;
-    xdr = await stellarService.buildRefundTransaction(toPublicKey, amount, currency === 'XLM' ? undefined : new Asset(currency, 'GA...')); // Need to handle assets
+    xdr = await stellarService.buildRefundTransaction(
+      toPublicKey,
+      amount,
+      currency === "XLM" ? undefined : new Asset(currency, "GA..."),
+    ); // Need to handle assets
     // For now, assume XLM
   }
 
   if (!xdr) {
-    throw new Error('No transaction XDR to submit');
+    throw new Error("No transaction XDR to submit");
   }
 
   const result = await stellarService.submitTransaction(xdr);
@@ -51,7 +66,7 @@ async function processStellarTx(job: Job<StellarTxJobData>): Promise<void> {
 
     if (paymentId) {
       await pool.query(
-        "UPDATE payments SET status = 'failed', updated_at = NOW() WHERE id = $1",
+        "UPDATE transactions SET status = 'failed', updated_at = NOW() WHERE id = $1",
         [paymentId],
       );
     }
@@ -70,9 +85,15 @@ async function processStellarTx(job: Job<StellarTxJobData>): Promise<void> {
   });
 
   if (paymentId) {
-    if (type === 'refund') {
+    if (type === "refund") {
       // For refunds, call refundPayment to create the refund record and update booking
-      await PaymentsService.refundPayment(paymentId, userId, amount, description, result.hash);
+      await PaymentsService.refundPayment(
+        paymentId,
+        userId,
+        amount,
+        description,
+        result.hash,
+      );
     } else {
       // For regular payments, update the payment record
       await pool.query(

--- a/src/workers/payment.worker.ts
+++ b/src/workers/payment.worker.ts
@@ -23,7 +23,7 @@ async function pollPaymentStatus(job: Job<PaymentPollJobData>): Promise<void> {
   const { rows } = await pool.query<{
     status: string;
     transaction_hash: string | null;
-  }>("SELECT status, transaction_hash FROM payments WHERE id = $1", [
+  }>("SELECT status, transaction_hash FROM transactions WHERE id = $1", [
     paymentId,
   ]);
 
@@ -52,7 +52,7 @@ async function pollPaymentStatus(job: Job<PaymentPollJobData>): Promise<void> {
 
       if (confirmed) {
         await pool.query(
-          "UPDATE payments SET status = 'completed', updated_at = NOW() WHERE id = $1",
+          "UPDATE transactions SET status = 'completed', updated_at = NOW() WHERE id = $1",
           [paymentId],
         );
         logger.info("Payment marked completed via Stellar", {

--- a/src/workers/report.worker.ts
+++ b/src/workers/report.worker.ts
@@ -1,19 +1,19 @@
-import { Worker, Job } from 'bullmq';
-import pool from '../config/database';
+import { Worker, Job } from "bullmq";
+import pool from "../config/database";
 import {
   redisConnection,
   CONCURRENCY,
   QUEUE_NAMES,
-} from '../queues/queue.config';
-import { logger } from '../utils/logger.utils';
-import type { ReportJobData } from '../queues/report.queue';
+} from "../queues/queue.config";
+import { logger } from "../utils/logger.utils";
+import type { ReportJobData } from "../queues/report.queue";
 
 async function generateWeeklyEarningsReport(
   job: Job<ReportJobData>,
 ): Promise<void> {
   const { periodStart, periodEnd, mentorId } = job.data;
 
-  logger.info('Generating weekly earnings report', {
+  logger.info("Generating weekly earnings report", {
     jobId: job.id,
     periodStart,
     periodEnd,
@@ -21,7 +21,7 @@ async function generateWeeklyEarningsReport(
   });
 
   const params: any[] = [periodStart, periodEnd];
-  let mentorFilter = '';
+  let mentorFilter = "";
 
   if (mentorId) {
     params.push(mentorId);
@@ -34,7 +34,7 @@ async function generateWeeklyEarningsReport(
        COUNT(p.id)::int          AS total_sessions,
        COALESCE(SUM(p.amount), 0) AS gross_earnings,
        COALESCE(SUM(p.amount * 0.95), 0) AS net_earnings
-     FROM payments p
+     FROM transactions p
      JOIN sessions s ON p.user_id = s.learner_id
      WHERE p.created_at BETWEEN $1 AND $2
        AND p.status = 'completed'
@@ -44,7 +44,7 @@ async function generateWeeklyEarningsReport(
     params,
   );
 
-  logger.info('Weekly earnings report generated', {
+  logger.info("Weekly earnings report generated", {
     jobId: job.id,
     rows: rows.length,
     periodStart,
@@ -53,7 +53,7 @@ async function generateWeeklyEarningsReport(
 
   // In a real system you'd persist this or email it; for now we log the summary
   if (rows.length === 0) {
-    logger.info('No earnings data for period', { periodStart, periodEnd });
+    logger.info("No earnings data for period", { periodStart, periodEnd });
   }
 }
 
@@ -66,15 +66,15 @@ export const reportWorker = new Worker<ReportJobData>(
   },
 );
 
-reportWorker.on('completed', (job) => {
-  logger.info('Report job completed', {
+reportWorker.on("completed", (job) => {
+  logger.info("Report job completed", {
     jobId: job.id,
     reportType: job.data.reportType,
   });
 });
 
-reportWorker.on('failed', (job, err) => {
-  logger.error('Report job failed', {
+reportWorker.on("failed", (job, err) => {
+  logger.error("Report job failed", {
     jobId: job?.id,
     reportType: job?.data?.reportType,
     attempt: job?.attemptsMade,
@@ -82,6 +82,6 @@ reportWorker.on('failed', (job, err) => {
   });
 });
 
-reportWorker.on('error', (err) => {
-  logger.error('Report worker error', { error: err.message });
+reportWorker.on("error", (err) => {
+  logger.error("Report worker error", { error: err.message });
 });


### PR DESCRIPTION
Problem                                                                        
                                                                                 
  StellarTxWorker references a payments table that doesn't exist — the actual    
  table is transactions. This caused every escrow state transition to silently   
  fail: submitted Stellar transactions never updated the payment record on either
  the success or failure path. The same bug was present in two other workers.    
                                                                                 
  Changes                                                                        
                                                                                 
  ┌──────┬──────────────┐                                                        
  │ File │ What changed │                                                        
  ├──────┼──────────────┤                                                        
  │  │                                                                           
  ├────────────────────────────────┼─────────────────────────────────────────────
  ────────────────────────────┤                                                  
  │ `src/jobs/stellarTx.worker.ts` │ `UPDATE payments` → `UPDATE transactions` on
  the rejection/failure path │                                                   
  │  │                                                                           
  └────────────────────────────────┴─────────────────────────────────────────────
  payments` → `transactions` on both the status-check and confirmed paths │      
  │  │                                                                           
  └─────────────────────────────────┴────────────────────────────────────────────
  └─────────────────────────────────┴────────────────────────────────────────────
  ────────────────────────────────────────────────────────────────┘              
                                                                                 
  Audit                                                                          
                                                                                 
  All remaining workers (email, escrowCheck, notifications, escrow-release,      
  notificationCleanup, sessionReminder) were inspected — none reference the      
  payments table in SQL.

Closes #197 