### PR TITLE
Fix GraphQL initialization, consent status code, and escrow release r…

### DIFF
--- a/src/controllers/consent.controller.ts
+++ b/src/controllers/consent.controller.ts
@@ -76,11 +76,10 @@ export const ConsentController = {
 
     try {
       const { rows } = await pool.query<ConsentRecord>(query, values);
-      ResponseUtil.success(
+      ResponseUtil.created(
         res,
         rows[0],
         "Consent choices recorded successfully",
-        201,
       );
     } catch (error) {
       ResponseUtil.error(

--- a/src/queues/escrow-release.queue.ts
+++ b/src/queues/escrow-release.queue.ts
@@ -37,10 +37,27 @@ export async function scheduleEscrowRelease(
 
 /**
  * Cancel a pending escrow auto-release (e.g. dispute raised).
+ * If the job is already active, marks the escrow as disputed in the DB
+ * so the worker will skip the release.
  */
 export async function cancelEscrowRelease(escrowId: string): Promise<void> {
   const job = await escrowReleaseQueue.getJob(`escrow-release:${escrowId}`);
-  if (job) {
+  if (!job) {
+    return;
+  }
+
+  const state = await job.getState();
+  
+  // If job is waiting, delayed, or paused, we can safely remove it
+  if (['waiting', 'delayed', 'paused'].includes(state)) {
     await job.remove();
+  } else if (state === 'active') {
+    // Job is already being processed - mark escrow as disputed in DB
+    // The worker will check this status before releasing
+    const pool = (await import('../config/database')).default;
+    await pool.query(
+      'UPDATE escrows SET status = $1, updated_at = NOW() WHERE id = $2',
+      ['disputed', escrowId]
+    );
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,7 @@ import app from "./app";
 import { initializeModels } from "./models";
 import { createSocketServer } from "./config/socket";
 import { initializeSocketService } from "./services/socket.service";
+import { initializeGraphQL } from "./graphql/server";
 import {
   stellarMonitorJob,
 } from "./jobs/stellarMonitor.job";
@@ -83,6 +84,11 @@ startScheduler().catch((err) => {
 const { port: PORT, apiVersion: API_VERSION } = config.server;
 const NODE_ENV = config.env;
 
+// Initialize GraphQL server
+initializeGraphQL(app).catch((err) => {
+  logger.error("Failed to initialize GraphQL server", { error: err });
+});
+
 // Start server
 const server = app.listen(PORT, () => {
   logger.info("Server started", {
@@ -91,6 +97,7 @@ const server = app.listen(PORT, () => {
     apiUrl: `http://localhost:${PORT}/api/${API_VERSION}`,
     healthCheck: `http://localhost:${PORT}/health`,
     apiDocs: `http://localhost:${PORT}/api/${API_VERSION}/docs`,
+    graphql: `http://localhost:${PORT}/api/graphql`,
     webSocket: `ws://localhost:${PORT}/ws`,
   });
 });

--- a/src/workers/escrow-release.worker.ts
+++ b/src/workers/escrow-release.worker.ts
@@ -19,13 +19,15 @@ async function processEscrowRelease(
 
   logger.info('Processing escrow auto-release', { jobId: job.id, escrowId });
 
+  // Check current escrow status from DB (not cache) to handle race conditions
   const escrow = await EscrowApiService.getEscrowById(escrowId);
 
   if (!escrow) {
     throw new Error(`Escrow ${escrowId} not found`);
   }
 
-  // Skip if already released, disputed, or refunded
+  // Skip if already released, disputed, refunded, or cancelled
+  // This check prevents release if a dispute was raised while the job was active
   if (
     ['released', 'disputed', 'refunded', 'cancelled'].includes(escrow.status)
   ) {


### PR DESCRIPTION
…ace condition

Closes #316: Initialize GraphQL server in server.ts - resolvers were implemented but server wasn't mounted
Closes #318: Use ResponseUtil.created() for proper 201 status on consent creation
Closes #319: Handle escrow release race condition by checking job state and marking disputed in DB if active

closes #316 
closes #318 
closes #319 