### PR TITLE
fix: resolve issues #313, #314, #315

### DIFF
--- a/src/config/queue.ts
+++ b/src/config/queue.ts
@@ -40,6 +40,7 @@ export const QUEUE_NAMES = {
   EXPORT: "export-queue",
   SESSION_REMINDER: "session-reminder-queue",
   AUDIT_LOG: "audit-log-queue",
+  NOTIFICATION_CLEANUP: "notification-cleanup-queue",
 } as const;
 
 export type QueueName = (typeof QUEUE_NAMES)[keyof typeof QUEUE_NAMES];

--- a/src/services/push.service.ts
+++ b/src/services/push.service.ts
@@ -1,9 +1,9 @@
-import * as admin from 'firebase-admin';
-import { PushTokensModel } from '../models/push-tokens.model';
-import { UsersService } from './users.service';
-import { NotificationChannel } from '../models/notifications.model';
-import { logger } from '../utils/logger';
-import { env } from '../config/env';
+import * as admin from "firebase-admin";
+import { PushTokensModel } from "../models/push-tokens.model";
+import { UsersService } from "./users.service";
+import { NotificationChannel } from "../models/notifications.model";
+import { logger } from "../utils/logger";
+import { env } from "../config/env";
 
 export interface PushNotificationPayload {
   title: string;
@@ -37,8 +37,14 @@ export const PushService = {
 
     try {
       // Check if Firebase credentials are configured
-      if (!env.FIREBASE_PROJECT_ID || !env.FIREBASE_PRIVATE_KEY || !env.FIREBASE_CLIENT_EMAIL) {
-        logger.warn('Firebase credentials not configured. Push notifications will be disabled.');
+      if (
+        !env.FIREBASE_PROJECT_ID ||
+        !env.FIREBASE_PRIVATE_KEY ||
+        !env.FIREBASE_CLIENT_EMAIL
+      ) {
+        logger.warn(
+          "Firebase credentials not configured. Push notifications will be disabled.",
+        );
         return;
       }
 
@@ -46,15 +52,15 @@ export const PushService = {
       admin.initializeApp({
         credential: admin.credential.cert({
           projectId: env.FIREBASE_PROJECT_ID,
-          privateKey: env.FIREBASE_PRIVATE_KEY.replace(/\\n/g, '\n'),
+          privateKey: env.FIREBASE_PRIVATE_KEY.replace(/\\n/g, "\n"),
           clientEmail: env.FIREBASE_CLIENT_EMAIL,
         }),
       });
 
       this.initialized = true;
-      logger.info('Firebase Admin SDK initialized successfully');
+      logger.info("Firebase Admin SDK initialized successfully");
     } catch (error) {
-      logger.error('Failed to initialize Firebase Admin SDK:', error);
+      logger.error("Failed to initialize Firebase Admin SDK:", error);
     }
   },
 
@@ -65,7 +71,7 @@ export const PushService = {
     userId: string,
     title: string,
     body: string,
-    data?: Record<string, string>
+    data?: Record<string, string>,
   ): Promise<PushSendResult> {
     const result: PushSendResult = {
       success: false,
@@ -78,18 +84,24 @@ export const PushService = {
     try {
       // Check if Firebase is initialized
       if (!this.initialized) {
-        result.errors.push('Firebase not initialized');
+        result.errors.push("Firebase not initialized");
         return result;
       }
 
       // Check user notification preferences
       const user = await UsersService.findById(userId);
       const preferences = user?.notification_preferences;
-      
+
       if (preferences) {
         const type = data?.type;
-        if (type && preferences[type] && preferences[type][NotificationChannel.PUSH] === false) {
-          result.errors.push(`User has disabled push notifications for type: ${type}`);
+        if (
+          type &&
+          preferences[type] &&
+          preferences[type][NotificationChannel.PUSH] === false
+        ) {
+          result.errors.push(
+            `User has disabled push notifications for type: ${type}`,
+          );
           return result;
         }
       }
@@ -98,7 +110,7 @@ export const PushService = {
       const tokens = await PushTokensModel.getActiveTokensByUserId(userId);
 
       if (tokens.length === 0) {
-        result.errors.push('No active push tokens found for user');
+        result.errors.push("No active push tokens found for user");
         return result;
       }
 
@@ -110,7 +122,10 @@ export const PushService = {
       };
 
       // Send to all user devices
-      const sendResult = await this.sendToTokens(tokens.map(t => t.token), payload);
+      const sendResult = await this.sendToTokens(
+        tokens.map((t) => t.token),
+        payload,
+      );
 
       // Handle invalid tokens
       if (sendResult.invalidTokens.length > 0) {
@@ -119,8 +134,8 @@ export const PushService = {
 
       // Update last_used_at for successful tokens
       const successfulTokens = tokens
-        .map(t => t.token)
-        .filter(token => !sendResult.invalidTokens.includes(token));
+        .map((t) => t.token)
+        .filter((token) => !sendResult.invalidTokens.includes(token));
 
       for (const token of successfulTokens) {
         await PushTokensModel.updateLastUsed(token);
@@ -128,7 +143,9 @@ export const PushService = {
 
       return sendResult;
     } catch (error) {
-      result.errors.push(`Failed to send push notification: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      result.errors.push(
+        `Failed to send push notification: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
       return result;
     }
   },
@@ -138,7 +155,7 @@ export const PushService = {
    */
   async sendToTokens(
     tokens: string[],
-    payload: PushNotificationPayload
+    payload: PushNotificationPayload,
   ): Promise<PushSendResult> {
     const result: PushSendResult = {
       success: false,
@@ -149,19 +166,18 @@ export const PushService = {
     };
 
     if (!this.initialized) {
-      result.errors.push('Firebase not initialized');
+      result.errors.push("Firebase not initialized");
       return result;
     }
 
     if (tokens.length === 0) {
-      result.errors.push('No tokens provided');
+      result.errors.push("No tokens provided");
       return result;
     }
 
     try {
-      // Prepare FCM message
-      const message: admin.messaging.MulticastMessage = {
-        tokens,
+      const BATCH_SIZE = 500;
+      const baseMessage = {
         notification: {
           title: payload.title,
           body: payload.body,
@@ -169,39 +185,41 @@ export const PushService = {
         },
         data: payload.data || {},
         webpush: payload.clickAction
-          ? {
-              fcmOptions: {
-                link: payload.clickAction,
-              },
-            }
+          ? { fcmOptions: { link: payload.clickAction } }
           : undefined,
       };
 
-      // Send multicast message
-      const response = await admin.messaging().sendEachForMulticast(message);
+      for (let i = 0; i < tokens.length; i += BATCH_SIZE) {
+        const batch = tokens.slice(i, i + BATCH_SIZE);
+        const message: admin.messaging.MulticastMessage = {
+          ...baseMessage,
+          tokens: batch,
+        };
+        const response = await admin.messaging().sendEachForMulticast(message);
 
-      result.successCount = response.successCount;
-      result.failureCount = response.failureCount;
-      result.success = response.failureCount === 0;
+        result.successCount += response.successCount;
+        result.failureCount += response.failureCount;
 
-      // Process responses to identify invalid tokens
-      response.responses.forEach((resp, idx) => {
-        if (!resp.success) {
-          const error = resp.error;
-          
-          // Check for invalid/expired token errors
-          if (
-            error?.code === 'messaging/invalid-registration-token' ||
-            error?.code === 'messaging/registration-token-not-registered'
-          ) {
-            result.invalidTokens.push(tokens[idx]);
-          } else {
-            result.errors.push(`Token ${idx}: ${error?.message || 'Unknown error'}`);
+        response.responses.forEach((resp, idx) => {
+          if (!resp.success) {
+            const error = resp.error;
+            if (
+              error?.code === "messaging/invalid-registration-token" ||
+              error?.code === "messaging/registration-token-not-registered"
+            ) {
+              result.invalidTokens.push(batch[idx]);
+            } else {
+              result.errors.push(
+                `Token ${i + idx}: ${error?.message || "Unknown error"}`,
+              );
+            }
           }
-        }
-      });
+        });
+      }
 
-      logger.info('Push notification sent', {
+      result.success = result.failureCount === 0;
+
+      logger.info("Push notification sent", {
         successCount: result.successCount,
         failureCount: result.failureCount,
         invalidTokenCount: result.invalidTokens.length,
@@ -209,8 +227,10 @@ export const PushService = {
 
       return result;
     } catch (error) {
-      result.errors.push(`Failed to send push notification: ${error instanceof Error ? error.message : 'Unknown error'}`);
-      logger.error('Push notification error:', error);
+      result.errors.push(
+        `Failed to send push notification: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
+      logger.error("Push notification error:", error);
       return result;
     }
   },
@@ -240,12 +260,12 @@ export const PushService = {
       scheduledAt: Date;
       durationMinutes: number;
       bookingId: string;
-    }
+    },
   ): Promise<PushSendResult> {
-    const title = 'Session Starting Soon';
+    const title = "Session Starting Soon";
     const body = `Your session with ${sessionDetails.mentorName} starts in 15 minutes`;
     const data = {
-      type: 'session_reminder',
+      type: "session_reminder",
       bookingId: sessionDetails.bookingId,
       scheduledAt: sessionDetails.scheduledAt.toISOString(),
     };
@@ -261,12 +281,12 @@ export const PushService = {
     paymentDetails: {
       amount: string;
       transactionId: string;
-    }
+    },
   ): Promise<PushSendResult> {
-    const title = 'Payment Confirmed';
+    const title = "Payment Confirmed";
     const body = `Your payment of ${paymentDetails.amount} XLM has been confirmed`;
     const data = {
-      type: 'payment_confirmed',
+      type: "payment_confirmed",
       transactionId: paymentDetails.transactionId,
       amount: paymentDetails.amount,
     };
@@ -283,12 +303,12 @@ export const PushService = {
       senderName: string;
       messagePreview: string;
       conversationId: string;
-    }
+    },
   ): Promise<PushSendResult> {
     const title = `New message from ${messageDetails.senderName}`;
     const body = messageDetails.messagePreview;
     const data = {
-      type: 'new_message',
+      type: "new_message",
       conversationId: messageDetails.conversationId,
     };
 
@@ -301,9 +321,9 @@ export const PushService = {
   async sendTestNotification(userId: string): Promise<PushSendResult> {
     return this.sendToUser(
       userId,
-      'Test Notification',
-      'This is a test push notification from MentorMinds',
-      { type: 'test' }
+      "Test Notification",
+      "This is a test push notification from MentorMinds",
+      { type: "test" },
     );
   },
 };

--- a/src/services/zapier.service.ts
+++ b/src/services/zapier.service.ts
@@ -40,7 +40,9 @@ export const ZapierService = {
     return ACTIONS;
   },
 
-  async authenticateApiKey(rawApiKey: string | undefined): Promise<ZapierContext | null> {
+  async authenticateApiKey(
+    rawApiKey: string | undefined,
+  ): Promise<ZapierContext | null> {
     if (!rawApiKey) {
       return null;
     }
@@ -87,7 +89,13 @@ export const ZapierService = {
          (api_key_id, trigger_name, target_url, secret, metadata)
        VALUES ($1, $2, $3, $4, $5)
        RETURNING id`,
-      [context.apiKeyId, trigger, targetUrl, secret ?? null, JSON.stringify(metadata)],
+      [
+        context.apiKeyId,
+        trigger,
+        targetUrl,
+        secret ?? null,
+        JSON.stringify(metadata),
+      ],
     );
 
     return {
@@ -163,11 +171,24 @@ export const ZapierService = {
   async executeAction(
     action: ActionName,
     payload: Record<string, any>,
+    context: ZapierContext,
   ): Promise<Record<string, unknown>> {
     if (action === "send_message") {
+      const { rows: keyRows } = await pool.query<{ scopes: string[] }>(
+        `SELECT scopes FROM integration_api_keys WHERE id = $1`,
+        [context.apiKeyId],
+      );
+      if (!keyRows[0]?.scopes?.includes("messaging:write")) {
+        throw new Error("API key missing required scope: messaging:write");
+      }
+
+      if (!context.ownerUserId) {
+        throw new Error("API key has no associated owner user");
+      }
+
       const message = await MessagingService.sendMessage(
         payload.conversationId,
-        payload.senderId,
+        context.ownerUserId,
         String(payload.body ?? ""),
       );
       if (!message) {
@@ -181,7 +202,12 @@ export const ZapierService = {
         `INSERT INTO booking_notes (booking_id, author_id, content, is_private)
          VALUES ($1, $2, $3, COALESCE($4, FALSE))
          RETURNING id`,
-        [payload.bookingId, payload.authorId, payload.content, payload.isPrivate],
+        [
+          payload.bookingId,
+          payload.authorId,
+          payload.content,
+          payload.isPrivate,
+        ],
       );
       return { noteId: rows[0].id };
     }


### PR DESCRIPTION
## Summary

Fixes three security/correctness bugs in a single PR.
closes #313 
### #313 — ZapierService: impersonation via arbitrary senderId
- `executeAction` now accepts `context: ZapierContext` as a third parameter
- `send_message` uses `context.ownerUserId` instead of `payload.senderId`
- Throws if the API key lacks the `messaging:write` scope
- Participant validation is handled by `MessagingService.sendMessage` (returns `null` when sender is not in the conversation)
closes #314 
### #314 — QUEUE_NAMES missing NOTIFICATION_CLEANUP
- Added `NOTIFICATION_CLEANUP: 'notification-cleanup-queue'` to `src/config/queue.ts`
- `ESCROW_CHECK` and `STELLAR_TX` were already present; no changes needed there
- `queue.config.ts` was already a pure re-export; no duplicate to remove
closes #315 
### #315 — PushService: no FCM 500-token batching
- `sendToTokens` now iterates in chunks of 500 using `BATCH_SIZE = 500`
- Results (`successCount`, `failureCount`, `invalidTokens`, `errors`) are aggregated across all batches

## Testing
- TypeScript compiles without errors in all three changed files
- Existing test suite passes (pre-existing unrelated syntax error in `notification.service.unit.test.ts` excluded)