### PR TITLE
fix: address token refresh fingerprint + learner timeline cache

### DIFF
--- a/src/__tests__/middleware/token-refresh.middleware.unit.test.ts
+++ b/src/__tests__/middleware/token-refresh.middleware.unit.test.ts
@@ -1,0 +1,93 @@
+import crypto from "crypto";
+import { handleTokenRefresh } from "../../middleware/token-refresh.middleware";
+import { TokenService } from "../../services/token.service";
+import { ResponseUtil } from "../../utils/response.utils";
+
+jest.mock("../../services/token.service", () => ({
+  TokenService: {
+    rotateRefreshToken: jest.fn(),
+  },
+}));
+
+jest.mock("../../utils/response.utils", () => ({
+  ResponseUtil: {
+    success: jest.fn(),
+    unauthorized: jest.fn(),
+  },
+}));
+
+jest.mock("../../utils/logger", () => ({
+  logger: {
+    warn: jest.fn(),
+  },
+}));
+
+describe("handleTokenRefresh middleware", () => {
+  const mockRotateRefreshToken = TokenService.rotateRefreshToken as jest.Mock;
+  const mockSuccess = ResponseUtil.success as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("computes request fingerprint and passes it to token rotation", async () => {
+    mockRotateRefreshToken.mockResolvedValue({
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+    });
+
+    const req: any = {
+      body: { refreshToken: "valid-refresh-token" },
+      headers: {
+        "user-agent": "Mozilla/5.0 test agent",
+        "accept-language": "en-US,en;q=0.9",
+      },
+      ip: "203.0.113.10",
+    };
+    const res: any = {};
+    const next = jest.fn();
+
+    await handleTokenRefresh(req, res, next);
+
+    const expectedFingerprint = crypto
+      .createHash("sha256")
+      .update("Mozilla/5.0 test agent|en-US,en;q=0.9|203.0.113.10")
+      .digest("hex");
+
+    expect(mockRotateRefreshToken).toHaveBeenCalledWith(
+      "valid-refresh-token",
+      expectedFingerprint,
+    );
+    expect(mockSuccess).toHaveBeenCalledWith(
+      res,
+      { accessToken: "new-access-token", refreshToken: "new-refresh-token" },
+      "Token refreshed successfully",
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("continues refresh flow when no fingerprint can be derived", async () => {
+    mockRotateRefreshToken.mockResolvedValue({
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+    });
+
+    const req: any = {
+      body: { refreshToken: "valid-refresh-token" },
+      headers: {},
+      ip: "",
+      socket: { remoteAddress: "" },
+    };
+    const res: any = {};
+    const next = jest.fn();
+
+    await handleTokenRefresh(req, res, next);
+
+    expect(mockRotateRefreshToken).toHaveBeenCalledWith(
+      "valid-refresh-token",
+      undefined,
+    );
+    expect(mockSuccess).toHaveBeenCalledTimes(1);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/services/learners.service.unit.test.ts
+++ b/src/__tests__/services/learners.service.unit.test.ts
@@ -1,0 +1,59 @@
+jest.mock("../../config/db", () => ({
+  __esModule: true,
+  default: {
+    query: jest.fn(),
+  },
+}));
+
+jest.mock("../../services/cache.service", () => ({
+  CacheService: {
+    wrap: jest.fn(),
+    del: jest.fn(),
+  },
+}));
+
+import db from "../../config/db";
+import { CacheService } from "../../services/cache.service";
+import { LearnerService } from "../../services/learners.service";
+
+describe("LearnerService", () => {
+  const mockDbQuery = db.query as jest.Mock;
+  const mockWrap = CacheService.wrap as jest.Mock;
+  const mockDel = CacheService.del as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockWrap.mockImplementation(
+      async (_key: string, _ttl: number, fn: () => Promise<unknown>) => fn(),
+    );
+  });
+
+  it("caches session timeline responses for five minutes", async () => {
+    const learnerId = "learner-123";
+    const rows = [{ month: "2026-04", count: "2" }];
+
+    mockDbQuery.mockResolvedValueOnce({ rows });
+
+    const result = await LearnerService.getSessionTimeline(learnerId);
+
+    expect(mockWrap).toHaveBeenCalledTimes(1);
+    expect(mockWrap).toHaveBeenCalledWith(
+      `learner:timeline:${learnerId}`,
+      300,
+      expect.any(Function),
+    );
+    expect(mockDbQuery).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(rows);
+  });
+
+  it("invalidates progress and timeline cache keys together", async () => {
+    const learnerId = "learner-456";
+
+    await LearnerService.invalidateCache(learnerId);
+
+    expect(mockDel).toHaveBeenCalledTimes(3);
+    expect(mockDel).toHaveBeenCalledWith(`learner:progress:${learnerId}`);
+    expect(mockDel).toHaveBeenCalledWith(`learner:timeline:${learnerId}`);
+    expect(mockDel).toHaveBeenCalledWith(`learner:goal-timeline:${learnerId}`);
+  });
+});

--- a/src/middleware/token-refresh.middleware.ts
+++ b/src/middleware/token-refresh.middleware.ts
@@ -21,7 +21,7 @@ export const handleTokenRefresh = async (
       return;
     }
 
-    const fingerprint = JwtUtils.getDeviceFingerprint(req);
+    const fingerprint = JwtUtils.getDeviceFingerprint(req) ?? undefined;
 
     try {
       const tokens = await TokenService.rotateRefreshToken(

--- a/src/services/cache.service.ts
+++ b/src/services/cache.service.ts
@@ -17,6 +17,12 @@ interface MemEntry {
   value: string;
   expiresAt: number;
 }
+/**
+ * Fallback cache store used when Redis is unavailable.
+ * Limitation: if the process writes to memory during a Redis outage and Redis
+ * later reconnects, old in-memory entries can remain until TTL expiry because
+ * delete/invalidate operations route to the currently active backend.
+ */
 const memStore = new Map<string, MemEntry>();
 
 // Evict expired entries every minute

--- a/src/services/learners.service.ts
+++ b/src/services/learners.service.ts
@@ -19,9 +19,12 @@ export interface TimelineEntry {
 
 export class LearnerService {
   private static CACHE_TTL = 300; // 5 minutes
+  private static PROGRESS_CACHE_PREFIX = 'learner:progress';
+  private static TIMELINE_CACHE_PREFIX = 'learner:timeline';
+  private static GOAL_TIMELINE_CACHE_PREFIX = 'learner:goal-timeline';
 
   static async getProgressSummary(learnerId: string): Promise<ProgressSummary> {
-    const cacheKey = `learner:progress:${learnerId}`;
+    const cacheKey = `${this.PROGRESS_CACHE_PREFIX}:${learnerId}`;
     
     return await CacheService.wrap(cacheKey, this.CACHE_TTL, async () => {
       // 1. Basic stats from bookings
@@ -71,37 +74,49 @@ export class LearnerService {
   }
 
   static async getGoalCompletionTimeline(learnerId: string): Promise<TimelineEntry[]> {
-    const result = await db.query(
-      `SELECT 
-        TO_CHAR(completed_at, 'YYYY-MM') as month,
-        COUNT(*) as count
-       FROM goals
-       WHERE learner_id = $1 AND status = 'completed'
-         AND completed_at >= NOW() - INTERVAL '12 months'
-       GROUP BY month
-       ORDER BY month ASC`,
-      [learnerId]
-    );
-    return result.rows;
+    const cacheKey = `${this.GOAL_TIMELINE_CACHE_PREFIX}:${learnerId}`;
+
+    return await CacheService.wrap(cacheKey, this.CACHE_TTL, async () => {
+      const result = await db.query(
+        `SELECT 
+          TO_CHAR(completed_at, 'YYYY-MM') as month,
+          COUNT(*) as count
+         FROM goals
+         WHERE learner_id = $1 AND status = 'completed'
+           AND completed_at >= NOW() - INTERVAL '12 months'
+         GROUP BY month
+         ORDER BY month ASC`,
+        [learnerId]
+      );
+      return result.rows;
+    });
   }
 
   static async getSessionTimeline(learnerId: string): Promise<TimelineEntry[]> {
-    const result = await db.query(
-      `SELECT 
-        TO_CHAR(scheduled_start, 'YYYY-MM') as month,
-        COUNT(*) as count
-       FROM bookings
-       WHERE mentee_id = $1 AND status = 'completed'
-         AND scheduled_start >= NOW() - INTERVAL '12 months'
-       GROUP BY month
-       ORDER BY month ASC`,
-      [learnerId]
-    );
-    return result.rows;
+    const cacheKey = `${this.TIMELINE_CACHE_PREFIX}:${learnerId}`;
+
+    return await CacheService.wrap(cacheKey, this.CACHE_TTL, async () => {
+      const result = await db.query(
+        `SELECT 
+          TO_CHAR(scheduled_start, 'YYYY-MM') as month,
+          COUNT(*) as count
+         FROM bookings
+         WHERE mentee_id = $1 AND status = 'completed'
+           AND scheduled_start >= NOW() - INTERVAL '12 months'
+         GROUP BY month
+         ORDER BY month ASC`,
+        [learnerId]
+      );
+      return result.rows;
+    });
   }
 
   static async invalidateCache(learnerId: string): Promise<void> {
-    await CacheService.del(`learner:progress:${learnerId}`);
+    await Promise.all([
+      CacheService.del(`${this.PROGRESS_CACHE_PREFIX}:${learnerId}`),
+      CacheService.del(`${this.TIMELINE_CACHE_PREFIX}:${learnerId}`),
+      CacheService.del(`${this.GOAL_TIMELINE_CACHE_PREFIX}:${learnerId}`),
+    ]);
   }
 
   private static calculateStreaks(dates: Date[]): { current: number; longest: number } {

--- a/src/utils/jwt.utils.ts
+++ b/src/utils/jwt.utils.ts
@@ -17,6 +17,10 @@ export interface DecodedToken extends TokenPayload {
 }
 
 export const JwtUtils = {
+  isSha256Hash(value: string): boolean {
+    return /^[a-f0-9]{64}$/i.test(value);
+  },
+
   /**
    * Generate access token with short TTL (15 min)
    */
@@ -78,16 +82,39 @@ export const JwtUtils = {
   /**
    * Generate device fingerprint from request
    */
-  getDeviceFingerprint(req: Request): string {
-    const userAgent = req.headers['user-agent'] || 'unknown';
-    const ip = req.ip || req.headers['x-forwarded-for'] || 'unknown';
-    return `${userAgent}-${ip}`;
+  getDeviceFingerprint(req: Request): string | null {
+    const userAgentHeader = req.headers['user-agent'];
+    const acceptLanguageHeader = req.headers['accept-language'];
+    const forwardedFor = req.headers['x-forwarded-for'];
+
+    const userAgent =
+      typeof userAgentHeader === 'string' ? userAgentHeader.trim() : '';
+    const acceptLanguage =
+      typeof acceptLanguageHeader === 'string'
+        ? acceptLanguageHeader.trim()
+        : '';
+    const forwardedIp =
+      typeof forwardedFor === 'string'
+        ? forwardedFor.split(',')[0]?.trim() || ''
+        : Array.isArray(forwardedFor)
+          ? forwardedFor[0] || ''
+          : '';
+    const ip = req.ip || forwardedIp || req.socket?.remoteAddress || '';
+
+    if (!userAgent && !acceptLanguage && !ip) {
+      return null;
+    }
+
+    return this.hashFingerprint(`${userAgent}|${acceptLanguage}|${ip}`);
   },
 
   /**
    * Hash fingerprint for privacy in token
    */
   hashFingerprint(fingerprint: string): string {
+    if (this.isSha256Hash(fingerprint)) {
+      return fingerprint;
+    }
     return crypto.createHash('sha256').update(fingerprint).digest('hex');
   },
 


### PR DESCRIPTION
Closes #351
Closes #353
Closes #354
Closes #355

## Changes
- improved device fingerprint generation in JwtUtils.getDeviceFingerprint using User-Agent, Accept-Language, and IP with SHA-256 hashing
- made refresh fingerprint optional in token refresh middleware flow
- added timeline caching for learner session + goal timelines (5-minute TTL)
- updated learner cache invalidation to clear progress and timeline keys together
- documented Redis fallback limitation in cache service
- added unit tests for token-refresh middleware fingerprint flow and learner timeline cache invalidation

## Testing
- skipped by request (pipeline currently failing)
