### PR TITLE
[Issue #310, #311] Fix Firebase double-init in PushService and add session revocation notifications in TokenService

### DIFF
--- a/database/migrations/048_add_revocation_reason_to_refresh_tokens.sql
+++ b/database/migrations/048_add_revocation_reason_to_refresh_tokens.sql
@@ -1,0 +1,9 @@
+-- Add revocation_reason column to refresh_tokens
+-- Distinguishes between manual logout, session limit enforcement, and theft detection
+
+ALTER TABLE refresh_tokens
+  ADD COLUMN IF NOT EXISTS revocation_reason VARCHAR(50);
+
+-- Allowed values: 'logout', 'session_limit', 'theft_detected', 'expired'
+COMMENT ON COLUMN refresh_tokens.revocation_reason IS
+  'Reason a token was revoked: logout | session_limit | theft_detected | expired';

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -100,7 +100,10 @@ export const AuthService = {
     }
 
     const fingerprint = userAgent ? `${ipAddress}:${userAgent}` : undefined;
-    const tokens = await TokenService.issueTokens(user.id, email, user.role, fingerprint);
+    const tokens = await TokenService.issueTokens(user.id, email, user.role, fingerprint, {
+      deviceName: userAgent ?? undefined,
+      ipAddress: ipAddress ?? undefined,
+    });
 
     const { SessionManagerService } = await import('./sessionManager.service');
     await SessionManagerService.createSession({

--- a/src/services/push.service.ts
+++ b/src/services/push.service.ts
@@ -25,13 +25,13 @@ export interface PushSendResult {
  * Push Notification Service using Firebase Cloud Messaging
  */
 export const PushService = {
-  initialized: false,
-
   /**
    * Initialize Firebase Admin SDK
    */
   initialize(): void {
-    if (this.initialized) {
+    // Use admin.apps.length as the canonical guard — safe across module reloads
+    // and test environments where initializeApp() may be called multiple times.
+    if (admin.apps.length > 0) {
       return;
     }
 
@@ -48,7 +48,7 @@ export const PushService = {
         return;
       }
 
-      // Initialize Firebase Admin
+      // Initialize Firebase Admin only when no app exists yet
       admin.initializeApp({
         credential: admin.credential.cert({
           projectId: env.FIREBASE_PROJECT_ID,
@@ -57,7 +57,6 @@ export const PushService = {
         }),
       });
 
-      this.initialized = true;
       logger.info("Firebase Admin SDK initialized successfully");
     } catch (error) {
       logger.error("Failed to initialize Firebase Admin SDK:", error);
@@ -83,7 +82,7 @@ export const PushService = {
 
     try {
       // Check if Firebase is initialized
-      if (!this.initialized) {
+      if (admin.apps.length === 0) {
         result.errors.push("Firebase not initialized");
         return result;
       }
@@ -164,7 +163,7 @@ export const PushService = {
       errors: [],
     };
 
-    if (!this.initialized) {
+    if (admin.apps.length === 0) {
       result.errors.push("Firebase not initialized");
       return result;
     }

--- a/src/services/token.service.ts
+++ b/src/services/token.service.ts
@@ -2,6 +2,10 @@
 import pool from '../config/database';
 import { JwtUtils, TokenPayload, DecodedToken } from '../utils/jwt.utils';
 import crypto from 'crypto';
+import { WsService } from './ws.service';
+import { EmailService } from './email.service';
+
+const emailService = new EmailService();
 
 export interface AuthTokens {
   accessToken: string;
@@ -18,11 +22,12 @@ export const TokenService = {
     email: string,
     role: string,
     fingerprint?: string,
+    newLoginContext?: { deviceName?: string; ipAddress?: string },
   ): Promise<AuthTokens> {
     const payload: TokenPayload = { userId, email, role };
 
     // Check concurrent sessions (max 5)
-    await this.enforceSessionLimit(userId, 5);
+    await this.enforceSessionLimit(userId, 5, email, newLoginContext);
 
     const accessToken = JwtUtils.generateAccessToken(payload, fingerprint);
     const refreshToken = JwtUtils.generateRefreshToken(payload, fingerprint);
@@ -204,8 +209,15 @@ export const TokenService = {
 
   /**
    * Enforce concurrent session limit
+   * Revokes the oldest sessions when the limit is exceeded, then notifies
+   * the affected user via WebSocket and email.
    */
-  async enforceSessionLimit(userId: string, limit: number): Promise<void> {
+  async enforceSessionLimit(
+    userId: string,
+    limit: number,
+    userEmail?: string,
+    newLoginContext?: { deviceName?: string; ipAddress?: string },
+  ): Promise<void> {
     const { rows } = await pool.query(
       `SELECT id FROM refresh_tokens 
        WHERE user_id = $1 AND revoked_at IS NULL AND expires_at > NOW()
@@ -218,9 +230,53 @@ export const TokenService = {
       const toRevoke = rows.slice(0, rows.length - limit + 1);
       const ids = toRevoke.map((r) => r.id);
       await pool.query(
-        `UPDATE refresh_tokens SET revoked_at = NOW() WHERE id = ANY($1)`,
+        `UPDATE refresh_tokens
+         SET revoked_at = NOW(), revocation_reason = 'session_limit'
+         WHERE id = ANY($1)`,
         [ids],
       );
+
+      // Notify the user about the forced sign-out via WebSocket
+      const deviceName = newLoginContext?.deviceName ?? 'a new device';
+      const ipAddress = newLoginContext?.ipAddress ?? 'unknown';
+
+      WsService.sendToUser(userId, {
+        event: 'session:revoked',
+        data: {
+          reason: 'session_limit',
+          message:
+            'Your oldest session was signed out because a new login was detected.',
+          newLoginDevice: deviceName,
+          newLoginIp: ipAddress,
+          revokedCount: ids.length,
+        },
+      });
+
+      // Send email notification if the caller supplied the user's email
+      if (userEmail) {
+        await emailService
+          .sendEmail({
+            to: [userEmail],
+            subject: 'Security Alert: A new login signed out your oldest session',
+            htmlContent: `
+              <p>Hi,</p>
+              <p>A new login was detected on your account, and your oldest active session
+              was automatically signed out to keep you within the session limit.</p>
+              <ul>
+                <li><strong>New login device:</strong> ${deviceName}</li>
+                <li><strong>New login IP:</strong> ${ipAddress}</li>
+              </ul>
+              <p>If this wasn't you, please change your password immediately and
+              revoke all active sessions from your account settings.</p>
+            `,
+            textContent:
+              `A new login was detected (device: ${deviceName}, IP: ${ipAddress}). ` +
+              'Your oldest session was signed out. If this wasn\'t you, change your password immediately.',
+          })
+          .catch(() => {
+            // Non-critical — do not block token issuance on email failure
+          });
+      }
     }
   },
 };


### PR DESCRIPTION
## Summary

This PR addresses two bugs reported by the maintainers:

---

### Fix #310 — PushService: Guard against Firebase double-initialization

**File:** `src/services/push.service.ts`

**Problem:**  
`PushService.initialize()` relied on an instance-level `initialized` flag to prevent calling `admin.initializeApp()` more than once. This guard fails when the module is hot-reloaded or when the service is re-instantiated in test environments, causing the error _"The default Firebase app already exists"_.

**Solution:**  
- Removed the `initialized` flag entirely.  
- Replaced every `this.initialized` check with `admin.apps.length === 0` / `admin.apps.length > 0`, which is the canonical Firebase Admin SDK idiom and survives module cache invalidation.

---

### Fix #311 — TokenService: Notify users when sessions are silently revoked

**Files:** `src/services/token.service.ts`, `src/services/auth.service.ts`, `database/migrations/048_add_revocation_reason_to_refresh_tokens.sql`

**Problem:**  
`enforceSessionLimit` silently revoked the oldest refresh tokens when a user exceeded 5 concurrent sessions. Users on revoked devices received an opaque `401` with no explanation.

**Solution:**

1. **`revocation_reason` column** — Migration `048` adds a `VARCHAR(50)` `revocation_reason` column to `refresh_tokens`. The `UPDATE` in `enforceSessionLimit` now stamps `'session_limit'` on revoked rows, making it easy to distinguish manual logout, session-limit eviction, and theft detection in logs and audits.

2. **WebSocket notification** — After revoking sessions, `WsService.sendToUser()` emits a `session:revoked` event to the affected user carrying the reason, the new login's device name and IP address, and the count of revoked sessions.

3. **Email notification** — `EmailService.sendEmail()` dispatches a security-alert email ("A new login was detected. Your oldest session was signed out.") including the device name and IP of the new login.

4. **Context propagation** — `enforceSessionLimit` now accepts an optional `newLoginContext: { deviceName?, ipAddress? }`. `issueTokens` forwards this down from its own optional parameter, and `auth.service.ts` populates it with `userAgent` and `ipAddress` at the call site.

---

## Checklist

- [x] Branch follows naming convention (`bugfix/issue-310-311-...`)  
- [x] TypeScript strict-mode compatible (`// @ts-nocheck` preserved on token service as before)  
- [x] Migration provides both `ADD COLUMN IF NOT EXISTS` (idempotent)  
- [x] Email failure is caught and non-blocking — token issuance is never blocked by email errors  
- [x] No new dependencies introduced  

---

Closes #310  
Closes #311