### PR TITLE
fix: register consent routes and add integration tests (#312)

### DIFF
--- a/src/__tests__/consent.test.ts
+++ b/src/__tests__/consent.test.ts
@@ -1,0 +1,116 @@
+import { createUser } from '../../tests/factories/user.factory';
+import {
+  generateTestToken,
+  authenticatedPost,
+  authenticatedGet,
+  authenticatedPut,
+} from '../../tests/helpers/request.helper';
+
+const CONSENT_PAYLOAD = {
+  analytics_consent: true,
+  marketing_consent: false,
+  functional_consent: true,
+};
+
+describe('Consent API', () => {
+  describe('POST /consent', () => {
+    it('records consent and returns 201', async () => {
+      const user = await createUser({ role: 'user' });
+      const token = generateTestToken({ userId: user.id, email: user.email, role: user.role });
+
+      const res = await authenticatedPost('/consent', CONSENT_PAYLOAD, token);
+
+      expect(res.status).toBe(201);
+      expect(res.body.data).toMatchObject({
+        analytics_consent: true,
+        marketing_consent: false,
+        functional_consent: true,
+      });
+    });
+
+    it('returns 401 without auth', async () => {
+      const res = await import('supertest').then(({ default: request }) =>
+        request((await import('../../app')).default)
+          .post('/api/v1/consent')
+          .send(CONSENT_PAYLOAD),
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 400 for invalid payload', async () => {
+      const user = await createUser({ role: 'user' });
+      const token = generateTestToken({ userId: user.id, email: user.email, role: user.role });
+
+      const res = await authenticatedPost('/consent', { analytics_consent: 'yes' }, token);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('GET /consent', () => {
+    it('retrieves the latest consent record', async () => {
+      const user = await createUser({ role: 'user' });
+      const token = generateTestToken({ userId: user.id, email: user.email, role: user.role });
+
+      await authenticatedPost('/consent', CONSENT_PAYLOAD, token);
+      const res = await authenticatedGet('/consent', token);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toMatchObject({
+        analytics_consent: true,
+        marketing_consent: false,
+        functional_consent: true,
+      });
+    });
+
+    it('returns null data when no consent record exists', async () => {
+      const user = await createUser({ role: 'user' });
+      const token = generateTestToken({ userId: user.id, email: user.email, role: user.role });
+
+      const res = await authenticatedGet('/consent', token);
+      expect(res.status).toBe(200);
+      expect(res.body.data).toBeNull();
+    });
+  });
+
+  describe('PUT /consent', () => {
+    it('appends a new consent record', async () => {
+      const user = await createUser({ role: 'user' });
+      const token = generateTestToken({ userId: user.id, email: user.email, role: user.role });
+
+      await authenticatedPost('/consent', CONSENT_PAYLOAD, token);
+      const res = await authenticatedPut(
+        '/consent',
+        { analytics_consent: false, marketing_consent: false, functional_consent: false },
+        token,
+      );
+
+      expect(res.status).toBe(201);
+      expect(res.body.data.analytics_consent).toBe(false);
+    });
+  });
+
+  describe('GET /consent/stats (admin)', () => {
+    it('returns aggregate consent stats for admin', async () => {
+      const admin = await createUser({ role: 'admin' });
+      const adminToken = generateTestToken({ userId: admin.id, email: admin.email, role: 'admin' });
+
+      const res = await authenticatedGet('/consent/stats', adminToken);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toMatchObject({
+        total_unique_users: expect.any(Number),
+        analytics: expect.objectContaining({ opt_in_count: expect.any(Number) }),
+        marketing: expect.objectContaining({ opt_in_count: expect.any(Number) }),
+        functional: expect.objectContaining({ opt_in_count: expect.any(Number) }),
+      });
+    });
+
+    it('returns 403 for non-admin', async () => {
+      const user = await createUser({ role: 'user' });
+      const token = generateTestToken({ userId: user.id, email: user.email, role: user.role });
+
+      const res = await authenticatedGet('/consent/stats', token);
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/src/routes/consent.routes.ts
+++ b/src/routes/consent.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { ConsentController } from "../controllers/consent.controller";
 import { authenticate } from "../middleware/auth.middleware";
+import { requireRole } from "../middleware/rbac.middleware";
 import { asyncHandler } from "../utils/asyncHandler.utils";
 
 const router = Router();
@@ -99,5 +100,12 @@ router.get("/", authenticate, asyncHandler(ConsentController.getConsent));
  *         description: Unauthorized
  */
 router.put("/", authenticate, asyncHandler(ConsentController.updateConsent));
+
+router.get(
+  "/stats",
+  authenticate,
+  requireRole("admin"),
+  asyncHandler(ConsentController.getConsentStats),
+);
 
 export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -13,6 +13,7 @@ import reviewsRoutes from "./reviews.routes";
 import conversationsRoutes from "./conversations.routes";
 import messageSearchRoutes from "./messageSearch.routes";
 import integrationsRoutes from "./integrations.routes";
+import consentRoutes from "./consent.routes";
 import { BookingsService } from "../services/bookings.service";
 import { notificationCleanupService } from "../services/notification-cleanup.service";
 import {
@@ -54,6 +55,7 @@ router.use("/reviews", reviewsRoutes);
 router.use("/conversations", conversationsRoutes);
 router.use("/messages", messageSearchRoutes);
 router.use("/integrations", integrationsRoutes);
+router.use("/consent", consentRoutes);
 
 // JWKS public endpoint — no auth required
 router.get("/.well-known/jwks.json", asyncHandler(JwksController.getJwks));


### PR DESCRIPTION
## Summary

Fixes #312 — ConsentController had no route registration.

## Changes

**`consent.routes.ts`**
- Added missing `GET /consent/stats` endpoint (admin-only via `requireRole('admin')`)

**`routes/index.ts`**
- Mounted `consentRoutes` at `/consent`, making all four endpoints accessible:
  - `POST   /api/v1/consent` → `recordConsent`
  - `GET    /api/v1/consent` → `getConsent`
  - `PUT    /api/v1/consent` → `updateConsent`
  - `GET    /api/v1/consent/stats` → `getConsentStats` (admin only)

**`src/__tests__/consent.test.ts`** (new)
- Integration tests covering all four endpoints
- Verifies record + retrieve round-trip
- Verifies 401 for unauthenticated requests
- Verifies 400 for invalid payload
- Verifies 403 for non-admin on stats endpoint

Closes #312