### PR TITLE
security: implement OAuth state validation for Google Calendar to pre…

### DIFF
--- a/src/controllers/calendar.controller.ts
+++ b/src/controllers/calendar.controller.ts
@@ -67,7 +67,7 @@ export const CalendarController = {
    */
   async googleConnect(req: AuthenticatedRequest, res: Response): Promise<void> {
     const userId = req.user!.id;
-    const url = CalendarService.getGoogleAuthUrl(userId);
+    const url = await CalendarService.getGoogleAuthUrl(userId);
     res.redirect(url);
   },
 
@@ -79,13 +79,33 @@ export const CalendarController = {
     req: AuthenticatedRequest,
     res: Response,
   ): Promise<void> {
-    const { code, state: userId, error } = req.query as Record<string, string>;
+    const { code, state, error } = req.query as Record<string, string>;
 
     if (error) {
       throw createError(`Google OAuth error: ${error}`, 400);
     }
-    if (!code || !userId) {
+    if (!code || !state) {
       throw createError("Missing OAuth code or state", 400);
+    }
+
+    let userId: string;
+    let csrf: string;
+
+    try {
+      const parsedState = JSON.parse(state);
+      userId = parsedState.userId;
+      csrf = parsedState.csrf;
+    } catch (e) {
+      throw createError("Invalid OAuth state format", 400);
+    }
+
+    if (!userId || !csrf) {
+      throw createError("Incomplete OAuth state", 400);
+    }
+
+    const isValid = await CalendarService.verifyAndClearCsrfToken(userId, csrf);
+    if (!isValid) {
+      throw createError("Invalid or expired CSRF token", 403);
     }
 
     await CalendarService.connectGoogleCalendar(userId, code);

--- a/src/services/calendar.service.ts
+++ b/src/services/calendar.service.ts
@@ -1,4 +1,6 @@
+import crypto from "crypto";
 import { google } from "googleapis";
+import { redis } from "../config/redis";
 import { pool } from "../config/database";
 import { createError } from "../middleware/errorHandler";
 import {
@@ -122,13 +124,32 @@ export const CalendarService = {
   /**
    * Generate a Google OAuth2 authorisation URL for the given user
    */
-  getGoogleAuthUrl(userId: string): string {
+  async getGoogleAuthUrl(userId: string): Promise<string> {
+    const csrf = crypto.randomBytes(16).toString("hex");
+    // Store CSRF in Redis with 10-minute TTL
+    await redis.set(`google_oauth_csrf:${userId}`, csrf, "EX", 600);
+
     return oauth2Client.generateAuthUrl({
       access_type: "offline",
       scope: GOOGLE_SCOPES,
-      state: userId,
+      state: JSON.stringify({ userId, csrf }),
       prompt: "consent",
     });
+  },
+
+  /**
+   * Verify and clear the CSRF token from Redis
+   */
+  async verifyAndClearCsrfToken(userId: string, csrf: string): Promise<boolean> {
+    const key = `google_oauth_csrf:${userId}`;
+    const storedCsrf = await redis.get(key);
+
+    if (!storedCsrf || storedCsrf !== csrf) {
+      return false;
+    }
+
+    await redis.del(key);
+    return true;
   },
 
   /**


### PR DESCRIPTION
This PR addresses a high-severity security issue (#290) where the OAuth state parameter was not being validated during the Google Calendar connection flow, making it vulnerable to CSRF attacks.

Key Changes:

Generated a secure CSRF token using crypto.randomBytes(16).
Stored the CSRF token in Redis with a 10-minute (600s) TTL, keyed by userId.
Updated the OAuth state parameter to include both userId and csrf as a JSON string.
Implemented verification in the callback handler to ensure the returned state matches the stored secret.
Ensured the Redis key is deleted immediately after verification to prevent token reuse.
Verification:

Verified code logic ensures that any mismatch or expired token results in a 403 Forbidden error.
Verified that the state parameter is correctly encoded/decoded across the flow.
Closes #290 