### PR TITLE
feat: implement DDL check script and update pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+npm run check:ddl && npx lint-staged

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "docker:build": "docker compose build",
     "docker:dev": "docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build",
     "docker:test": "docker compose --env-file .env.docker.test -f docker-compose.test.yml up --build --abort-on-container-exit --exit-code-from test-backend",
+    "check:ddl": "node scripts/check-ddl.js",
     "prepare": "husky"
   },
   "keywords": [

--- a/scripts/check-ddl.js
+++ b/scripts/check-ddl.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+function getStagedFiles() {
+  const output = execSync('git diff --cached --name-only --diff-filter=ACM', {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'ignore'],
+  }).trim();
+
+  if (!output) {
+    return [];
+  }
+
+  return output.split('\n').filter(Boolean);
+}
+
+const stagedFiles = getStagedFiles().filter((file) => {
+  if (!/\.(ts|js)$/i.test(file)) {
+    return false;
+  }
+
+  if (file.startsWith('database/migrations')) {
+    return false;
+  }
+
+  if (file.startsWith('src/__tests__') || file.startsWith('src/tests')) {
+    return false;
+  }
+
+  return true;
+});
+
+const findings = [];
+
+for (const file of stagedFiles) {
+  if (!fs.existsSync(file)) {
+    continue;
+  }
+
+  const contents = fs.readFileSync(file, 'utf8');
+  const lines = contents.split(/\r?\n/);
+
+  lines.forEach((line, index) => {
+    if (line.includes('CREATE TABLE IF NOT EXISTS')) {
+      findings.push(`${file}:${index + 1}: ${line.trim()}`);
+    }
+  });
+}
+
+if (findings.length > 0) {
+  console.error('ERROR: Runtime DDL found in staged files outside migration files.');
+  console.error('Please move table creation statements into database migration files.');
+  console.error('Found the following occurrences:');
+  findings.forEach((match) => console.error(`  - ${match}`));
+  process.exit(1);
+}
+
+process.exit(0);

--- a/src/models/notifications.model.ts
+++ b/src/models/notifications.model.ts
@@ -63,38 +63,9 @@ export enum NotificationPriority {
  */
 export const NotificationsModel = {
   /**
-   * Initialize the notifications table with enhanced schema
+   * Notifications table schemas are managed by database migrations.
+   * Runtime DDL creation is intentionally removed to avoid schema drift.
    */
-  async initializeTable(): Promise<void> {
-    const query = `
-      CREATE TABLE IF NOT EXISTS notifications (
-        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-        user_id UUID NOT NULL,
-        type VARCHAR(50) NOT NULL,
-        channel VARCHAR(20) NOT NULL,
-        priority VARCHAR(20) DEFAULT 'normal',
-        title VARCHAR(255) NOT NULL,
-        message TEXT NOT NULL,
-        template_id VARCHAR(100),
-        template_data JSONB DEFAULT '{}'::jsonb,
-        data JSONB DEFAULT '{}'::jsonb,
-        is_read BOOLEAN DEFAULT FALSE,
-        scheduled_at TIMESTAMP WITH TIME ZONE,
-        expires_at TIMESTAMP WITH TIME ZONE,
-        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-        updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_notifications_user_id ON notifications(user_id);
-      CREATE INDEX IF NOT EXISTS idx_notifications_type ON notifications(type);
-      CREATE INDEX IF NOT EXISTS idx_notifications_channel ON notifications(channel);
-      CREATE INDEX IF NOT EXISTS idx_notifications_priority ON notifications(priority);
-      CREATE INDEX IF NOT EXISTS idx_notifications_scheduled_at ON notifications(scheduled_at);
-      CREATE INDEX IF NOT EXISTS idx_notifications_created_at ON notifications(created_at);
-      CREATE INDEX IF NOT EXISTS idx_notifications_is_read ON notifications(is_read);
-    `;
-    await pool.query(query);
-  },
 
   /**
    * Create a new notification


### PR DESCRIPTION
closes #390 

PR Summary
What changed
Removed runtime DDL schema creation from notifications.model.ts
Ensured notifications schema is managed by migrations only
Added a pre-commit guard to block CREATE TABLE IF NOT EXISTS in staged code outside migrations
Added check-ddl.js
Updated package.json with check:ddl
Updated pre-commit to run npm run check:ddl before lint-staged
Why
Prevents schema drift and runtime table creation during app startup
Enforces migration-first database schema management
Covers notifications table columns already defined in migrations 014_create_notifications.sql and 022_create_notifications.sql
Files changed
notifications.model.ts
package.json
pre-commit
check-ddl.js