### PR TITLE
fix: invalidate readiness cache on check errors

### DIFF
--- a/src/services/__tests__/health.service.unit.test.ts
+++ b/src/services/__tests__/health.service.unit.test.ts
@@ -1,0 +1,141 @@
+jest.mock("../../config/database", () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}));
+
+jest.mock("../../config/stellar", () => ({
+  server: {
+    ledgers: jest.fn(),
+  },
+}));
+
+jest.mock("../../config", () => ({
+  __esModule: true,
+  default: {
+    server: {
+      apiVersion: "v1",
+    },
+  },
+}));
+
+jest.mock("../../config/redis.config", () => ({
+  redisConfig: {
+    url: "redis://localhost:6379",
+  },
+}));
+
+jest.mock("../cache.service", () => ({
+  CacheService: {
+    isDistributed: jest.fn(),
+    ping: jest.fn(),
+  },
+}));
+
+jest.mock("../../utils/logger.utils", () => ({
+  logger: {
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+jest.mock("../../utils/table-validator.utils", () => ({
+  validateRequiredTables: jest.fn(),
+}));
+
+import HealthService, {
+  DetailedHealthStatus,
+  HealthStatus,
+} from "../health.service";
+
+const createStatus = (
+  status: HealthStatus,
+  error?: string,
+): DetailedHealthStatus => ({
+  status,
+  components: {
+    db: { status, error },
+    redis: { status: "healthy" },
+    horizon: { status: "healthy" },
+    queues: { status: "healthy", details: { active: 0 } },
+    system: { status: "healthy" },
+  },
+  uptime: 1,
+  version: "v1",
+  timestamp: new Date(0).toISOString(),
+});
+
+describe("HealthService readiness cache", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    (HealthService as any).readinessCache = null;
+  });
+
+  it("keeps healthy readiness results cached for 5 seconds", async () => {
+    const performFullCheck = jest
+      .spyOn(HealthService as any, "performFullCheck")
+      .mockResolvedValue(createStatus("healthy"));
+
+    jest.spyOn(Date, "now").mockReturnValueOnce(1000).mockReturnValueOnce(5999);
+
+    await HealthService.checkReadiness();
+    await HealthService.checkReadiness();
+
+    expect(performFullCheck).toHaveBeenCalledTimes(1);
+    expect((HealthService as any).readinessCache.lastError).toBeNull();
+  });
+
+  it("expires unhealthy readiness results after 1 second and stores lastError", async () => {
+    const unhealthy = createStatus("unhealthy", "database unavailable");
+    const healthy = createStatus("healthy");
+    const performFullCheck = jest
+      .spyOn(HealthService as any, "performFullCheck")
+      .mockResolvedValueOnce(unhealthy)
+      .mockResolvedValueOnce(healthy);
+
+    jest
+      .spyOn(Date, "now")
+      .mockReturnValueOnce(1000)
+      .mockReturnValueOnce(1999)
+      .mockReturnValueOnce(2001);
+
+    const first = await HealthService.checkReadiness();
+    expect((HealthService as any).readinessCache.lastError).toBe(
+      "db: database unavailable",
+    );
+
+    const cached = await HealthService.checkReadiness();
+    const refreshed = await HealthService.checkReadiness();
+
+    expect(first.status).toBe("unhealthy");
+    expect(cached).toBe(first);
+    expect(refreshed.status).toBe("healthy");
+    expect(performFullCheck).toHaveBeenCalledTimes(2);
+    expect((HealthService as any).readinessCache.lastError).toBeNull();
+  });
+
+  it("does not cache readiness results when the full check throws", async () => {
+    const cachedHealthy = createStatus("healthy");
+    const recoveredHealthy = createStatus("healthy");
+    const performFullCheck = jest
+      .spyOn(HealthService as any, "performFullCheck")
+      .mockResolvedValueOnce(cachedHealthy)
+      .mockRejectedValueOnce(new Error("redis check crashed"))
+      .mockResolvedValueOnce(recoveredHealthy);
+
+    jest
+      .spyOn(Date, "now")
+      .mockReturnValueOnce(1000)
+      .mockReturnValueOnce(7000)
+      .mockReturnValueOnce(7001);
+
+    await HealthService.checkReadiness();
+    const thrownResult = await HealthService.checkReadiness();
+    const afterThrow = await HealthService.checkReadiness();
+
+    expect(thrownResult.status).toBe("unhealthy");
+    expect(thrownResult.components.redis.error).toBe("redis check crashed");
+    expect(afterThrow.status).toBe("healthy");
+    expect(performFullCheck).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/services/health.service.ts
+++ b/src/services/health.service.ts
@@ -40,9 +40,11 @@ export class HealthService {
   private static readinessCache: {
     status: DetailedHealthStatus;
     timestamp: number;
+    lastError: string | null;
   } | null = null;
 
-  private static readonly CACHE_TTL_MS = 5000;
+  private static readonly HEALTHY_CACHE_TTL_MS = 5000;
+  private static readonly UNHEALTHY_CACHE_TTL_MS = 1000;
 
   /**
    * GET /health/live
@@ -55,24 +57,79 @@ export class HealthService {
   /**
    * GET /health/ready
    * Readiness probe - checks critical dependencies.
-   * Cached for 5 seconds to prevent hammering.
+   * Cached briefly to prevent hammering while still detecting recovery quickly.
    */
   static async checkReadiness(): Promise<DetailedHealthStatus> {
     const now = Date.now();
     if (
       this.readinessCache &&
-      now - this.readinessCache.timestamp < this.CACHE_TTL_MS
+      now - this.readinessCache.timestamp <
+        this.getCacheTtl(this.readinessCache.status)
     ) {
       return this.readinessCache.status;
     }
 
-    const status = await this.performFullCheck();
+    let status: DetailedHealthStatus;
+    try {
+      status = await this.performFullCheck();
+    } catch (err: any) {
+      const lastError = err instanceof Error ? err.message : String(err);
+      logger.error("Readiness check threw an exception", { error: lastError });
+      return this.createUnhandledErrorStatus(lastError);
+    }
+
     this.readinessCache = {
       status,
       timestamp: now,
+      lastError: this.getHealthStatusError(status),
     };
 
     return status;
+  }
+
+  private static getCacheTtl(status: DetailedHealthStatus): number {
+    return status.status === "unhealthy"
+      ? this.UNHEALTHY_CACHE_TTL_MS
+      : this.HEALTHY_CACHE_TTL_MS;
+  }
+
+  private static getHealthStatusError(
+    status: DetailedHealthStatus,
+  ): string | null {
+    if (status.status === "healthy") {
+      return null;
+    }
+
+    return (
+      Object.entries(status.components)
+        .map(([name, component]) =>
+          component.error ? `${name}: ${component.error}` : undefined,
+        )
+        .find((error): error is string => Boolean(error)) ?? null
+    );
+  }
+
+  private static createUnhandledErrorStatus(
+    error: string,
+  ): DetailedHealthStatus {
+    const failedComponent: HealthComponent = {
+      status: "unhealthy",
+      error,
+    };
+
+    return {
+      status: "unhealthy",
+      components: {
+        db: failedComponent,
+        redis: failedComponent,
+        horizon: failedComponent,
+        queues: failedComponent,
+        system: this.getSystemInfo(),
+      },
+      uptime: process.uptime(),
+      version: config.server.apiVersion || CURRENT_VERSION,
+      timestamp: new Date().toISOString(),
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary
Fixes #388 by improving readiness health check cache behavior.

## Changes
- Wraps `performFullCheck()` in `try/catch`.
- Returns an uncached `unhealthy` readiness response when a full check throws.
- Keeps healthy/degraded readiness cache TTL at 5 seconds.
- Reduces unhealthy readiness cache TTL to 1 second for faster recovery detection.
- Adds `lastError` to readiness cache entries to distinguish cached healthy from cached unhealthy states.
- Adds unit tests for healthy cache TTL, unhealthy cache TTL, `lastError`, and exception handling.

## Testing
```bash
node --max-old-space-size=4096 ./node_modules/.bin/jest -c jest.unit.config.ts --runTestsByPath src/services/__tests__/health.service.unit.test.ts --runInBand
