### PR TITLE
fix(wallet): implement 'wallet_status_changed' event and state delta capture (#239)

### DIFF
--- a/src/models/wallet-event.model.ts
+++ b/src/models/wallet-event.model.ts
@@ -10,7 +10,8 @@ export interface WalletEvent {
     | "trustline_add"
     | "transaction_view"
     | "wallet_created"
-    | "earnings_view";
+    | "earnings_view"
+    | "wallet_status_changed";
   metadata: Record<string, any>;
   ip_address: string | null;
   user_agent: string | null;

--- a/src/services/wallets.service.ts
+++ b/src/services/wallets.service.ts
@@ -346,12 +346,16 @@ export const WalletsService = {
    */
   async updateWalletStatus(userId: string, status: Wallet['status']): Promise<Wallet | null> {
     try {
+      // Fetch current wallet to capture status before update
+      const currentWallet = await WalletModel.findByUserId(userId);
+      const previousStatus = currentWallet?.status;
+
       const wallet = await WalletModel.updateStatus(userId, status);
-      
+
       if (wallet) {
         await this.logWalletEvent(userId, {
-          eventType: 'wallet_created', // Reusing event type for status changes
-          metadata: { statusChange: status, previousStatus: wallet.status },
+          eventType: 'wallet_status_changed',
+          metadata: { statusChange: status, previousStatus },
         });
 
         logger.info('wallet.statusUpdated', { userId, status });


### PR DESCRIPTION
## Description
This PR fixes a bug in the wallet event logging system where status changes were being misclassified as creation events. It also enhances data integrity by ensuring the "before" state of a wallet is captured and logged during status transitions.

## Key Changes

### **1. Type System Updates (`wallet-event.model.ts`)**
* Extended the `event_type` union type to include `wallet_status_changed`. This allows for more granular filtering and triggers in downstream services (e.g., notification or compliance engines).

### **2. Service Logic Refactor (`wallets.service.ts`)**
* **State Delta Capture**: Refactored `updateWalletStatus` to fetch the existing wallet record *prior* to executing the update. 
* **Event Correction**: Changed the emitted `eventType` from a generic `wallet_created` to the specific `wallet_status_changed`.
* **Metadata Enrichment**: The event metadata now explicitly logs the `previousStatus`, providing a clear audit trail of the wallet's lifecycle (e.g., `PENDING` -> `ACTIVE`).

## Technical Impact
* **Auditability**: Successfully captures the state transition, which is critical for financial auditing and debugging "stuck" wallet states.
* **Event Accuracy**: Prevents downstream consumers from incorrectly processing a status update as a new wallet creation.

## Verification
* Verified that the `previousStatus` is correctly extracted and present in the database audit logs.
* Confirmed that the `wallet_status_changed` event type triggers the correct event listeners.

**Related Issue**: Closes #239