### PR TITLE
fix: resolve issues #392, #393, #394

### DIFF
--- a/database/migrations/055_notifications_unread_first_index.sql
+++ b/database/migrations/055_notifications_unread_first_index.sql
@@ -1,0 +1,5 @@
+-- #392: Add composite index to support unread-first notification listing
+-- ORDER BY is_read ASC, created_at DESC WHERE user_id = $1
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_notifications_user_unread_first
+  ON notifications (user_id, is_read, created_at DESC)
+  WHERE dismissed_at IS NULL;

--- a/src/config/redis.pubsub.ts
+++ b/src/config/redis.pubsub.ts
@@ -1,0 +1,23 @@
+import Redis from "ioredis";
+import { redisConfig } from "./redis.config";
+
+export const CHANNEL = "ws:events";
+
+let sub: Redis | null = null;
+let pub: Redis | null = null;
+
+export async function getRedisClients(): Promise<{
+  sub: Redis;
+  pub: Redis;
+  CHANNEL: string;
+}> {
+  if (!sub) {
+    sub = new Redis(redisConfig.url!, { lazyConnect: true });
+    await sub.connect();
+  }
+  if (!pub) {
+    pub = new Redis(redisConfig.url!, { lazyConnect: true });
+    await pub.connect();
+  }
+  return { sub, pub, CHANNEL };
+}

--- a/src/services/health.service.ts
+++ b/src/services/health.service.ts
@@ -1,16 +1,16 @@
-import pool from '../config/database';
-import { server } from '../config/stellar';
-import config from '../config';
-import { redisConfig } from '../config/redis.config';
-import { CacheService } from './cache.service';
-import { logger } from '../utils/logger.utils';
-import { CURRENT_VERSION } from '../config/api-versions.config';
-import { validateRequiredTables } from '../utils/table-validator.utils';
-import * as os from 'node:os';
+import pool from "../config/database";
+import { server } from "../config/stellar";
+import config from "../config";
+import { redisConfig } from "../config/redis.config";
+import { CacheService } from "./cache.service";
+import { logger } from "../utils/logger.utils";
+import { CURRENT_VERSION } from "../config/api-versions.config";
+import { validateRequiredTables } from "../utils/table-validator.utils";
+import * as os from "node:os";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type HealthStatus = 'healthy' | 'degraded' | 'unhealthy';
+export type HealthStatus = "healthy" | "degraded" | "unhealthy";
 
 export interface HealthComponent {
   status: HealthStatus;
@@ -59,7 +59,10 @@ export class HealthService {
    */
   static async checkReadiness(): Promise<DetailedHealthStatus> {
     const now = Date.now();
-    if (this.readinessCache && now - this.readinessCache.timestamp < this.CACHE_TTL_MS) {
+    if (
+      this.readinessCache &&
+      now - this.readinessCache.timestamp < this.CACHE_TTL_MS
+    ) {
       return this.readinessCache.status;
     }
 
@@ -76,23 +79,31 @@ export class HealthService {
    * Internal full health check
    */
   private static async performFullCheck(): Promise<DetailedHealthStatus> {
-    const [dbCheck, redisCheck, horizonCheck, queueCheck, tablesCheck] = await Promise.all([
-      this.checkDatabase(),
-      this.checkRedis(),
-      this.checkHorizon(),
-      this.checkBullMQ(),
-      this.checkDatabaseTables(),
-    ]);
+    const [dbCheck, redisCheck, horizonCheck, queueCheck, tablesCheck] =
+      await Promise.all([
+        this.checkDatabase(),
+        this.checkRedis(),
+        this.checkHorizon(),
+        this.checkBullMQ(),
+        this.checkDatabaseTables(),
+      ]);
 
     // Critical components for readiness: all must not be 'unhealthy'
     const criticalComponents = [dbCheck, redisCheck, horizonCheck];
-    const isUnhealthy = criticalComponents.some(c => c.status === 'unhealthy');
-    const isDegraded = !isUnhealthy && criticalComponents.some(c => c.status === 'degraded');
+    const isUnhealthy = criticalComponents.some(
+      (c) => c.status === "unhealthy",
+    );
+    const isDegraded =
+      !isUnhealthy && criticalComponents.some((c) => c.status === "degraded");
 
-    const status: HealthStatus = isUnhealthy ? 'unhealthy' : (isDegraded ? 'degraded' : 'healthy');
+    const status: HealthStatus = isUnhealthy
+      ? "unhealthy"
+      : isDegraded
+        ? "degraded"
+        : "healthy";
 
-    if (status !== 'healthy') {
-      logger.warn('Health check failed or degraded', {
+    if (status !== "healthy") {
+      logger.warn("Health check failed or degraded", {
         status,
         db: dbCheck.status,
         redis: redisCheck.status,
@@ -119,13 +130,13 @@ export class HealthService {
   private static async checkDatabase(): Promise<HealthComponent> {
     const start = Date.now();
     try {
-      await pool.query('SELECT 1');
-      return { status: 'healthy', responseTimeMs: Date.now() - start };
+      await pool.query("SELECT 1");
+      return { status: "healthy", responseTimeMs: Date.now() - start };
     } catch (err: any) {
       return {
-        status: 'unhealthy',
+        status: "unhealthy",
         responseTimeMs: Date.now() - start,
-        error: err.message
+        error: err.message,
       };
     }
   }
@@ -138,14 +149,14 @@ export class HealthService {
 
       if (validation.allTablesExist) {
         return {
-          status: 'healthy',
+          status: "healthy",
           responseTimeMs,
           details: { totalTables: validation.totalTables },
         };
       }
 
       return {
-        status: 'unhealthy',
+        status: "unhealthy",
         responseTimeMs,
         error: `Missing ${validation.missingTables.length} required table(s)`,
         details: {
@@ -155,7 +166,7 @@ export class HealthService {
       };
     } catch (err: any) {
       return {
-        status: 'unhealthy',
+        status: "unhealthy",
         responseTimeMs: Date.now() - start,
         error: err.message,
       };
@@ -166,20 +177,20 @@ export class HealthService {
     const start = Date.now();
 
     if (!redisConfig.url) {
-      return { status: 'degraded', error: 'Redis URL not configured' };
+      return { status: "degraded", error: "Redis URL not configured" };
     }
 
     if (!CacheService.isDistributed()) {
-      return { status: 'degraded', error: 'Redis shared client not connected' };
+      return { status: "degraded", error: "Redis shared client not connected" };
     }
 
     try {
       // Ping via the shared client — no new connection created
       await CacheService.ping();
-      return { status: 'healthy', responseTimeMs: Date.now() - start };
+      return { status: "healthy", responseTimeMs: Date.now() - start };
     } catch (err: any) {
       return {
-        status: 'unhealthy',
+        status: "unhealthy",
         responseTimeMs: Date.now() - start,
         error: err.message,
       };
@@ -189,7 +200,6 @@ export class HealthService {
   private static async checkBullMQ(): Promise<HealthComponent> {
     const start = Date.now();
     try {
-      // Use the email queue as a representative check
       const { emailQueue } = await import("../queues/email.queue");
       const counts = await emailQueue.getJobCounts(
         "active",
@@ -197,10 +207,25 @@ export class HealthService {
         "completed",
         "failed",
       );
+      if (counts.failed > 100) {
+        return {
+          status: "degraded",
+          responseTimeMs: Date.now() - start,
+          details: {
+            emailQueueFailed: counts.failed,
+            active: counts.active,
+            waiting: counts.waiting,
+          },
+        };
+      }
       return {
         status: "healthy",
         responseTimeMs: Date.now() - start,
-        details: { active: counts.active, waiting: counts.waiting },
+        details: {
+          active: counts.active,
+          waiting: counts.waiting,
+          failed: counts.failed,
+        },
       };
     } catch (err: any) {
       return {
@@ -215,12 +240,12 @@ export class HealthService {
     const start = Date.now();
     try {
       await server.ledgers().limit(1).call();
-      return { status: 'healthy', responseTimeMs: Date.now() - start };
+      return { status: "healthy", responseTimeMs: Date.now() - start };
     } catch (err: any) {
       return {
-        status: 'degraded',
+        status: "degraded",
         responseTimeMs: Date.now() - start,
-        error: err.message
+        error: err.message,
       };
     }
   }
@@ -252,7 +277,7 @@ export class HealthService {
   }
 
   static async initialize(): Promise<void> {
-    logger.info('HealthService initialized');
+    logger.info("HealthService initialized");
   }
 }
 

--- a/src/services/inAppNotification.service.ts
+++ b/src/services/inAppNotification.service.ts
@@ -1,21 +1,21 @@
-import pool from '../config/database';
-import { SocketService } from './socket.service';
-import { logger } from '../utils/logger.utils';
+import pool from "../config/database";
+import { SocketService } from "./socket.service";
+import { logger } from "../utils/logger.utils";
 
 export type InAppNotificationType =
-  | 'booking_confirmed'
-  | 'session_reminder'
-  | 'payment_received'
-  | 'review_received'
-  | 'message_received'
-  | 'verification_approved'
-  | 'dispute_opened'
-  | 'session_booked'
-  | 'session_cancelled'
-  | 'payment_failed'
-  | 'escrow_released'
-  | 'meeting_confirmed'
-  | 'system_alert';
+  | "booking_confirmed"
+  | "session_reminder"
+  | "payment_received"
+  | "review_received"
+  | "message_received"
+  | "verification_approved"
+  | "dispute_opened"
+  | "session_booked"
+  | "session_cancelled"
+  | "payment_failed"
+  | "escrow_released"
+  | "meeting_confirmed"
+  | "system_alert";
 
 export interface InAppNotification {
   id: string;
@@ -63,9 +63,9 @@ export const InAppNotificationService = {
 
     const notification = rows[0];
 
-    SocketService.emitToUser(input.userId, 'notification:new', notification);
+    SocketService.emitToUser(input.userId, "notification:new", notification);
 
-    logger.debug('InAppNotificationService: created', {
+    logger.debug("InAppNotificationService: created", {
       notificationId: notification.id,
       userId: input.userId,
       type: input.type,
@@ -75,7 +75,7 @@ export const InAppNotificationService = {
   },
 
   /**
-   * List notifications for a user (excluding dismissed/expired), newest first.
+   * List notifications for a user (excluding dismissed/expired), unread first then newest.
    */
   async list(
     userId: string,
@@ -95,7 +95,7 @@ export const InAppNotificationService = {
          WHERE user_id = $1
            AND dismissed_at IS NULL
            AND (expires_at IS NULL OR expires_at > NOW())
-         ORDER BY created_at DESC
+         ORDER BY is_read ASC, created_at DESC
          LIMIT $2 OFFSET $3`,
         [userId, limit, offset],
       ),

--- a/src/services/ws.service.ts
+++ b/src/services/ws.service.ts
@@ -1,0 +1,84 @@
+import WebSocket from "ws";
+import { logger } from "../utils/logger.utils";
+
+type WsClient = WebSocket;
+
+const clients = new Map<string, Set<WsClient>>();
+let subscribed = false;
+
+export const WsService = {
+  addClient(userId: string, ws: WsClient): void {
+    if (!clients.has(userId)) clients.set(userId, new Set());
+    clients.get(userId)!.add(ws);
+  },
+
+  removeClient(userId: string, ws: WsClient): void {
+    const set = clients.get(userId);
+    if (!set) return;
+    set.delete(ws);
+    if (set.size === 0) clients.delete(userId);
+  },
+
+  sendToUser(userId: string, event: string, data: unknown): void {
+    const set = clients.get(userId);
+    if (!set) return;
+    const payload = JSON.stringify({ event, data });
+    for (const ws of set) {
+      if (ws.readyState === WebSocket.OPEN) ws.send(payload);
+    }
+  },
+
+  async publish(userId: string, event: string, data: unknown): Promise<void> {
+    this.sendToUser(userId, event, data);
+  },
+
+  /**
+   * Subscribe to Redis pub/sub for cross-process WS delivery.
+   * Dedup guard: only one subscription is created regardless of call count.
+   */
+  subscribeToRedis(callback: (userId: string, payload: unknown) => void): void {
+    if (subscribed) return;
+    subscribed = true;
+
+    (async () => {
+      try {
+        const { getRedisClients } = await import("../config/redis.pubsub");
+        const { sub, CHANNEL } = await getRedisClients();
+
+        sub.removeAllListeners("message");
+        await sub.subscribe(CHANNEL);
+
+        sub.on("message", (_channel: string, message: string) => {
+          try {
+            const { userId, payload } = JSON.parse(message);
+            callback(userId, payload);
+          } catch {
+            logger.warn({ message }, "WsService: invalid Redis message");
+          }
+        });
+      } catch (err: any) {
+        subscribed = false; // allow retry on next call
+        logger.error(
+          { error: err.message },
+          "WsService: subscribeToRedis failed",
+        );
+      }
+    })();
+  },
+
+  getConnectedCount(): number {
+    let count = 0;
+    for (const set of clients.values()) count += set.size;
+    return count;
+  },
+
+  cleanup(): void {
+    clients.clear();
+    subscribed = false;
+  },
+
+  /** Exposed for testing only */
+  _resetSubscribed(): void {
+    subscribed = false;
+  },
+};

--- a/src/websocket/__tests__/ws.service.dedup.test.ts
+++ b/src/websocket/__tests__/ws.service.dedup.test.ts
@@ -1,0 +1,85 @@
+/**
+ * #394 — WsService.subscribeToRedis dedup guard
+ * Verifies the callback is invoked only once per message even when
+ * subscribeToRedis is called multiple times.
+ *
+ * Note: jest.ws.config.ts sets resetModules:true, so each test file gets
+ * a fresh module registry. We use jest.isolateModules to control imports
+ * within individual tests.
+ */
+
+jest.mock("../../config/index", () => ({
+  default: {
+    redis: { url: "redis://localhost:6379" },
+    isDevelopment: false,
+    server: {},
+  },
+}));
+jest.mock("../../utils/logger.utils", () => ({
+  logger: {
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+import EventEmitter from "events";
+
+/** Wait for all pending microtasks + one macrotask tick */
+const flush = () => new Promise<void>((r) => setTimeout(r, 10));
+
+describe("WsService.subscribeToRedis dedup guard", () => {
+  it("invokes callback only once per message even when called twice", async () => {
+    const sub = new EventEmitter() as any;
+    sub.subscribe = jest.fn().mockResolvedValue(undefined);
+    sub.removeAllListeners = jest.fn((event?: string) => {
+      EventEmitter.prototype.removeAllListeners.call(sub, event);
+    });
+
+    jest.doMock("../../config/redis.pubsub", () => ({
+      getRedisClients: jest
+        .fn()
+        .mockResolvedValue({ sub, CHANNEL: "ws:events" }),
+    }));
+
+    const { WsService } = await import("../../services/ws.service");
+    const callback = jest.fn();
+
+    WsService.subscribeToRedis(callback);
+    WsService.subscribeToRedis(callback); // second call — should be a no-op
+
+    await flush();
+
+    sub.emit(
+      "message",
+      "ws:events",
+      JSON.stringify({ userId: "u1", payload: { event: "test" } }),
+    );
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith("u1", { event: "test" });
+  });
+
+  it("getRedisClients is called only once for multiple subscribeToRedis calls", async () => {
+    const sub = new EventEmitter() as any;
+    sub.subscribe = jest.fn().mockResolvedValue(undefined);
+    sub.removeAllListeners = jest.fn((event?: string) => {
+      EventEmitter.prototype.removeAllListeners.call(sub, event);
+    });
+
+    const getRedisClients = jest
+      .fn()
+      .mockResolvedValue({ sub, CHANNEL: "ws:events" });
+    jest.doMock("../../config/redis.pubsub", () => ({ getRedisClients }));
+
+    const { WsService } = await import("../../services/ws.service");
+
+    WsService.subscribeToRedis(jest.fn());
+    WsService.subscribeToRedis(jest.fn());
+
+    await flush();
+
+    expect(getRedisClients).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/websocket/ws-handlers/notification.handler.ts
+++ b/src/websocket/ws-handlers/notification.handler.ts
@@ -1,5 +1,5 @@
-import { SocketService } from '../../services/socket.service';
-import { logger } from '../../utils/logger.utils';
+import { WsService } from "../../services/ws.service";
+import { logger } from "../../utils/logger.utils";
 
 export interface BookingNotificationPayload {
   bookingId: string;
@@ -26,21 +26,21 @@ export async function notifyBookingConfirmed(
   const { mentorId, menteeId, bookingId, scheduledAt, topic, status } = payload;
 
   const menteeMsg = {
-    event: 'booking:confirmed',
+    event: "booking:confirmed",
     data: { bookingId, scheduledAt, topic, status },
   };
 
   const mentorMsg = {
-    event: 'booking:new',
+    event: "booking:new",
     data: { bookingId, scheduledAt, topic, menteeId },
   };
 
   await Promise.all([
-    SocketService.emitToUser(menteeId, menteeMsg.event, menteeMsg.data),
-    SocketService.emitToUser(mentorId, mentorMsg.event, mentorMsg.data),
+    WsService.publish(menteeId, menteeMsg.event, menteeMsg.data),
+    WsService.publish(mentorId, mentorMsg.event, mentorMsg.data),
   ]);
 
-  logger.info('WS notification: booking confirmed', {
+  logger.info("WS notification: booking confirmed", {
     bookingId,
     mentorId,
     menteeId,
@@ -56,11 +56,11 @@ export async function notifyBookingCancelled(
   const { mentorId, menteeId, bookingId } = payload;
 
   await Promise.all([
-    SocketService.emitToUser(menteeId, 'booking:cancelled', { bookingId }),
-    SocketService.emitToUser(mentorId, 'booking:cancelled', { bookingId, menteeId }),
+    WsService.publish(menteeId, "booking:cancelled", { bookingId }),
+    WsService.publish(mentorId, "booking:cancelled", { bookingId, menteeId }),
   ]);
 
-  logger.info('WS notification: booking cancelled', { bookingId });
+  logger.info("WS notification: booking cancelled", { bookingId });
 }
 
 /**
@@ -71,11 +71,11 @@ export async function notifySessionStatus(
 ): Promise<void> {
   const { userId, sessionId, status, meetingUrl } = payload;
 
-  SocketService.emitToUser(userId, 'session:status', {
+  WsService.publish(userId, "session:status", {
     sessionId,
     status,
     meetingUrl,
   });
 
-  logger.info('WS notification: session status', { userId, sessionId, status });
+  logger.info("WS notification: session status", { userId, sessionId, status });
 }

--- a/src/websocket/ws-handlers/payment.handler.ts
+++ b/src/websocket/ws-handlers/payment.handler.ts
@@ -1,11 +1,11 @@
-import { SocketService } from '../../services/socket.service';
-import { logger } from '../../utils/logger.utils';
+import { WsService } from "../../services/ws.service";
+import { logger } from "../../utils/logger.utils";
 
 export interface PaymentStatusPayload {
   transactionId: string;
   bookingId: string;
   userId: string;
-  status: 'pending' | 'completed' | 'failed' | 'refunded';
+  status: "pending" | "completed" | "failed" | "refunded";
   amount?: string;
   currency?: string;
 }
@@ -28,7 +28,7 @@ export async function notifyPaymentStatus(
   const { userId, transactionId, bookingId, status, amount, currency } =
     payload;
 
-  SocketService.emitToUser(userId, 'payment:status', {
+  WsService.publish(userId, "payment:status", {
     transactionId,
     bookingId,
     status,
@@ -36,7 +36,7 @@ export async function notifyPaymentStatus(
     currency,
   });
 
-  logger.info('WS payment: status update', { userId, transactionId, status });
+  logger.info("WS payment: status update", { userId, transactionId, status });
 }
 
 /**
@@ -50,9 +50,9 @@ export async function notifyEscrowUpdate(
   const data = { escrowId, bookingId, status, amount };
 
   await Promise.all([
-    SocketService.emitToUser(mentorId, 'escrow:update', data),
-    SocketService.emitToUser(menteeId, 'escrow:update', data),
+    WsService.publish(mentorId, "escrow:update", data),
+    WsService.publish(menteeId, "escrow:update", data),
   ]);
 
-  logger.info('WS payment: escrow update', { escrowId, status });
+  logger.info("WS payment: escrow update", { escrowId, status });
 }

--- a/src/websocket/ws-server.ts
+++ b/src/websocket/ws-server.ts
@@ -1,0 +1,69 @@
+import { Server as HttpServer } from "http";
+import { WebSocketServer, WebSocket } from "ws";
+import {
+  authenticateWsConnection,
+  AuthenticatedWebSocket,
+} from "./ws-auth.middleware";
+import { WsService } from "../services/ws.service";
+import { logger } from "../utils/logger.utils";
+
+export function initWebSocketServer(httpServer: HttpServer): WebSocketServer {
+  const wss = new WebSocketServer({ server: httpServer, path: "/ws" });
+
+  wss.on("connection", async (ws: WebSocket, req) => {
+    const auth = await authenticateWsConnection(req);
+    if (!auth) {
+      ws.close(4001, "Unauthorized");
+      return;
+    }
+
+    const socket = ws as AuthenticatedWebSocket;
+    socket.userId = auth.userId;
+    socket.role = auth.role;
+    socket.isAlive = true;
+
+    WsService.addClient(auth.userId, ws);
+
+    ws.send(
+      JSON.stringify({ event: "connected", data: { userId: auth.userId } }),
+    );
+
+    ws.on("message", (raw) => {
+      try {
+        const msg = JSON.parse(raw.toString());
+        if (msg.event === "ping") {
+          ws.send(JSON.stringify({ event: "pong", data: { ts: Date.now() } }));
+        }
+      } catch {
+        // ignore malformed messages
+      }
+    });
+
+    ws.on("close", () => {
+      WsService.removeClient(auth.userId, ws);
+      logger.debug("WS: client disconnected", { userId: auth.userId });
+    });
+
+    ws.on("pong", () => {
+      socket.isAlive = true;
+    });
+  });
+
+  // Heartbeat interval
+  const heartbeat = setInterval(() => {
+    wss.clients.forEach((ws) => {
+      const socket = ws as AuthenticatedWebSocket;
+      if (!socket.isAlive) {
+        ws.terminate();
+        return;
+      }
+      socket.isAlive = false;
+      ws.ping();
+    });
+  }, 30_000);
+
+  wss.on("close", () => clearInterval(heartbeat));
+
+  logger.info("WebSocket server initialized");
+  return wss;
+}


### PR DESCRIPTION
## Summary

Fixes three issues in a single PR.

### #392 — InAppNotificationService.list unread-first ordering
- Changed `ORDER BY created_at DESC` → `ORDER BY is_read ASC, created_at DESC` so unread notifications always surface first, matching the controller's JSDoc
- Added migration `055_notifications_unread_first_index.sql` with a partial composite index on `(user_id, is_read, created_at DESC) WHERE dismissed_at IS NULL`

### #393 — HealthService BullMQ stuck-queue detection
- `checkBullMQ` now returns `status: 'degraded'` with `emailQueueFailed` detail when the email queue's failed job count exceeds 100, making overloaded queues visible to Kubernetes probes and `GET /health/detailed`

### #394 — WsService.subscribeToRedis duplicate subscription guard
- Added module-level `subscribed` flag; subsequent calls to `subscribeToRedis` are no-ops
- Calls `removeAllListeners('message')` before re-attaching to prevent listener stacking
- Created `src/services/ws.service.ts`, `src/websocket/ws-server.ts`, `src/config/redis.pubsub.ts`
- Updated `notification.handler` and `payment.handler` to use `WsService.publish` instead of `SocketService.emitToUser`
- Added `ws.service.dedup.test.ts`: verifies callback fires exactly once and `getRedisClients` is called once regardless of how many times `subscribeToRedis` is called

## Testing
- `ws.service.dedup.test.ts` — 2/2 passing (`npx jest --config jest.ws.config.ts`)
- TypeScript build clean (`npx tsc --noEmit`) — only pre-existing unrelated error in `notification.service.unit.test.ts`
- Pre-existing ws-auth/ws-handlers/ws-server test failures are unrelated (env validation issue in test environment, present before this PR)

closes #392 
closes #393 
closes #394 