### PR TITLE
fix: eliminate quota race condition in checkAndUpdateQuota (#275)

### DIFF
--- a/src/services/__tests__/attachment.service.unit.test.ts
+++ b/src/services/__tests__/attachment.service.unit.test.ts
@@ -1,0 +1,283 @@
+import { AttachmentService } from "../attachment.service";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+jest.mock("../../config/database", () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}));
+
+jest.mock("../../utils/logger.utils", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock("@aws-sdk/client-s3", () => ({
+  S3Client: jest.fn().mockImplementation(() => ({ send: jest.fn() })),
+  PutObjectCommand: jest.fn(),
+  DeleteObjectCommand: jest.fn(),
+  GetObjectCommand: jest.fn(),
+}));
+
+jest.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: jest.fn().mockResolvedValue("https://signed.example.com/file"),
+}));
+
+jest.mock("../../queues/virus-scan.queue", () => ({
+  virusScanQueue: { add: jest.fn() },
+}));
+
+jest.mock("../socket.service", () => ({
+  SocketService: { emitToUser: jest.fn() },
+}));
+
+jest.mock("../messaging.service", () => ({
+  MessagingService: { sendMessage: jest.fn(), getConversation: jest.fn() },
+}));
+
+import pool from "../../config/database";
+
+const mockPool = pool as jest.Mocked<typeof pool>;
+
+const DAILY_QUOTA_BYTES = 50 * 1024 * 1024; // 50 MB
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ── validateFile ───────────────────────────────────────────────────────────────
+
+describe("AttachmentService.validateFile", () => {
+  it("accepts a valid JPEG under 10 MB", () => {
+    expect(
+      AttachmentService.validateFile("image/jpeg", 5 * 1024 * 1024),
+    ).toBeNull();
+  });
+
+  it("accepts a valid PNG under 10 MB", () => {
+    expect(
+      AttachmentService.validateFile("image/png", 1 * 1024 * 1024),
+    ).toBeNull();
+  });
+
+  it("accepts a valid WebP under 10 MB", () => {
+    expect(
+      AttachmentService.validateFile("image/webp", 8 * 1024 * 1024),
+    ).toBeNull();
+  });
+
+  it("rejects an image exceeding 10 MB", () => {
+    const err = AttachmentService.validateFile("image/jpeg", 11 * 1024 * 1024);
+    expect(err).toBe("Image exceeds 10 MB limit");
+  });
+
+  it("accepts a PDF under 20 MB", () => {
+    expect(
+      AttachmentService.validateFile("application/pdf", 15 * 1024 * 1024),
+    ).toBeNull();
+  });
+
+  it("rejects a PDF exceeding 20 MB", () => {
+    const err = AttachmentService.validateFile(
+      "application/pdf",
+      21 * 1024 * 1024,
+    );
+    expect(err).toBe("Document exceeds 20 MB limit");
+  });
+
+  it("rejects an unsupported MIME type", () => {
+    const err = AttachmentService.validateFile("video/mp4", 1 * 1024 * 1024);
+    expect(err).toMatch(/Unsupported file type/);
+    expect(err).toMatch(/video\/mp4/);
+  });
+});
+
+// ── checkAndUpdateQuota ────────────────────────────────────────────────────────
+
+describe("AttachmentService.checkAndUpdateQuota", () => {
+  const userId = "user-abc";
+  const fileSize = 5 * 1024 * 1024; // 5 MB
+
+  describe("quota available — UPDATE succeeds", () => {
+    it("returns true when the conditional UPDATE increments bytes_used", async () => {
+      // UPDATE matches the row and respects the quota condition
+      mockPool.query.mockResolvedValueOnce({
+        rows: [{ bytes_used: String(fileSize) }],
+        rowCount: 1,
+      } as any);
+
+      const result = await AttachmentService.checkAndUpdateQuota(
+        userId,
+        fileSize,
+      );
+
+      expect(result).toBe(true);
+      // INSERT step must not be called
+      expect(mockPool.query).toHaveBeenCalledTimes(1);
+    });
+
+    it("passes userId, fileSize, and quota as parameters to the UPDATE", async () => {
+      mockPool.query.mockResolvedValueOnce({
+        rows: [{ bytes_used: String(fileSize) }],
+        rowCount: 1,
+      } as any);
+
+      await AttachmentService.checkAndUpdateQuota(userId, fileSize);
+
+      expect(mockPool.query).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE user_upload_quotas"),
+        [userId, fileSize, DAILY_QUOTA_BYTES],
+      );
+    });
+
+    it("returns true at the exact quota boundary (bytes_used + fileSize === quota)", async () => {
+      const remaining = DAILY_QUOTA_BYTES - fileSize;
+      // Simulate the row already having `remaining` bytes; after update = DAILY_QUOTA_BYTES
+      mockPool.query.mockResolvedValueOnce({
+        rows: [{ bytes_used: String(DAILY_QUOTA_BYTES) }],
+        rowCount: 1,
+      } as any);
+
+      const result = await AttachmentService.checkAndUpdateQuota(
+        userId,
+        fileSize,
+      );
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("quota exceeded — UPDATE finds row but WHERE is false", () => {
+    it("returns false when the conditional UPDATE matches no rows and INSERT conflicts", async () => {
+      // UPDATE returns no rows (quota condition not met)
+      mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 } as any);
+      // INSERT returns no rows (ON CONFLICT DO NOTHING — row already exists)
+      mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 } as any);
+
+      const result = await AttachmentService.checkAndUpdateQuota(
+        userId,
+        fileSize,
+      );
+
+      expect(result).toBe(false);
+      expect(mockPool.query).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not use BEGIN/COMMIT/ROLLBACK — no transaction wrapping", async () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 } as any);
+      mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 } as any);
+
+      await AttachmentService.checkAndUpdateQuota(userId, fileSize);
+
+      const allCalls: string[] = (mockPool.query as jest.Mock).mock.calls.map(
+        (c: any[]) => (typeof c[0] === "string" ? c[0].toUpperCase() : ""),
+      );
+      expect(allCalls.some((q) => q.includes("BEGIN"))).toBe(false);
+      expect(allCalls.some((q) => q.includes("COMMIT"))).toBe(false);
+      expect(allCalls.some((q) => q.includes("ROLLBACK"))).toBe(false);
+    });
+  });
+
+  describe("first upload of the day — INSERT succeeds", () => {
+    it("returns true when UPDATE finds no row but INSERT creates the first row", async () => {
+      // UPDATE returns no rows (no row for today yet)
+      mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 } as any);
+      // INSERT creates the first row for today
+      mockPool.query.mockResolvedValueOnce({
+        rows: [{ bytes_used: String(fileSize) }],
+        rowCount: 1,
+      } as any);
+
+      const result = await AttachmentService.checkAndUpdateQuota(
+        userId,
+        fileSize,
+      );
+
+      expect(result).toBe(true);
+      expect(mockPool.query).toHaveBeenCalledTimes(2);
+    });
+
+    it("passes userId and fileSize to the INSERT", async () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 } as any);
+      mockPool.query.mockResolvedValueOnce({
+        rows: [{ bytes_used: String(fileSize) }],
+        rowCount: 1,
+      } as any);
+
+      await AttachmentService.checkAndUpdateQuota(userId, fileSize);
+
+      expect(mockPool.query).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining("INSERT INTO user_upload_quotas"),
+        [userId, fileSize],
+      );
+    });
+
+    it("INSERT uses ON CONFLICT DO NOTHING to prevent double-counting on concurrent first uploads", async () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 } as any);
+      mockPool.query.mockResolvedValueOnce({
+        rows: [{ bytes_used: String(fileSize) }],
+        rowCount: 1,
+      } as any);
+
+      await AttachmentService.checkAndUpdateQuota(userId, fileSize);
+
+      const insertCall: string = (mockPool.query as jest.Mock).mock.calls[1][0];
+      expect(insertCall.toUpperCase()).toContain("ON CONFLICT");
+      expect(insertCall.toUpperCase()).toContain("DO NOTHING");
+    });
+  });
+
+  describe("error propagation", () => {
+    it("propagates a database error from the UPDATE step", async () => {
+      const dbError = new Error("connection refused");
+      mockPool.query.mockRejectedValueOnce(dbError);
+
+      await expect(
+        AttachmentService.checkAndUpdateQuota(userId, fileSize),
+      ).rejects.toThrow("connection refused");
+    });
+
+    it("propagates a database error from the INSERT step", async () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 } as any);
+      const dbError = new Error("unique violation");
+      mockPool.query.mockRejectedValueOnce(dbError);
+
+      await expect(
+        AttachmentService.checkAndUpdateQuota(userId, fileSize),
+      ).rejects.toThrow("unique violation");
+    });
+  });
+
+  describe("conditional UPDATE query shape", () => {
+    it("UPDATE WHERE clause includes the quota guard (bytes_used + file_size <= quota)", async () => {
+      mockPool.query.mockResolvedValueOnce({
+        rows: [{ bytes_used: "1" }],
+        rowCount: 1,
+      } as any);
+
+      await AttachmentService.checkAndUpdateQuota(userId, fileSize);
+
+      const updateSql: string = (mockPool.query as jest.Mock).mock.calls[0][0];
+      // Must contain the conditional guard — not an unconditional increment
+      expect(updateSql).toMatch(/bytes_used\s*\+\s*\$2\s*<=\s*\$3/i);
+    });
+
+    it("UPDATE does not contain a rollback-style decrement (the old race-condition pattern)", async () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 } as any);
+      mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 } as any);
+
+      await AttachmentService.checkAndUpdateQuota(userId, fileSize);
+
+      const allSql: string = (mockPool.query as jest.Mock).mock.calls
+        .map((c: any[]) => (typeof c[0] === "string" ? c[0] : ""))
+        .join("\n");
+      // The old pattern subtracted bytes on rollback — must not appear
+      expect(allSql).not.toMatch(/bytes_used\s*-\s*\$/);
+    });
+  });
+});

--- a/src/services/attachment.service.ts
+++ b/src/services/attachment.service.ts
@@ -1,27 +1,32 @@
-import path from 'path';
-import crypto from 'crypto';
-import pool from '../config/database';
-import { SocketService } from './socket.service';
-import { MessagingService } from './messaging.service';
-import { logger } from '../utils/logger.utils';
-import { S3Client, PutObjectCommand, DeleteObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
-import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { virusScanQueue } from '../queues/virus-scan.queue';
+import path from "path";
+import crypto from "crypto";
+import pool from "../config/database";
+import { SocketService } from "./socket.service";
+import { MessagingService } from "./messaging.service";
+import { logger } from "../utils/logger.utils";
+import {
+  S3Client,
+  PutObjectCommand,
+  DeleteObjectCommand,
+  GetObjectCommand,
+} from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { virusScanQueue } from "../queues/virus-scan.queue";
 
 const s3 = new S3Client({
-  region: process.env.AWS_REGION || 'us-east-1',
+  region: process.env.AWS_REGION || "us-east-1",
   credentials: {
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID || '',
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || '',
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID || "",
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || "",
   },
 });
 
 const DAILY_QUOTA_BYTES = 50 * 1024 * 1024; // 50 MB
 
-const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
-const ALLOWED_DOC_TYPES = ['application/pdf'];
+const ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp"];
+const ALLOWED_DOC_TYPES = ["application/pdf"];
 const IMAGE_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
-const DOC_MAX_BYTES = 20 * 1024 * 1024;   // 20 MB
+const DOC_MAX_BYTES = 20 * 1024 * 1024; // 20 MB
 
 export interface AttachmentRecord {
   id: string;
@@ -33,7 +38,7 @@ export interface AttachmentRecord {
   mime_type: string;
   storage_key: string;
   storage_bucket: string;
-  scan_status: 'pending' | 'clean' | 'infected' | 'error';
+  scan_status: "pending" | "clean" | "infected" | "error";
   scanned_at: Date | null;
   created_at: Date;
   signed_url?: string;
@@ -46,11 +51,11 @@ export const AttachmentService = {
    */
   validateFile(mimeType: string, fileSize: number): string | null {
     if (ALLOWED_IMAGE_TYPES.includes(mimeType)) {
-      if (fileSize > IMAGE_MAX_BYTES) return 'Image exceeds 10 MB limit';
+      if (fileSize > IMAGE_MAX_BYTES) return "Image exceeds 10 MB limit";
       return null;
     }
     if (ALLOWED_DOC_TYPES.includes(mimeType)) {
-      if (fileSize > DOC_MAX_BYTES) return 'Document exceeds 20 MB limit';
+      if (fileSize > DOC_MAX_BYTES) return "Document exceeds 20 MB limit";
       return null;
     }
     return `Unsupported file type: ${mimeType}. Allowed: JPEG, PNG, WebP, PDF`;
@@ -59,43 +64,46 @@ export const AttachmentService = {
   /**
    * Atomically check and increment the daily upload quota.
    * Returns false if the quota would be exceeded.
+   *
+   * Two-step approach that eliminates the optimistic-increment-then-rollback race:
+   *   1. Conditional UPDATE — only increments when bytes_used + fileSize <= quota.
+   *      If the row is missing (first upload today) or quota is full, no row is touched.
+   *   2. INSERT for the first-upload-of-day case — ON CONFLICT DO NOTHING ensures
+   *      that if another request already inserted the row (race on first upload),
+   *      we correctly treat it as quota-exceeded rather than double-counting.
    */
-  async checkAndUpdateQuota(userId: string, fileSize: number): Promise<boolean> {
-    const client = await pool.connect();
-    try {
-      await client.query('BEGIN');
+  async checkAndUpdateQuota(
+    userId: string,
+    fileSize: number,
+  ): Promise<boolean> {
+    // Step 1: increment only when it won't exceed the quota (atomic, no rollback needed).
+    const { rows: updated } = await pool.query<{ bytes_used: string }>(
+      `UPDATE user_upload_quotas
+       SET bytes_used = bytes_used + $2
+       WHERE user_id = $1
+         AND quota_date = CURRENT_DATE
+         AND bytes_used + $2 <= $3
+       RETURNING bytes_used`,
+      [userId, fileSize, DAILY_QUOTA_BYTES],
+    );
 
-      const { rows } = await client.query<{ bytes_used: string }>(
-        `INSERT INTO user_upload_quotas (user_id, quota_date, bytes_used)
-         VALUES ($1, CURRENT_DATE, $2)
-         ON CONFLICT (user_id, quota_date) DO UPDATE
-           SET bytes_used = user_upload_quotas.bytes_used + $2
-         RETURNING bytes_used`,
-        [userId, fileSize],
-      );
+    if (updated.length > 0) return true;
 
-      const newTotal = parseInt(rows[0].bytes_used, 10);
+    // Step 2: UPDATE found no row — either the row doesn't exist yet (first upload
+    // today) or the quota is already met.  Attempt an insert; DO NOTHING on conflict
+    // so a concurrent first-upload doesn't double-count.
+    const { rows: inserted } = await pool.query<{ bytes_used: string }>(
+      `INSERT INTO user_upload_quotas (user_id, quota_date, bytes_used)
+       VALUES ($1, CURRENT_DATE, $2)
+       ON CONFLICT (user_id, quota_date) DO NOTHING
+       RETURNING bytes_used`,
+      [userId, fileSize],
+    );
 
-      if (newTotal > DAILY_QUOTA_BYTES) {
-        // Roll back the increment — quota exceeded
-        await client.query(
-          `UPDATE user_upload_quotas
-           SET bytes_used = bytes_used - $1
-           WHERE user_id = $2 AND quota_date = CURRENT_DATE`,
-          [fileSize, userId],
-        );
-        await client.query('COMMIT');
-        return false;
-      }
-
-      await client.query('COMMIT');
-      return true;
-    } catch (err) {
-      await client.query('ROLLBACK');
-      throw err;
-    } finally {
-      client.release();
-    }
+    // Inserted → first upload of the day, within quota.
+    // Conflict (no rows returned) → row already existed but the conditional UPDATE
+    // above didn't fire, meaning the quota is already reached or exceeded.
+    return inserted.length > 0;
   },
 
   /**
@@ -105,23 +113,22 @@ export const AttachmentService = {
     fileBuffer: Buffer,
     originalName: string,
   ): Promise<{ storageKey: string; bucket: string }> {
-    const ext = path.extname(originalName) || '';
+    const ext = path.extname(originalName) || "";
     const storageKey = `${crypto.randomUUID()}${ext}`;
-    const bucket = process.env.AWS_S3_BUCKET || 'attachments';
+    const bucket = process.env.AWS_S3_BUCKET || "attachments";
 
     await s3.send(
       new PutObjectCommand({
         Bucket: bucket,
         Key: storageKey,
         Body: fileBuffer,
-      })
+      }),
     );
 
-    logger.debug('AttachmentService: file stored to S3', { storageKey });
+    logger.debug("AttachmentService: file stored to S3", { storageKey });
 
     return { storageKey, bucket };
   },
-
 
   /**
    * Generate a signed URL valid for 1 hour using AWS SDK.
@@ -148,10 +155,17 @@ export const AttachmentService = {
     const validationError = this.validateFile(mimeType, fileBuffer.length);
     if (validationError) throw new Error(validationError);
 
-    const withinQuota = await this.checkAndUpdateQuota(uploaderId, fileBuffer.length);
-    if (!withinQuota) throw new Error('Daily upload quota exceeded (50 MB/day)');
+    const withinQuota = await this.checkAndUpdateQuota(
+      uploaderId,
+      fileBuffer.length,
+    );
+    if (!withinQuota)
+      throw new Error("Daily upload quota exceeded (50 MB/day)");
 
-    const { storageKey, bucket } = await this.storeFile(fileBuffer, originalName);
+    const { storageKey, bucket } = await this.storeFile(
+      fileBuffer,
+      originalName,
+    );
 
     // Create a message whose body is the file name
     const message = await MessagingService.sendMessage(
@@ -163,9 +177,11 @@ export const AttachmentService = {
     if (!message) {
       // Clean up orphaned file
       try {
-        await s3.send(new DeleteObjectCommand({ Bucket: bucket, Key: storageKey }));
+        await s3.send(
+          new DeleteObjectCommand({ Bucket: bucket, Key: storageKey }),
+        );
       } catch (err) {
-        logger.warn('Failed to cleanup orphaned file', { err });
+        logger.warn("Failed to cleanup orphaned file", { err });
       }
       return null;
     }
@@ -192,26 +208,29 @@ export const AttachmentService = {
     const attachment = rows[0];
 
     // Queue async virus scan job
-    await virusScanQueue.add('scan-file', {
+    await virusScanQueue.add("scan-file", {
       attachmentId: attachment.id,
       storageKey,
       bucket,
     });
 
-    logger.info('[AttachmentService] File uploaded, virus scan queued', {
+    logger.info("[AttachmentService] File uploaded, virus scan queued", {
       attachmentId: attachment.id,
       uploaderId,
     });
 
     // Emit attachment notification to recipient (without signed URL until scan completes)
-    const conv = await MessagingService.getConversation(conversationId, uploaderId);
+    const conv = await MessagingService.getConversation(
+      conversationId,
+      uploaderId,
+    );
     if (conv) {
       const recipientId =
         conv.participant_one_id === uploaderId
           ? conv.participant_two_id
           : conv.participant_one_id;
 
-      SocketService.emitToUser(recipientId, 'message:new', {
+      SocketService.emitToUser(recipientId, "message:new", {
         conversationId,
         message,
         attachment: {
@@ -242,23 +261,27 @@ export const AttachmentService = {
           new DeleteObjectCommand({
             Bucket: att.storage_bucket,
             Key: att.storage_key,
-          })
+          }),
         );
       } catch (err) {
-        logger.warn('AttachmentService: failed to delete file from S3', {
+        logger.warn("AttachmentService: failed to delete file from S3", {
           storageKey: att.storage_key,
           err,
         });
       }
     }
 
-    await pool.query(`DELETE FROM message_attachments WHERE message_id = $1`, [messageId]);
+    await pool.query(`DELETE FROM message_attachments WHERE message_id = $1`, [
+      messageId,
+    ]);
   },
 
   /**
    * Get attachment with signed URL only if scan status is clean.
    */
-  async getAttachmentWithUrl(attachmentId: string): Promise<AttachmentRecord | null> {
+  async getAttachmentWithUrl(
+    attachmentId: string,
+  ): Promise<AttachmentRecord | null> {
     const { rows } = await pool.query<AttachmentRecord>(
       `SELECT * FROM message_attachments WHERE id = $1`,
       [attachmentId],
@@ -268,8 +291,11 @@ export const AttachmentService = {
     if (!attachment) return null;
 
     // Only generate signed URL if scan is clean
-    if (attachment.scan_status === 'clean') {
-      attachment.signed_url = await this.generateSignedUrl(attachment.storage_key, attachment.storage_bucket);
+    if (attachment.scan_status === "clean") {
+      attachment.signed_url = await this.generateSignedUrl(
+        attachment.storage_key,
+        attachment.storage_bucket,
+      );
     }
 
     return attachment;
@@ -278,7 +304,10 @@ export const AttachmentService = {
   /**
    * Notify uploader when scan completes via WebSocket.
    */
-  async notifyScanComplete(attachmentId: string, scanStatus: 'clean' | 'infected' | 'error'): Promise<void> {
+  async notifyScanComplete(
+    attachmentId: string,
+    scanStatus: "clean" | "infected" | "error",
+  ): Promise<void> {
     const { rows } = await pool.query<AttachmentRecord>(
       `SELECT * FROM message_attachments WHERE id = $1`,
       [attachmentId],
@@ -288,18 +317,25 @@ export const AttachmentService = {
     if (!attachment) return;
 
     let signedUrl: string | undefined;
-    if (scanStatus === 'clean') {
-      signedUrl = await this.generateSignedUrl(attachment.storage_key, attachment.storage_bucket);
+    if (scanStatus === "clean") {
+      signedUrl = await this.generateSignedUrl(
+        attachment.storage_key,
+        attachment.storage_bucket,
+      );
     }
 
-    SocketService.emitToUser(attachment.uploader_id, 'attachment:scan_complete', {
-      attachmentId: attachment.id,
-      scanStatus,
-      signedUrl,
-      file_name: attachment.file_name,
-    });
+    SocketService.emitToUser(
+      attachment.uploader_id,
+      "attachment:scan_complete",
+      {
+        attachmentId: attachment.id,
+        scanStatus,
+        signedUrl,
+        file_name: attachment.file_name,
+      },
+    );
 
-    logger.info('[AttachmentService] Scan complete notification sent', {
+    logger.info("[AttachmentService] Scan complete notification sent", {
       attachmentId,
       scanStatus,
       uploaderId: attachment.uploader_id,


### PR DESCRIPTION
## Problem

`checkAndUpdateQuota` used an optimistic **increment-then-rollback** pattern:

1. `INSERT … ON CONFLICT DO UPDATE SET bytes_used = bytes_used + $2` — always increments  
2. If the returned total exceeded 50 MB, a second `UPDATE bytes_used = bytes_used - $1` rolled it back

Between step 1 and step 2 a concurrent request reads the inflated `bytes_used`, concludes it is within quota, and proceeds — both uploads go through, exceeding the daily limit.

## Fix

**Two-step atomic approach** — no transaction, no rollback:

**Step 1 — conditional UPDATE** (only fires when quota won't be exceeded):
```sql
UPDATE user_upload_quotas
SET bytes_used = bytes_used + $2
WHERE user_id = $1
  AND quota_date = CURRENT_DATE
  AND bytes_used + $2 <= $3
RETURNING bytes_used
```
- Row updated → within quota → `return true`
- No rows → either quota is met **or** no row for today yet → fall through to step 2

**Step 2 — INSERT for first upload of the day:**
```sql
INSERT INTO user_upload_quotas (user_id, quota_date, bytes_used)
VALUES ($1, CURRENT_DATE, $2)
ON CONFLICT (user_id, quota_date) DO NOTHING
RETURNING bytes_used
```
- Row inserted → first upload today → `return true`  
- Conflict (row already existed, step 1 didn't fire) → quota reached → `return false`

The `pool.connect()` + `BEGIN`/`COMMIT`/`ROLLBACK` wrapper is removed entirely — neither step requires a transaction.

## Tests (19 passing)

| Scenario | Expectation |
|---|---|
| UPDATE increments within quota | `true`, only 1 query |
| UPDATE fires at exact boundary | `true` |
| UPDATE no rows + INSERT conflict | `false`, 2 queries |
| UPDATE no rows + INSERT succeeds | `true` (first upload of day) |
| DB error in UPDATE step | propagated |
| DB error in INSERT step | propagated |
| UPDATE SQL contains quota guard `bytes_used + $2 <= $3` | assertion on SQL text |
| No `BEGIN`/`COMMIT`/`ROLLBACK` calls | assertion on query calls |
| No rollback-style decrement (`bytes_used - $`) | assertion on SQL text |



closes #275 