### PR TITLE
Moderation service check for autoHide all set

### DIFF
--- a/database/migrations/014_create_flags.sql
+++ b/database/migrations/014_create_flags.sql
@@ -29,7 +29,10 @@ CREATE TABLE IF NOT EXISTS flags (
     
     -- Timestamps
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    
+    -- Ensure a user can only flag an entity once
+    UNIQUE (entity_type, entity_id, flagger_id)
 );
 
 -- Create indexes

--- a/src/services/moderation.service.ts
+++ b/src/services/moderation.service.ts
@@ -48,11 +48,30 @@ export const ModerationService = {
     flaggerId: string,
     reason: string,
   ): Promise<FlagRecord> {
+    // Check if user has already flagged this entity
+    const checkQuery = `
+       SELECT id FROM flags
+       WHERE entity_type = $1 AND entity_id = $2 AND flagger_id = $3
+     `;
+
+    const { rows } = await pool.query(checkQuery, [
+      entityType,
+      entityId,
+      flaggerId,
+    ]);
+
+    if (rows.length > 0) {
+      // User has already flagged this entity
+      const error: any = new Error("User has already flagged this content");
+      error.statusCode = 409;
+      throw error;
+    }
+
     const query = `
-      INSERT INTO flags (entity_type, entity_id, flagger_id, reason, status)
-      VALUES ($1, $2, $3, $4, 'pending')
-      RETURNING *
-    `;
+       INSERT INTO flags (entity_type, entity_id, flagger_id, reason, status)
+       VALUES ($1, $2, $3, $4, 'pending')
+       RETURNING *
+     `;
 
     const { rows } = await pool.query<FlagRecord>(query, [
       entityType,
@@ -80,10 +99,10 @@ export const ModerationService = {
    */
   async checkAutoHide(entityType: string, entityId: string): Promise<void> {
     const countQuery = `
-      SELECT COUNT(*) as flag_count
-      FROM flags
-      WHERE entity_type = $1 AND entity_id = $2 AND status = 'pending'
-    `;
+       SELECT COUNT(DISTINCT flagger_id) as flag_count
+       FROM flags
+       WHERE entity_type = $1 AND entity_id = $2 AND status = 'pending'
+     `;
 
     const { rows } = await pool.query(countQuery, [entityType, entityId]);
     const flagCount = parseInt(rows[0].flag_count, 10);
@@ -105,9 +124,10 @@ export const ModerationService = {
    */
   async hideContent(entityType: string, entityId: string): Promise<void> {
     if (entityType === "review") {
-      await pool.query(`UPDATE reviews SET is_published = false WHERE id = $1`, [
-        entityId,
-      ]);
+      await pool.query(
+        `UPDATE reviews SET is_published = false WHERE id = $1`,
+        [entityId],
+      );
     } else if (
       ["mentor_bio", "profile_photo", "user_profile"].includes(entityType)
     ) {
@@ -147,20 +167,20 @@ export const ModerationService = {
     offset = 0,
   ): Promise<{ data: FlagWithDetails[]; total: number }> {
     const query = `
-      SELECT 
-        f.*,
-        u.email as flagger_email,
-        u.full_name as flagger_name,
-        (SELECT COUNT(*) FROM flags f2 
-         WHERE f2.entity_type = f.entity_type 
-         AND f2.entity_id = f.entity_id 
-         AND f2.status = 'pending') as flag_count
-      FROM flags f
-      JOIN users u ON f.flagger_id = u.id
-      WHERE f.status = 'pending'
-      ORDER BY f.created_at ASC
-      LIMIT $1 OFFSET $2
-    `;
+       SELECT 
+         f.*,
+         u.email as flagger_email,
+         u.full_name as flagger_name,
+         (SELECT COUNT(DISTINCT flagger_id) FROM flags f2 
+          WHERE f2.entity_type = f.entity_type 
+          AND f2.entity_id = f.entity_id 
+          AND f2.status = 'pending') as flag_count
+       FROM flags f
+       JOIN users u ON f.flagger_id = u.id
+       WHERE f.status = 'pending'
+       ORDER BY f.created_at ASC
+       LIMIT $1 OFFSET $2
+     `;
 
     const countQuery = `
       SELECT COUNT(*) FROM flags WHERE status = 'pending'


### PR DESCRIPTION
# CLOSES #285 

I've implemented all the required fixes for the flagging system:

1. Database Migration (/workspaces/MentorsMind-Backend/database/migrations/014_create_flags.sql)
-  Added UNIQUE constraint on (entity_type, entity_id, flagger_id) to prevent duplicate flags from the same user
2. Moderation Service (/workspaces/MentorsMind-Backend/src/services/moderation.service.ts) 
- Updated checkAutoHide() method to count DISTINCT flagger_id instead of total rows
3. Updated getQueue() method's subquery to count DISTINCT flagger_id
- Added pre-flag check in flagContent() method to return 409 Conflict if user already flagged the entity

### Verification:

All changes align with the requirements:

✅ UNIQUE constraint added to prevent duplicate flags
✅ Count queries now use COUNT(DISTINCT flagger_id)
✅ 409 Conflict returned when user attempts to flag same content twice

The fixes ensure that auto-hiding only triggers when 3+ distinct users flag content, preventing a single bad actor from triggering auto-hide through multiple flags.