### PR TITLE
fix(queues): standardize retry config to attempts=5, delay=2000ms (#407)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -224,3 +224,28 @@ Set `SECRETS_PROVIDER=vault`, `VAULT_ADDR`, `VAULT_TOKEN`, `VAULT_SECRET_PATH=se
 ---
 
 🔒 = sensitive — never logged, never included in error output, injected via secrets provider in production.
+
+---
+
+## Queue Retry Policy
+
+All BullMQ queues share a single `defaultJobOptions` defined in `src/config/queue.ts` (re-exported via `src/queues/queue.config.ts`).
+
+### Default (all queues unless overridden)
+
+| Setting | Value |
+|---------|-------|
+| `attempts` | `5` |
+| `backoff.type` | `exponential` |
+| `backoff.delay` | `2000 ms` |
+| Retry sequence | 2 s → 4 s → 8 s → 16 s → 32 s |
+| `removeOnComplete` | last 100 jobs |
+| `removeOnFail` | `false` (retained for dead-letter inspection) |
+
+### Per-queue overrides
+
+| Queue | `attempts` | `backoff.type` | `backoff.delay` | Reason |
+|-------|-----------|----------------|-----------------|--------|
+| `payment-poll-queue` | `20` | `fixed` | `30 000 ms` | Polls Stellar network every 30 s for up to 10 min |
+
+On startup the server logs the effective retry configuration for every registered queue (level: `info`, field: `queue retry config`).

--- a/src/config/queue.ts
+++ b/src/config/queue.ts
@@ -15,14 +15,18 @@ export const redisConnection: ConnectionOptions = {
 };
 
 /**
- * Default job options: 3 attempts, exponential backoff starting at 1 second.
+ * Default job options: 5 attempts, exponential backoff starting at 2 seconds.
+ * Sequence: 2s → 4s → 8s → 16s → 32s.
  * Failed jobs are retained for dead-letter inspection.
+ *
+ * Queue-level overrides:
+ *   - paymentPollQueue: attempts=20, fixed delay=30s (Stellar polling)
  */
 export const defaultJobOptions: DefaultJobOptions = {
-  attempts: 3,
+  attempts: 5,
   backoff: {
     type: "exponential",
-    delay: 1000, // 1s → 2s → 4s
+    delay: 2000, // 2s → 4s → 8s → 16s → 32s
   },
   removeOnComplete: { count: 100 },
   removeOnFail: false,

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,9 +23,7 @@ import app from "./app";
 import { createSocketServer } from "./config/socket";
 import { initializeSocketService } from "./services/socket.service";
 import { initializeGraphQL } from "./graphql/server";
-import {
-  stellarMonitorJob,
-} from "./jobs/stellarMonitor.job";
+import { stellarMonitorJob } from "./jobs/stellarMonitor.job";
 import {
   emailWorker,
   paymentWorker,
@@ -75,6 +73,25 @@ import("./services/jwks.service").then(({ JwksService }) =>
   ),
 );
 
+// Log effective retry configuration for each active queue
+import { defaultJobOptions, QUEUE_NAMES } from "./config/queue";
+const queueRetryOverrides: Record<
+  string,
+  { attempts: number; backoff: unknown }
+> = {
+  [QUEUE_NAMES.PAYMENT_POLL]: {
+    attempts: 20,
+    backoff: { type: "fixed", delay: 30_000 },
+  },
+};
+Object.values(QUEUE_NAMES).forEach((name) => {
+  const effective = queueRetryOverrides[name] ?? {
+    attempts: defaultJobOptions.attempts,
+    backoff: defaultJobOptions.backoff,
+  };
+  logger.info("Queue retry config", { queue: name, ...effective });
+});
+
 // Start background job workers and scheduler
 startScheduler().catch((err) => {
   logger.error("Failed to start job scheduler", { error: err });
@@ -111,9 +128,13 @@ stellarMonitorJob.start().catch((err) => {
 });
 
 // Start background exchange rate refresh (60s interval, cached in Redis)
-import('./services/assetExchange.service').then(({ AssetExchangeService }) => {
-  AssetExchangeService.startRateRefresh();
-}).catch((err) => logger.error('Failed to start asset exchange rate refresh', { error: err }));
+import("./services/assetExchange.service")
+  .then(({ AssetExchangeService }) => {
+    AssetExchangeService.startRateRefresh();
+  })
+  .catch((err) =>
+    logger.error("Failed to start asset exchange rate refresh", { error: err }),
+  );
 
 // Graceful shutdown
 async function shutdown(signal: string) {


### PR DESCRIPTION

  fix(queues): standardize BullMQ retry config — attempts=5, delay=2000ms
  
  Closes #407
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Description
  
  src/config/queue.ts (the single source of truth for all BullMQ configuration) had defaultJobOptions set to attempts: 3 with a 1 s exponential backoff,
  while src/queues/queue.config.ts (which re-exports from it) was documented with attempts: 5 and a 2 s backoff. Workers that consumed these options were
  therefore operating with inconsistent retry behaviour depending on which import path they traced — critical financial operations (escrow release) and
  non-critical operations (reports) had different effective retry counts with no intentional reason.
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Changes
  
  src/config/queue.ts
  
  - Updated defaultJobOptions.attempts from 3 → 5.
  - Updated defaultJobOptions.backoff.delay from 1000 → 2000 ms.
  - Retry sequence is now uniform across all queues: 2 s → 4 s → 8 s → 16 s → 32 s.
  - Added JSDoc comment explicitly calling out the paymentPollQueue override (attempts: 20, fixed 30 s delay) so future readers understand it is
  intentional.
  
  src/server.ts
  
  - Added a startup log block that iterates every registered queue name (QUEUE_NAMES) and logs its effective retry configuration at info level before
  workers start.
  - Per-queue overrides (currently only payment-poll-queue) are declared in a local map so the log reflects the real runtime values, not just the default.
  
  CONFIG.md
  
  - Added a new Queue Retry Policy section documenting:
    - The default attempts, backoff.type, backoff.delay, and full retry sequence.
    - removeOnComplete / removeOnFail retention policy.
    - A per-queue overrides table listing every queue that deviates from the default and the reason why.
    - A note that effective config is printed to the log on every server startup.
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Testing
  
  - npx tsc --noEmit passes (the only pre-existing error is an unrelated syntax issue in a test file).
  - No logic changes to worker processors — only the retry envelope is affected.
  - Escrow release and report workers now both use attempts: 5 / 2 s exponential backoff as intended.