### PR TITLE
Generate wallet mnemonic and secure backup

### DIFF
--- a/mentorminds-frontend/src/hooks/useWallet.ts
+++ b/mentorminds-frontend/src/hooks/useWallet.ts
@@ -17,11 +17,18 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { entropyToMnemonic, validateMnemonic } from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
 import {
+  clearMnemonicBackup,
   loadSecuritySettings,
+  loadMnemonicBackup,
   saveSecuritySettings,
+  saveMnemonicBackup,
   clearSecuritySettings,
   DEFAULT_SECURITY_SETTINGS,
+  type MnemonicWordCount,
+  type MnemonicBackupRecord,
   type WalletSecuritySettings,
 } from './walletSecurityStorage';
 
@@ -129,6 +136,29 @@ export interface WalletState {
 
   // Whether the wallet is currently locked due to inactivity timeout
   isLocked: boolean;
+  mnemonicSetup: WalletMnemonicSetupState;
+}
+
+export interface MnemonicBackupChecklist {
+  writtenDown: boolean;
+  storedOffline: boolean;
+  understandRecoveryRisk: boolean;
+}
+
+export interface MnemonicBackupChallenge {
+  index: number;
+  position: number;
+}
+
+export interface WalletMnemonicSetupState {
+  words: string[];
+  wordCount: MnemonicWordCount | null;
+  generatedAt: string | null;
+  isBackedUp: boolean;
+  hasEncryptedBackup: boolean;
+  encryptedBackupSavedAt: string | null;
+  checklist: MnemonicBackupChecklist;
+  challenges: MnemonicBackupChallenge[];
 }
 
 // ---------------------------------------------------------------------------
@@ -161,7 +191,58 @@ const INITIAL_STATE: WalletState = {
   isSecuritySettingsLoading: true, // true until first load completes
   error: null,
   isLocked: false,
+  mnemonicSetup: {
+    words: [],
+    wordCount: null,
+    generatedAt: null,
+    isBackedUp: false,
+    hasEncryptedBackup: false,
+    encryptedBackupSavedAt: null,
+    checklist: {
+      writtenDown: false,
+      storedOffline: false,
+      understandRecoveryRisk: false,
+    },
+    challenges: [],
+  },
 };
+
+const DEFAULT_MNEMONIC_CHECKLIST: MnemonicBackupChecklist = {
+  writtenDown: false,
+  storedOffline: false,
+  understandRecoveryRisk: false,
+};
+
+function secureRandomInt(maxExclusive: number): number {
+  if (!Number.isInteger(maxExclusive) || maxExclusive <= 0) {
+    throw new Error('maxExclusive must be a positive integer.');
+  }
+
+  const maxUint32 = 0xffffffff;
+  const threshold = maxUint32 - (maxUint32 % maxExclusive);
+  const randomBytes = new Uint32Array(1);
+
+  do {
+    crypto.getRandomValues(randomBytes);
+  } while (randomBytes[0] >= threshold);
+
+  return randomBytes[0] % maxExclusive;
+}
+
+function createBackupChallenges(wordCount: MnemonicWordCount): MnemonicBackupChallenge[] {
+  const first = secureRandomInt(wordCount);
+  let second = secureRandomInt(wordCount);
+  while (second === first) {
+    second = secureRandomInt(wordCount);
+  }
+
+  return [first, second]
+    .sort((a, b) => a - b)
+    .map((index) => ({
+      index,
+      position: index + 1,
+    }));
+}
 
 // ---------------------------------------------------------------------------
 // Internal fetch helper
@@ -582,6 +663,7 @@ export function useWallet(options: UseWalletOptions) {
 
   const resetWallet = useCallback(() => {
     clearSecuritySettings();
+    clearMnemonicBackup();
     if (lockTimerRef.current) {
       clearTimeout(lockTimerRef.current);
     }
@@ -592,6 +674,186 @@ export function useWallet(options: UseWalletOptions) {
     });
   }, []);
 
+  const generateMnemonic = useCallback(
+    (wordCount: MnemonicWordCount = 12): string[] => {
+      if (wordCount !== 12 && wordCount !== 24) {
+        throw new Error('Mnemonic word count must be either 12 or 24.');
+      }
+
+      const entropySize = wordCount === 24 ? 32 : 16;
+      const entropy = crypto.getRandomValues(new Uint8Array(entropySize));
+      const mnemonic = entropyToMnemonic(entropy, wordlist);
+      const words = mnemonic.trim().toLowerCase().split(/\s+/);
+
+      if (words.length !== wordCount || !validateMnemonic(mnemonic, wordlist)) {
+        throw new Error('Failed to generate a valid BIP39 mnemonic.');
+      }
+
+      setState((prev) => ({
+        ...prev,
+        mnemonicSetup: {
+          words,
+          wordCount,
+          generatedAt: new Date().toISOString(),
+          isBackedUp: false,
+          hasEncryptedBackup: false,
+          encryptedBackupSavedAt: null,
+          checklist: { ...DEFAULT_MNEMONIC_CHECKLIST },
+          challenges: createBackupChallenges(wordCount),
+        },
+      }));
+
+      return words;
+    },
+    [],
+  );
+
+  const updateMnemonicBackupChecklist = useCallback(
+    (updates: Partial<MnemonicBackupChecklist>): void => {
+      setState((prev) => ({
+        ...prev,
+        mnemonicSetup: (() => {
+          const checklist = {
+            ...prev.mnemonicSetup.checklist,
+            ...updates,
+          };
+          return {
+            ...prev.mnemonicSetup,
+            checklist,
+            isBackedUp:
+              prev.mnemonicSetup.isBackedUp &&
+              checklist.writtenDown &&
+              checklist.storedOffline &&
+              checklist.understandRecoveryRisk,
+          };
+        })(),
+      }));
+    },
+    [],
+  );
+
+  const clearEncryptedMnemonicBackup = useCallback(() => {
+    clearMnemonicBackup();
+    setState((prev) => ({
+      ...prev,
+      mnemonicSetup: {
+        ...prev.mnemonicSetup,
+        hasEncryptedBackup: false,
+        encryptedBackupSavedAt: null,
+      },
+    }));
+  }, []);
+
+  const verifyMnemonicBackup = useCallback(
+    (answers: Record<number, string>): boolean => {
+      const { words, challenges, checklist } = state.mnemonicSetup;
+      if (!words.length || !challenges.length) {
+        throw new Error('Generate a mnemonic before backup verification.');
+      }
+      if (
+        !checklist.writtenDown ||
+        !checklist.storedOffline ||
+        !checklist.understandRecoveryRisk
+      ) {
+        throw new Error(
+          'Confirm backup checklist (written down, stored offline, recovery risk) first.',
+        );
+      }
+
+      const isValid = challenges.every(({ index }) => {
+        const answer = (answers[index] ?? '').trim().toLowerCase();
+        return answer.length > 0 && answer === words[index];
+      });
+
+      if (!isValid) return false;
+
+      setState((prev) => ({
+        ...prev,
+        mnemonicSetup: {
+          ...prev.mnemonicSetup,
+          isBackedUp: true,
+        },
+      }));
+
+      return true;
+    },
+    [state.mnemonicSetup],
+  );
+
+  const saveEncryptedMnemonic = useCallback(
+    async (passphrase: string): Promise<void> => {
+      const { words, wordCount, isBackedUp } = state.mnemonicSetup;
+      if (!words.length || !wordCount) {
+        throw new Error('No mnemonic available to back up.');
+      }
+      if (!isBackedUp) {
+        throw new Error(
+          'Mnemonic must be manually verified before encrypted backup is allowed.',
+        );
+      }
+
+      const { savedAt } = await saveMnemonicBackup(
+        words.join(' '),
+        passphrase,
+        wordCount,
+      );
+
+      setState((prev) => ({
+        ...prev,
+        mnemonicSetup: {
+          ...prev.mnemonicSetup,
+          hasEncryptedBackup: true,
+          encryptedBackupSavedAt: savedAt,
+        },
+      }));
+    },
+    [state.mnemonicSetup],
+  );
+
+  const loadEncryptedMnemonic = useCallback(
+    async (passphrase: string): Promise<MnemonicBackupRecord | null> => {
+      const backup = await loadMnemonicBackup(passphrase);
+      if (!backup) return null;
+
+      setState((prev) => ({
+        ...prev,
+        mnemonicSetup: {
+          words: backup.words,
+          wordCount: backup.wordCount,
+          generatedAt: backup.savedAt,
+          isBackedUp: true,
+          hasEncryptedBackup: true,
+          encryptedBackupSavedAt: backup.savedAt,
+          checklist: {
+            writtenDown: true,
+            storedOffline: true,
+            understandRecoveryRisk: true,
+          },
+          challenges: createBackupChallenges(backup.wordCount),
+        },
+      }));
+
+      return backup;
+    },
+    [],
+  );
+
+  const clearMnemonicSetup = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      mnemonicSetup: {
+        words: [],
+        wordCount: null,
+        generatedAt: null,
+        isBackedUp: false,
+        hasEncryptedBackup: false,
+        encryptedBackupSavedAt: null,
+        checklist: { ...DEFAULT_MNEMONIC_CHECKLIST },
+        challenges: [],
+      },
+    }));
+  }, []);
+
   // ---------------------------------------------------------------------------
   // Exposed API
   // ---------------------------------------------------------------------------
@@ -599,6 +861,8 @@ export function useWallet(options: UseWalletOptions) {
   return {
     // State
     ...state,
+    isMnemonicBackupRequired:
+      state.mnemonicSetup.words.length > 0 && !state.mnemonicSetup.isBackedUp,
 
     // Security settings actions
     updateSecuritySettings,
@@ -614,6 +878,15 @@ export function useWallet(options: UseWalletOptions) {
     fetchEarnings,
     fetchPayoutRequests,
     createPayoutRequest,
+
+    // Mnemonic generation and backup actions
+    generateMnemonic,
+    updateMnemonicBackupChecklist,
+    verifyMnemonicBackup,
+    saveEncryptedMnemonic,
+    loadEncryptedMnemonic,
+    clearEncryptedMnemonicBackup,
+    clearMnemonicSetup,
 
     // Cleanup
     resetWallet,

--- a/mentorminds-frontend/src/hooks/walletSecurityStorage.ts
+++ b/mentorminds-frontend/src/hooks/walletSecurityStorage.ts
@@ -24,8 +24,10 @@
  */
 
 const STORAGE_KEY = 'mm_wallet_security_cfg';
+const MNEMONIC_BACKUP_KEY = 'mm_wallet_mnemonic_backup';
 const DEVICE_SECRET_KEY = 'mm_wallet_device_secret';
 const PBKDF2_ITERATIONS = 100_000;
+const MNEMONIC_PBKDF2_ITERATIONS = 250_000;
 // Static salt — uniqueness comes from the per-device secret, not the salt
 const PBKDF2_SALT = 'mentorminds-wallet-security-v1';
 
@@ -76,6 +78,33 @@ async function deriveKey(deviceSecret: string): Promise<CryptoKey> {
   );
 }
 
+async function deriveMnemonicBackupKey(
+  passphrase: string,
+  salt: Uint8Array,
+): Promise<CryptoKey> {
+  const enc = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(passphrase),
+    { name: 'PBKDF2' },
+    false,
+    ['deriveKey'],
+  );
+
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt,
+      iterations: MNEMONIC_PBKDF2_ITERATIONS,
+      hash: 'SHA-256',
+    },
+    keyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
 function toBase64(buffer: ArrayBuffer): string {
   return btoa(String.fromCharCode(...new Uint8Array(buffer)));
 }
@@ -96,6 +125,24 @@ export interface WalletSecuritySettings {
   /** Require explicit confirmation before submitting send transactions. */
   requireSendConfirmation: boolean;
   /** ISO timestamp of when settings were last persisted. */
+  savedAt: string;
+}
+
+export type MnemonicWordCount = 12 | 24;
+
+interface EncryptedMnemonicBackupBlob {
+  version: 1;
+  wordCount: MnemonicWordCount;
+  savedAt: string;
+  salt: string;
+  iv: string;
+  ciphertext: string;
+}
+
+export interface MnemonicBackupRecord {
+  mnemonic: string;
+  words: string[];
+  wordCount: MnemonicWordCount;
   savedAt: string;
 }
 
@@ -194,6 +241,133 @@ export async function loadSecuritySettings(): Promise<WalletSecuritySettings> {
  */
 export function clearSecuritySettings(): void {
   localStorage.removeItem(STORAGE_KEY);
+  localStorage.removeItem(MNEMONIC_BACKUP_KEY);
   // Note: intentionally keep DEVICE_SECRET_KEY so re-login on the same device
   // can still decrypt any other encrypted blobs that share the same key.
+}
+
+export async function saveMnemonicBackup(
+  mnemonic: string,
+  passphrase: string,
+  wordCount: MnemonicWordCount,
+): Promise<{ savedAt: string }> {
+  const trimmedPassphrase = passphrase.trim();
+  if (trimmedPassphrase.length < 10) {
+    throw new Error('Backup passphrase must be at least 10 characters.');
+  }
+
+  const normalizedMnemonic = mnemonic.trim().toLowerCase().replace(/\s+/g, ' ');
+  const words = normalizedMnemonic.split(' ');
+  if (words.length !== wordCount) {
+    throw new Error(`Expected ${wordCount} words in mnemonic backup payload.`);
+  }
+
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const key = await deriveMnemonicBackupKey(trimmedPassphrase, salt);
+
+  const payload = JSON.stringify({
+    mnemonic: normalizedMnemonic,
+    wordCount,
+    savedAt: new Date().toISOString(),
+  });
+
+  const cipherBuffer = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    new TextEncoder().encode(payload),
+  );
+
+  const record: EncryptedMnemonicBackupBlob = {
+    version: 1,
+    wordCount,
+    savedAt: new Date().toISOString(),
+    salt: toBase64(salt.buffer),
+    iv: toBase64(iv.buffer),
+    ciphertext: toBase64(cipherBuffer),
+  };
+
+  localStorage.setItem(MNEMONIC_BACKUP_KEY, JSON.stringify(record));
+  return { savedAt: record.savedAt };
+}
+
+export async function loadMnemonicBackup(
+  passphrase: string,
+): Promise<MnemonicBackupRecord | null> {
+  const raw = localStorage.getItem(MNEMONIC_BACKUP_KEY);
+  if (!raw) return null;
+
+  const trimmedPassphrase = passphrase.trim();
+  if (!trimmedPassphrase) {
+    throw new Error('Backup passphrase is required.');
+  }
+
+  let parsed: EncryptedMnemonicBackupBlob;
+  try {
+    parsed = JSON.parse(raw) as EncryptedMnemonicBackupBlob;
+  } catch {
+    localStorage.removeItem(MNEMONIC_BACKUP_KEY);
+    return null;
+  }
+
+  if (
+    parsed.version !== 1 ||
+    (parsed.wordCount !== 12 && parsed.wordCount !== 24) ||
+    typeof parsed.salt !== 'string' ||
+    typeof parsed.iv !== 'string' ||
+    typeof parsed.ciphertext !== 'string'
+  ) {
+    localStorage.removeItem(MNEMONIC_BACKUP_KEY);
+    return null;
+  }
+
+  try {
+    const salt = fromBase64(parsed.salt);
+    const iv = fromBase64(parsed.iv);
+    const ciphertext = fromBase64(parsed.ciphertext);
+    const key = await deriveMnemonicBackupKey(trimmedPassphrase, salt);
+
+    const plainBuffer = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv },
+      key,
+      ciphertext,
+    );
+
+    const payload = JSON.parse(
+      new TextDecoder().decode(plainBuffer),
+    ) as Partial<MnemonicBackupRecord>;
+    if (
+      typeof payload.mnemonic !== 'string' ||
+      (payload.wordCount !== 12 && payload.wordCount !== 24) ||
+      typeof payload.savedAt !== 'string'
+    ) {
+      throw new Error('Invalid decrypted mnemonic backup payload.');
+    }
+
+    const normalizedMnemonic = payload.mnemonic
+      .trim()
+      .toLowerCase()
+      .replace(/\s+/g, ' ');
+    const words = normalizedMnemonic.split(' ');
+    if (words.length !== payload.wordCount) {
+      throw new Error('Mnemonic word count mismatch in backup payload.');
+    }
+
+    return {
+      mnemonic: normalizedMnemonic,
+      words,
+      wordCount: payload.wordCount,
+      savedAt: payload.savedAt,
+    };
+  } catch (error) {
+    throw new Error(
+      error instanceof Error
+        ? `Unable to decrypt mnemonic backup: ${error.message}`
+        : 'Unable to decrypt mnemonic backup.',
+    );
+  }
+}
+
+export function clearMnemonicBackup(): void {
+  localStorage.removeItem(MNEMONIC_BACKUP_KEY);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@opentelemetry/resources": "^1.30.1",
         "@opentelemetry/sdk-node": "^0.57.2",
         "@opentelemetry/semantic-conventions": "^1.30.0",
+        "@scure/bip39": "^1.6.0",
         "@sentry/node": "^10.46.0",
         "@sentry/profiling-node": "^10.46.0",
         "@socket.io/redis-adapter": "^8.3.0",
@@ -5381,6 +5382,28 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
       "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@opentelemetry/resources": "^1.30.1",
     "@opentelemetry/sdk-node": "^0.57.2",
     "@opentelemetry/semantic-conventions": "^1.30.0",
+    "@scure/bip39": "^1.6.0",
     "@sentry/node": "^10.46.0",
     "@sentry/profiling-node": "^10.46.0",
     "@socket.io/redis-adapter": "^8.3.0",


### PR DESCRIPTION
Closes #212

## Summary
- add standards-compliant BIP39 mnemonic generation (12/24 words) in useWallet
- use secure Web Crypto RNG for entropy and backup-challenge selection
- add enforced backup confirmation flow (checklist + challenge words) before marking mnemonic as backed up
- add encrypted local mnemonic backup with AES-GCM + PBKDF2 passphrase protection
- clear mnemonic backup artifacts on wallet reset and expose backup state/actions for UI gating

## Validation
- manual code review
- note: repository eslint/tsconfig currently excludes mentorminds-frontend, so hook files cannot be linted by current root config