### PR TITLE
fix: cursor pagination in GraphQL schema and IP anonymization (#306, #307)

### DIFF
--- a/src/controllers/consent.controller.ts
+++ b/src/controllers/consent.controller.ts
@@ -2,6 +2,7 @@ import { Response } from "express";
 import pool from "../config/database";
 import { AuthenticatedRequest } from "../types/api.types";
 import { ResponseUtil } from "../utils/response.utils";
+import { anonymizeIp } from "../utils/sanitization.utils";
 
 export interface ConsentRecord {
   id: string;
@@ -47,10 +48,11 @@ export const ConsentController = {
       return;
     }
 
-    const ipAddress =
-      (req.headers["x-forwarded-for"] as string) ||
-      req.socket.remoteAddress ||
-      "";
+    const ipAddress = anonymizeIp(
+      (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() ||
+        req.socket.remoteAddress ||
+        "",
+    );
     const userAgent = req.headers["user-agent"] || "";
 
     const query = `

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/server';
+import { gql } from "@apollo/server";
 
 const typeDefs = gql`
   enum BookingStatus {
@@ -45,7 +45,7 @@ const typeDefs = gql`
   }
 
   input PaginationInput {
-    page: Int = 1
+    cursor: String
     limit: Int = 10
   }
 
@@ -55,20 +55,24 @@ const typeDefs = gql`
     mentor(id: ID!): Mentor
     mentors(
       filter: MentorFilterInput
-      page: Int = 1
+      cursor: String
       limit: Int = 10
       sortBy: MentorSortBy = CREATED_AT
       sortOrder: SortOrder = DESC
-    ): MentorListResult
+    ): MentorConnection
 
     booking(id: ID!): Booking
-    bookings(status: BookingStatus, page: Int = 1, limit: Int = 10): BookingListResult
+    bookings(
+      status: BookingStatus
+      cursor: String
+      limit: Int = 10
+    ): BookingListResult
 
     payment(id: ID!): Payment
     payments(
       status: PaymentStatus
       type: PaymentType
-      page: Int = 1
+      cursor: String
       limit: Int = 10
     ): PaymentListResult
   }
@@ -81,7 +85,11 @@ const typeDefs = gql`
     bio: String
     avatarUrl: String
     wallet: Wallet
-    bookings(status: BookingStatus, page: Int = 1, limit: Int = 10): BookingListResult
+    bookings(
+      status: BookingStatus
+      cursor: String
+      limit: Int = 10
+    ): BookingListResult
     payments: [Payment!]!
     reviews: [Review!]!
   }
@@ -104,7 +112,11 @@ const typeDefs = gql`
     totalReviews: Int
     kycVerified: Boolean
     wallet: Wallet
-    bookings(status: BookingStatus, page: Int = 1, limit: Int = 10): BookingListResult
+    bookings(
+      status: BookingStatus
+      cursor: String
+      limit: Int = 10
+    ): BookingListResult
     payments: [Payment!]!
     reviews: [Review!]!
   }
@@ -140,6 +152,8 @@ const typeDefs = gql`
   type BookingListResult {
     bookings: [Booking!]!
     total: Int!
+    nextCursor: String
+    hasMore: Boolean!
   }
 
   type Payment {
@@ -155,6 +169,31 @@ const typeDefs = gql`
   type PaymentListResult {
     payments: [Payment!]!
     total: Int!
+    nextCursor: String
+    hasMore: Boolean!
+  }
+
+  type MentorEdge {
+    node: Mentor!
+    cursor: String!
+  }
+
+  type PageInfo {
+    hasNextPage: Boolean!
+    endCursor: String
+  }
+
+  type MentorConnection {
+    edges: [MentorEdge!]!
+    pageInfo: PageInfo!
+    total: Int!
+  }
+
+  type MentorListResult {
+    mentors: [Mentor!]!
+    total: Int!
+    nextCursor: String
+    hasMore: Boolean!
   }
 
   type Review {
@@ -165,14 +204,6 @@ const typeDefs = gql`
     rating: Int!
     comment: String
     createdAt: String!
-  }
-
-  type MentorListResult {
-    mentors: [Mentor!]!
-    total: Int!
-    page: Int!
-    limit: Int!
-    totalPages: Int!
   }
 `;
 

--- a/src/services/auditLog.service.ts
+++ b/src/services/auditLog.service.ts
@@ -3,8 +3,9 @@
  * Provides tamper-evident logging for all sensitive actions
  */
 
-import pool from '../config/database';
-import { Request } from 'express';
+import pool from "../config/database";
+import { Request } from "express";
+import { anonymizeIp } from "../utils/sanitization.utils";
 
 export interface AuditLogEntry {
   id: string;
@@ -56,11 +57,12 @@ export interface PaginatedAuditLogs {
  * Extract client IP from request
  */
 export const extractIpAddress = (req: Request): string => {
-  const forwardedFor = req.headers['x-forwarded-for'];
-  if (typeof forwardedFor === 'string') {
-    return forwardedFor.split(',')[0].trim();
-  }
-  return req.ip || req.socket.remoteAddress || 'unknown';
+  const forwardedFor = req.headers["x-forwarded-for"];
+  const raw =
+    typeof forwardedFor === "string"
+      ? forwardedFor.split(",")[0].trim()
+      : req.ip || req.socket.remoteAddress || "unknown";
+  return anonymizeIp(raw);
 };
 
 export const AuditLogService = {
@@ -102,12 +104,15 @@ export const AuditLogService = {
     action: string,
     resourceType: string,
     resourceId?: string | null,
-    changes?: { oldValue?: Record<string, any>; newValue?: Record<string, any> },
-    metadata?: Record<string, any>
+    changes?: {
+      oldValue?: Record<string, any>;
+      newValue?: Record<string, any>;
+    },
+    metadata?: Record<string, any>,
   ): Promise<AuditLogEntry> {
     const userId = (req as any).user?.id || null;
     const ipAddress = extractIpAddress(req);
-    const userAgent = req.headers['user-agent'] || null;
+    const userAgent = req.headers["user-agent"] || null;
 
     return this.log({
       userId,
@@ -155,7 +160,8 @@ export const AuditLogService = {
       values.push(filters.endDate);
     }
 
-    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const whereClause =
+      conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
     // Get total count
     const countQuery = `SELECT COUNT(*) FROM audit_logs ${whereClause}`;
@@ -191,53 +197,55 @@ export const AuditLogService = {
    */
   async exportToCSV(filters: AuditLogFilters): Promise<string> {
     const result = await this.query({ ...filters, limit: 10000, page: 1 });
-    
+
     // CSV header
     const headers = [
-      'ID',
-      'User ID',
-      'Action',
-      'Resource Type',
-      'Resource ID',
-      'Old Value',
-      'New Value',
-      'IP Address',
-      'User Agent',
-      'Metadata',
-      'Created At',
-      'Record Hash'
+      "ID",
+      "User ID",
+      "Action",
+      "Resource Type",
+      "Resource ID",
+      "Old Value",
+      "New Value",
+      "IP Address",
+      "User Agent",
+      "Metadata",
+      "Created At",
+      "Record Hash",
     ];
 
-    const csvRows = [headers.join(',')];
+    const csvRows = [headers.join(",")];
 
     // CSV data rows
     for (const log of result.logs) {
       const row = [
         log.id,
-        log.user_id || '',
+        log.user_id || "",
         log.action,
         log.resource_type,
-        log.resource_id || '',
-        log.old_value ? JSON.stringify(log.old_value).replace(/"/g, '""') : '',
-        log.new_value ? JSON.stringify(log.new_value).replace(/"/g, '""') : '',
-        log.ip_address || '',
-        log.user_agent ? log.user_agent.replace(/"/g, '""') : '',
+        log.resource_id || "",
+        log.old_value ? JSON.stringify(log.old_value).replace(/"/g, '""') : "",
+        log.new_value ? JSON.stringify(log.new_value).replace(/"/g, '""') : "",
+        log.ip_address || "",
+        log.user_agent ? log.user_agent.replace(/"/g, '""') : "",
         JSON.stringify(log.metadata).replace(/"/g, '""'),
         log.created_at.toISOString(),
-        log.record_hash || ''
+        log.record_hash || "",
       ];
-      
+
       // Wrap fields in quotes and escape internal quotes
-      csvRows.push(row.map(field => `"${field}"`).join(','));
+      csvRows.push(row.map((field) => `"${field}"`).join(","));
     }
 
-    return csvRows.join('\n');
+    return csvRows.join("\n");
   },
 
   /**
    * Verify audit log chain integrity
    */
-  async verifyChainIntegrity(limit = 1000): Promise<{ valid: boolean; errors: string[] }> {
+  async verifyChainIntegrity(
+    limit = 1000,
+  ): Promise<{ valid: boolean; errors: string[] }> {
     const query = `
       SELECT id, user_id, action, resource_type, resource_id,
              old_value, new_value, created_at, previous_hash, record_hash
@@ -245,17 +253,19 @@ export const AuditLogService = {
       ORDER BY created_at ASC, id ASC
       LIMIT $1
     `;
-    
+
     const { rows } = await pool.query<AuditLogEntry>(query, [limit]);
     const errors: string[] = [];
 
     for (let i = 0; i < rows.length; i++) {
       const current = rows[i];
-      
+
       if (i > 0) {
         const previous = rows[i - 1];
         if (current.previous_hash !== previous.record_hash) {
-          errors.push(`Chain break at record ${current.id}: previous_hash mismatch`);
+          errors.push(
+            `Chain break at record ${current.id}: previous_hash mismatch`,
+          );
         }
       }
     }
@@ -270,9 +280,9 @@ export const AuditLogService = {
    * Get audit log statistics
    */
   async getStats(startDate?: string, endDate?: string): Promise<any> {
-    let whereClause = '';
+    let whereClause = "";
     const values: any[] = [];
-    
+
     if (startDate || endDate) {
       const conditions: string[] = [];
       if (startDate) {
@@ -283,7 +293,7 @@ export const AuditLogService = {
         conditions.push(`created_at <= $${values.length + 1}`);
         values.push(endDate);
       }
-      whereClause = `WHERE ${conditions.join(' AND ')}`;
+      whereClause = `WHERE ${conditions.join(" AND ")}`;
     }
 
     const query = `

--- a/src/utils/sanitization.utils.ts
+++ b/src/utils/sanitization.utils.ts
@@ -3,8 +3,8 @@
  * Provides XSS prevention, SQL injection detection, and general input sanitization.
  */
 
-import { logger } from './logger.utils';
-import { validationConfig } from '../config/validation.config';
+import { logger } from "./logger.utils";
+import { validationConfig } from "../config/validation.config";
 
 // ---------------------------------------------------------------------------
 // HTML / XSS sanitization
@@ -12,14 +12,14 @@ import { validationConfig } from '../config/validation.config';
 
 /** HTML entities that must be escaped to neutralize XSS payloads */
 const HTML_ENTITIES: Record<string, string> = {
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&#x27;',
-    '/': '&#x2F;',
-    '`': '&#x60;',
-    '=': '&#x3D;',
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#x27;",
+  "/": "&#x2F;",
+  "`": "&#x60;",
+  "=": "&#x3D;",
 };
 
 /**
@@ -28,7 +28,7 @@ const HTML_ENTITIES: Record<string, string> = {
  * depth measure; the primary guard is Content-Type: application/json.
  */
 export function escapeHtml(input: string): string {
-    return input.replace(/[&<>"'`=/]/g, (char) => HTML_ENTITIES[char] ?? char);
+  return input.replace(/[&<>"'`=/]/g, (char) => HTML_ENTITIES[char] ?? char);
 }
 
 /**
@@ -36,15 +36,15 @@ export function escapeHtml(input: string): string {
  * javascript: URIs, data:text/html URIs).
  */
 export function stripXss(input: string): string {
-    let sanitized = input;
-    for (const pattern of validationConfig.security.dangerousPatterns) {
-        // Reset lastIndex for global regexes
-        if (pattern instanceof RegExp && pattern.global) {
-            pattern.lastIndex = 0;
-        }
-        sanitized = sanitized.replace(pattern, '');
+  let sanitized = input;
+  for (const pattern of validationConfig.security.dangerousPatterns) {
+    // Reset lastIndex for global regexes
+    if (pattern instanceof RegExp && pattern.global) {
+      pattern.lastIndex = 0;
     }
-    return sanitized;
+    sanitized = sanitized.replace(pattern, "");
+  }
+  return sanitized;
 }
 
 /**
@@ -52,7 +52,7 @@ export function stripXss(input: string): string {
  * Use this on any freeform text field before persisting.
  */
 export function sanitizeString(input: string): string {
-    return stripXss(input).trim();
+  return stripXss(input).trim();
 }
 
 // ---------------------------------------------------------------------------
@@ -65,15 +65,15 @@ export function sanitizeString(input: string): string {
  * additional layer that can log or block obviously malicious input.
  */
 export function containsSqlInjection(input: string): boolean {
-    for (const pattern of validationConfig.security.sqlInjectionPatterns) {
-        if (pattern instanceof RegExp && pattern.global) {
-            pattern.lastIndex = 0;
-        }
-        if (pattern.test(input)) {
-            return true;
-        }
+  for (const pattern of validationConfig.security.sqlInjectionPatterns) {
+    if (pattern instanceof RegExp && pattern.global) {
+      pattern.lastIndex = 0;
     }
-    return false;
+    if (pattern.test(input)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**
@@ -81,19 +81,19 @@ export function containsSqlInjection(input: string): boolean {
  * Logs a warning and returns the matched indicator if found.
  */
 export function detectAndLogSqlInjection(
-    input: string,
-    fieldName: string,
-    requestId?: string,
+  input: string,
+  fieldName: string,
+  requestId?: string,
 ): boolean {
-    if (containsSqlInjection(input)) {
-        logger.warn('Potential SQL injection attempt detected', {
-            field: fieldName,
-            requestId,
-            sample: input.slice(0, validationConfig.logging.maxLogFieldLength),
-        });
-        return true;
-    }
-    return false;
+  if (containsSqlInjection(input)) {
+    logger.warn("Potential SQL injection attempt detected", {
+      field: fieldName,
+      requestId,
+      sample: input.slice(0, validationConfig.logging.maxLogFieldLength),
+    });
+    return true;
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -101,21 +101,21 @@ export function detectAndLogSqlInjection(
 // ---------------------------------------------------------------------------
 
 export interface SanitizeOptions {
-    /** Strip XSS patterns (default: true) */
-    stripXssPatterns?: boolean;
-    /** Trim whitespace from strings (default: true) */
-    trimStrings?: boolean;
-    /** Remove keys whose values are undefined (default: true) */
-    removeUndefined?: boolean;
-    /** Maximum object depth to recurse (default: 10) */
-    maxDepth?: number;
+  /** Strip XSS patterns (default: true) */
+  stripXssPatterns?: boolean;
+  /** Trim whitespace from strings (default: true) */
+  trimStrings?: boolean;
+  /** Remove keys whose values are undefined (default: true) */
+  removeUndefined?: boolean;
+  /** Maximum object depth to recurse (default: 10) */
+  maxDepth?: number;
 }
 
 const DEFAULT_OPTIONS: Required<SanitizeOptions> = {
-    stripXssPatterns: true,
-    trimStrings: true,
-    removeUndefined: true,
-    maxDepth: 10,
+  stripXssPatterns: true,
+  trimStrings: true,
+  removeUndefined: true,
+  maxDepth: 10,
 };
 
 /**
@@ -125,37 +125,37 @@ const DEFAULT_OPTIONS: Required<SanitizeOptions> = {
  * - Numbers, booleans, null: returned as-is.
  */
 export function sanitizeObject(
-    value: unknown,
-    options: SanitizeOptions = {},
-    _depth = 0,
+  value: unknown,
+  options: SanitizeOptions = {},
+  _depth = 0,
 ): unknown {
-    const opts = { ...DEFAULT_OPTIONS, ...options };
+  const opts = { ...DEFAULT_OPTIONS, ...options };
 
-    if (_depth > opts.maxDepth) {
-        return value;
-    }
-
-    if (typeof value === 'string') {
-        let result = value;
-        if (opts.stripXssPatterns) result = stripXss(result);
-        if (opts.trimStrings) result = result.trim();
-        return result;
-    }
-
-    if (Array.isArray(value)) {
-        return value.map((item) => sanitizeObject(item, opts, _depth + 1));
-    }
-
-    if (value !== null && typeof value === 'object') {
-        const sanitized: Record<string, unknown> = {};
-        for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
-            if (opts.removeUndefined && val === undefined) continue;
-            sanitized[key] = sanitizeObject(val, opts, _depth + 1);
-        }
-        return sanitized;
-    }
-
+  if (_depth > opts.maxDepth) {
     return value;
+  }
+
+  if (typeof value === "string") {
+    let result = value;
+    if (opts.stripXssPatterns) result = stripXss(result);
+    if (opts.trimStrings) result = result.trim();
+    return result;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeObject(item, opts, _depth + 1));
+  }
+
+  if (value !== null && typeof value === "object") {
+    const sanitized: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      if (opts.removeUndefined && val === undefined) continue;
+      sanitized[key] = sanitizeObject(val, opts, _depth + 1);
+    }
+    return sanitized;
+  }
+
+  return value;
 }
 
 // ---------------------------------------------------------------------------
@@ -168,7 +168,7 @@ export function sanitizeObject(
  * separately via Zod schemas.
  */
 export function sanitizeStellarAddress(input: string): string {
-    return input.trim().toUpperCase();
+  return input.trim().toUpperCase();
 }
 
 // ---------------------------------------------------------------------------
@@ -177,19 +177,19 @@ export function sanitizeStellarAddress(input: string): string {
 
 /** Sanitize an email: lowercase + trim. */
 export function sanitizeEmail(email: string): string {
-    return email.trim().toLowerCase();
+  return email.trim().toLowerCase();
 }
 
 /** Sanitize a URL: trim and ensure it doesn't start with javascript: */
 export function sanitizeUrl(url: string): string {
-    const trimmed = url.trim();
-    if (/^javascript:/i.test(trimmed)) return '';
-    return trimmed;
+  const trimmed = url.trim();
+  if (/^javascript:/i.test(trimmed)) return "";
+  return trimmed;
 }
 
 /** Normalize a phone number: remove all non-digit and non-plus characters. */
 export function sanitizePhone(phone: string): string {
-    return phone.replace(/[^\d+]/g, '');
+  return phone.replace(/[^\d+]/g, "");
 }
 
 /**
@@ -197,6 +197,32 @@ export function sanitizePhone(phone: string): string {
  * Useful before persisting to avoid silently overflowing column limits.
  */
 export function truncateString(input: string, maxLength: number): string {
-    if (input.length <= maxLength) return input;
-    return input.slice(0, maxLength - 1) + '…';
+  if (input.length <= maxLength) return input;
+  return input.slice(0, maxLength - 1) + "…";
+}
+
+// ---------------------------------------------------------------------------
+// IP address anonymization (GDPR)
+// ---------------------------------------------------------------------------
+
+/**
+ * Anonymize an IP address before storage:
+ * - IPv4: zero the last octet  (192.168.1.100 → 192.168.1.0)
+ * - IPv6: zero the last 80 bits / 5 groups (keep first 3 groups)
+ */
+export function anonymizeIp(ip: string): string {
+  if (!ip || ip === "unknown") return ip;
+  // IPv4
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(ip)) {
+    return ip.replace(/\.\d+$/, ".0");
+  }
+  // IPv6: keep first 3 groups, zero the rest
+  const parts = ip.split(":");
+  if (parts.length >= 3) {
+    return parts
+      .slice(0, 3)
+      .concat(new Array(parts.length - 3).fill("0"))
+      .join(":");
+  }
+  return ip;
 }


### PR DESCRIPTION
## Summary

Fixes two issues in a single PR.

### #306 — GraphQL Schema Uses Offset Pagination

- Replaced `page`/`limit` offset pagination with `cursor`/`limit` cursor-based pagination across all GraphQL list queries (`mentors`, `bookings`, `payments`) and nested fields on `User` and `Mentor` types.
- Added `MentorConnection` type following the Relay cursor connection spec (`edges`, `pageInfo`, `total`).
- Updated `BookingListResult` and `PaymentListResult` to include `nextCursor: String` and `hasMore: Boolean!`.
- Removed the now-unused `PaginationInput` offset fields.

### #307 — ConsentController Stores Raw IP Address

- Added `anonymizeIp(ip: string): string` utility in `sanitization.utils.ts`:
  - IPv4: zeroes the last octet (`192.168.1.100 → 192.168.1.0`)
  - IPv6: zeroes the last 80 bits (keeps first 3 groups)
- Applied anonymization in `extractIpAddress()` in `auditLog.service.ts` — this covers all audit log callers across the codebase.
- Applied anonymization directly in `ConsentController.recordConsent()` for the consent record IP field.

## Files Changed

- `src/graphql/schema.ts`
- `src/utils/sanitization.utils.ts`
- `src/services/auditLog.service.ts`
- `src/controllers/consent.controller.ts`

Closes #306
Closes #307