### PR TITLE
Implement Attachment service

### DIFF
--- a/src/queues/virus-scan.queue.ts
+++ b/src/queues/virus-scan.queue.ts
@@ -3,7 +3,7 @@ import config from '../config';
 import { logger } from '../utils/logger';
 import pool from '../config/database';
 import { S3Client, GetObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
-import { AttachmentService } from '../services/attachment.service';
+import { SocketService } from '../services/socket.service';
 
 const s3 = new S3Client({
   region: process.env.AWS_REGION || 'us-east-1',
@@ -67,7 +67,22 @@ export const virusScanWorker = new Worker(
       });
       
       // Notify uploader via WebSocket
-      await AttachmentService.notifyScanComplete(attachmentId, scanResult);
+      let signedUrl: string | undefined;
+      if (scanResult === 'clean') {
+        const { getSignedUrl } = await import('@aws-sdk/s3-request-presigner');
+        const command = new GetObjectCommand({
+          Bucket: bucket,
+          Key: storageKey,
+        });
+        signedUrl = await getSignedUrl(s3, command, { expiresIn: 3600 });
+      }
+      
+      SocketService.emitToUser(attachment.uploader_id, 'attachment:scan_complete', {
+        attachmentId: attachment.id,
+        scanStatus: scanResult,
+        signedUrl,
+        file_name: attachment.file_name,
+      });
       
       // If infected, delete the file from S3
       if (scanResult === 'infected') {

--- a/src/queues/virus-scan.queue.ts
+++ b/src/queues/virus-scan.queue.ts
@@ -1,0 +1,167 @@
+import { Queue, Worker, Job } from 'bullmq';
+import config from '../config';
+import { logger } from '../utils/logger';
+import pool from '../config/database';
+import { S3Client, GetObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
+import { AttachmentService } from '../services/attachment.service';
+
+const s3 = new S3Client({
+  region: process.env.AWS_REGION || 'us-east-1',
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID || '',
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || '',
+  },
+});
+
+const redisUrl = config.redis.url || 'redis://localhost:6379';
+const url = new URL(redisUrl);
+
+const connection = {
+  host: url.hostname,
+  port: parseInt(url.port, 10) || 6379,
+  password: url.password || undefined,
+};
+
+export const virusScanQueue = new Queue('virus-scan-queue', { connection });
+
+export const virusScanWorker = new Worker(
+  'virus-scan-queue',
+  async (job: Job) => {
+    const { attachmentId, storageKey, bucket } = job.data;
+    
+    try {
+      // Download file from S3 for scanning
+      const getCommand = new GetObjectCommand({
+        Bucket: bucket,
+        Key: storageKey,
+      });
+      
+      const response = await s3.send(getCommand);
+      const chunks: Uint8Array[] = [];
+      
+      // @ts-ignore - response.Body is a readable stream
+      for await (const chunk of response.Body) {
+        chunks.push(chunk);
+      }
+      
+      const fileBuffer = Buffer.concat(chunks);
+      
+      // Scan file with ClamAV
+      const scanResult = await scanWithClamAV(fileBuffer);
+      
+      // Update attachment record with scan result
+      const { rows } = await pool.query(
+        `UPDATE message_attachments
+         SET scan_status = $1, scanned_at = NOW()
+         WHERE id = $2
+         RETURNING *`,
+        [scanResult, attachmentId]
+      );
+      
+      const attachment = rows[0];
+      
+      logger.info('[VirusScanQueue] Scan completed', {
+        attachmentId,
+        scanResult,
+        fileSize: fileBuffer.length,
+      });
+      
+      // Notify uploader via WebSocket
+      await AttachmentService.notifyScanComplete(attachmentId, scanResult);
+      
+      // If infected, delete the file from S3
+      if (scanResult === 'infected') {
+        try {
+          await s3.send(new DeleteObjectCommand({ Bucket: bucket, Key: storageKey }));
+          logger.warn('[VirusScanQueue] Deleted infected file from S3', { storageKey });
+        } catch (err) {
+          logger.error('[VirusScanQueue] Failed to delete infected file', { err });
+        }
+      }
+      
+      return { attachmentId, scanResult };
+    } catch (error) {
+      logger.error('[VirusScanQueue] Scan failed', {
+        attachmentId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      
+      // Mark as error if scan fails
+      await pool.query(
+        `UPDATE message_attachments
+         SET scan_status = 'error', scanned_at = NOW()
+         WHERE id = $1`,
+        [attachmentId]
+      );
+      
+      throw error;
+    }
+  },
+  { connection, concurrency: 3 },
+);
+
+virusScanWorker.on('completed', (job) => {
+  logger.info(`Virus scan job ${job.id} completed`);
+});
+
+virusScanWorker.on('failed', (job, err) => {
+  logger.error(`Virus scan job ${job?.id} failed`, { error: err.message });
+});
+
+/**
+ * Scan a file buffer using ClamAV via clamdscan or clamscan
+ */
+async function scanWithClamAV(fileBuffer: Buffer): Promise<'clean' | 'infected' | 'error'> {
+  const { exec } = require('child_process');
+  const { promisify } = require('util');
+  const execAsync = promisify(exec);
+  const fs = require('fs');
+  const path = require('path');
+  const os = require('os');
+  
+  try {
+    // Create a temporary file for scanning
+    const tempDir = os.tmpdir();
+    const tempFilePath = path.join(tempDir, `scan_${Date.now()}_${Math.random().toString(36).substring(7)}`);
+    
+    fs.writeFileSync(tempFilePath, fileBuffer);
+    
+    // Try clamdscan first (faster, uses daemon), fallback to clamscan
+    let scanResult;
+    try {
+      scanResult = await execAsync(`clamdscan --no-summary ${tempFilePath}`);
+    } catch (clamdError) {
+      // clamdscan not available, try clamscan
+      try {
+        scanResult = await execAsync(`clamscan --no-summary ${tempFilePath}`);
+      } catch (clamscanError) {
+        // Neither available, log error and return error status
+        logger.error('[VirusScanQueue] Neither clamdscan nor clamscan available');
+        fs.unlinkSync(tempFilePath);
+        return 'error';
+      }
+    }
+    
+    // Clean up temp file
+    fs.unlinkSync(tempFilePath);
+    
+    // Parse output - ClamAV returns "OK" for clean, or virus name for infected
+    const stdout = scanResult.stdout || '';
+    const stderr = scanResult.stderr || '';
+    const output = stdout + stderr;
+    
+    if (output.includes('OK') && !output.includes('FOUND')) {
+      return 'clean';
+    } else if (output.includes('FOUND') || output.includes('Infected')) {
+      return 'infected';
+    } else {
+      logger.warn('[VirusScanQueue] Unknown scan result', { output });
+      return 'error';
+    }
+  } catch (error) {
+    logger.error('[VirusScanQueue] Scan execution failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return 'error';
+  }
+}

--- a/src/services/admin.service.ts
+++ b/src/services/admin.service.ts
@@ -72,7 +72,9 @@ export const AdminService = {
     offset = 0,
     role?: string,
   ): Promise<{ data: UserRecord[]; total: number }> {
-    let query = "SELECT * FROM users WHERE deleted_at IS NULL";
+    let query = `SELECT id, email, first_name, last_name, role, is_active, is_verified,
+                 average_rating, total_sessions_completed, created_at, updated_at
+                 FROM users WHERE deleted_at IS NULL`;
     const params: any[] = [];
     if (role) {
       query += " AND role = $1";

--- a/src/services/attachment.service.ts
+++ b/src/services/attachment.service.ts
@@ -6,6 +6,7 @@ import { MessagingService } from './messaging.service';
 import { logger } from '../utils/logger.utils';
 import { S3Client, PutObjectCommand, DeleteObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { virusScanQueue } from '../queues/virus-scan.queue';
 
 const s3 = new S3Client({
   region: process.env.AWS_REGION || 'us-east-1',
@@ -121,20 +122,6 @@ export const AttachmentService = {
     return { storageKey, bucket };
   },
 
-  /**
-   * Virus scan stub — replace with ClamAV or cloud equivalent.
-   * Detects the EICAR test string as a placeholder.
-   */
-  async scanFile(fileBuffer: Buffer): Promise<'clean' | 'infected' | 'error'> {
-    try {
-      const eicar =
-        'X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*';
-      if (fileBuffer.toString('ascii').includes(eicar)) return 'infected';
-      return 'clean';
-    } catch {
-      return 'error';
-    }
-  },
 
   /**
    * Generate a signed URL valid for 1 hour using AWS SDK.
@@ -149,7 +136,7 @@ export const AttachmentService = {
 
   /**
    * Upload a file attachment to a conversation.
-   * Validates → checks quota → scans → stores → creates message → saves metadata.
+   * Validates → checks quota → stores → creates message → saves metadata with pending status → queues async scan.
    */
   async uploadAttachment(
     conversationId: string,
@@ -163,9 +150,6 @@ export const AttachmentService = {
 
     const withinQuota = await this.checkAndUpdateQuota(uploaderId, fileBuffer.length);
     if (!withinQuota) throw new Error('Daily upload quota exceeded (50 MB/day)');
-
-    const scanResult = await this.scanFile(fileBuffer);
-    if (scanResult === 'infected') throw new Error('File rejected: virus detected');
 
     const { storageKey, bucket } = await this.storeFile(fileBuffer, originalName);
 
@@ -186,11 +170,12 @@ export const AttachmentService = {
       return null;
     }
 
+    // Store attachment with pending scan status
     const { rows } = await pool.query<AttachmentRecord>(
       `INSERT INTO message_attachments
          (message_id, conversation_id, uploader_id, file_name, file_size,
           mime_type, storage_key, storage_bucket, scan_status, scanned_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'pending', NULL)
        RETURNING *`,
       [
         message.id,
@@ -201,14 +186,24 @@ export const AttachmentService = {
         mimeType,
         storageKey,
         bucket,
-        scanResult,
       ],
     );
 
     const attachment = rows[0];
-    attachment.signed_url = await this.generateSignedUrl(storageKey, bucket);
 
-    // Emit attachment notification to recipient
+    // Queue async virus scan job
+    await virusScanQueue.add('scan-file', {
+      attachmentId: attachment.id,
+      storageKey,
+      bucket,
+    });
+
+    logger.info('[AttachmentService] File uploaded, virus scan queued', {
+      attachmentId: attachment.id,
+      uploaderId,
+    });
+
+    // Emit attachment notification to recipient (without signed URL until scan completes)
     const conv = await MessagingService.getConversation(conversationId, uploaderId);
     if (conv) {
       const recipientId =
@@ -224,7 +219,7 @@ export const AttachmentService = {
           file_name: attachment.file_name,
           file_size: attachment.file_size,
           mime_type: attachment.mime_type,
-          signed_url: attachment.signed_url,
+          scan_status: attachment.scan_status,
         },
       });
     }
@@ -258,5 +253,56 @@ export const AttachmentService = {
     }
 
     await pool.query(`DELETE FROM message_attachments WHERE message_id = $1`, [messageId]);
+  },
+
+  /**
+   * Get attachment with signed URL only if scan status is clean.
+   */
+  async getAttachmentWithUrl(attachmentId: string): Promise<AttachmentRecord | null> {
+    const { rows } = await pool.query<AttachmentRecord>(
+      `SELECT * FROM message_attachments WHERE id = $1`,
+      [attachmentId],
+    );
+
+    const attachment = rows[0] || null;
+    if (!attachment) return null;
+
+    // Only generate signed URL if scan is clean
+    if (attachment.scan_status === 'clean') {
+      attachment.signed_url = await this.generateSignedUrl(attachment.storage_key, attachment.storage_bucket);
+    }
+
+    return attachment;
+  },
+
+  /**
+   * Notify uploader when scan completes via WebSocket.
+   */
+  async notifyScanComplete(attachmentId: string, scanStatus: 'clean' | 'infected' | 'error'): Promise<void> {
+    const { rows } = await pool.query<AttachmentRecord>(
+      `SELECT * FROM message_attachments WHERE id = $1`,
+      [attachmentId],
+    );
+
+    const attachment = rows[0];
+    if (!attachment) return;
+
+    let signedUrl: string | undefined;
+    if (scanStatus === 'clean') {
+      signedUrl = await this.generateSignedUrl(attachment.storage_key, attachment.storage_bucket);
+    }
+
+    SocketService.emitToUser(attachment.uploader_id, 'attachment:scan_complete', {
+      attachmentId: attachment.id,
+      scanStatus,
+      signedUrl,
+      file_name: attachment.file_name,
+    });
+
+    logger.info('[AttachmentService] Scan complete notification sent', {
+      attachmentId,
+      scanStatus,
+      uploaderId: attachment.uploader_id,
+    });
   },
 };

--- a/src/services/export.service.ts
+++ b/src/services/export.service.ts
@@ -16,11 +16,19 @@ if (!fs.existsSync(EXPORT_DIR)) {
   fs.mkdirSync(EXPORT_DIR, { recursive: true });
 }
 
+function toExportSafeRecord(user: any): any {
+  const safeUser = { ...user };
+  delete safeUser.password_hash;
+  delete safeUser.refresh_token;
+  delete safeUser.reset_token;
+  return safeUser;
+}
+
 export const ExportService = {
   async requestExport(userId: string): Promise<string> {
     const job = await ExportJobModel.create(userId);
     await exportQueue.add('process-export', { userId, jobId: job.id });
-    
+
     await AuditLoggerService.logEvent({
       level: LogLevel.INFO,
       action: 'DATA_EXPORT_REQUESTED',
@@ -50,8 +58,9 @@ export const ExportService = {
 
       archive.pipe(output);
 
-      // Add profile
-      archive.append(JSON.stringify(user, null, 2), { name: 'profile.json' });
+      // Add profile with sensitive fields stripped
+      const safeUser = toExportSafeRecord(user);
+      archive.append(JSON.stringify(safeUser, null, 2), { name: 'profile.json' });
       
       // Add sessions
       archive.append(JSON.stringify(sessions, null, 2), { name: 'sessions.json' });

--- a/src/services/verification.service.ts
+++ b/src/services/verification.service.ts
@@ -265,8 +265,8 @@ export const VerificationService = {
     ): Promise<VerificationRecord> {
         const verification = await this.getById(verificationId);
         if (!verification) throw new Error('Verification not found');
-        if (verification.status !== 'pending') {
-            throw new Error('Verification is not pending');
+        if (!['pending', 'more_info_requested'].includes(verification.status)) {
+            throw new Error('Verification is not in a reviewable state');
         }
 
         const { rows } = await pool.query<VerificationRecord>(

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,12 +1,16 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": ".",
+    "rootDir": "./src",
     "outDir": "./dist"
   },
   "include": [
-    "src/config/env.ts",
-    "src/config/monitoring.config.ts",
-    "src/tests/setup.ts"
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "noUnusedParameters": false,
     "noImplicitReturns": false,
     "noFallthroughCasesInSwitch": true,
-    "types": []
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]


### PR DESCRIPTION
Summary
1. attachment.service.ts (Virus Scanning)

Removed fake EICAR test string scanner
Created new virus-scan.queue.ts with BullMQ worker for async ClamAV scanning
Changed uploadAttachment to store files with scan_status: 'pending'
Queues async scan job instead of blocking upload
Only generates signed URL after scan completes with 'clean' status
Added notifyScanComplete() method for WebSocket notifications
Added getAttachmentWithUrl() method that only returns signed URL for clean files
2. admin.service.ts (PII Leak)

Replaced SELECT * with explicit column list in listUsers()
Excludes: password_hash, phone_number_encrypted, date_of_birth_encrypted, government_id_number_encrypted, bank_account_details_encrypted, google_calendar_access_token
Only returns: id, email, first_name, last_name, role, is_active, is_verified, average_rating, total_sessions_completed, created_at, updated_at
3. verification.service.ts (Status Transition)

Changed requestMoreInfo() guard from status !== 'pending' to !['pending', 'more_info_requested'].includes(status)
Now matches the same guard used in approve() and reject()
Allows admins to request additional info multiple times on the same record
4. export.service.ts (GDPR Export)

Added toExportSafeRecord() helper function
Strips password_hash, refresh_token, and reset_token before adding to archive
Applied to user data in processExport() before writing to profile.json

closes #289 
closes #293 
closes #294 
closes #279 