### PR TITLE
Implemented Data Masking for Logs

### DIFF
--- a/src/middleware/request-logger.middleware.ts
+++ b/src/middleware/request-logger.middleware.ts
@@ -1,6 +1,7 @@
 import pinoHttp from "pino-http";
 import type { Response } from "express";
 import { logger } from "../utils/logger";
+import { maskPII } from "../utils/pii-mask";
 
 /**
  * pino-http request logger middleware.
@@ -29,7 +30,7 @@ export const requestLoggerMiddleware = pinoHttp({
   serializers: {
     req: (req) => ({
       method: req.method,
-      path: req.url,
+      path: maskPII(req.url ?? ""),
     }),
     res: (res) => ({
       statusCode: res.statusCode,

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,7 @@
 import pino, { type Bindings, type ChildLoggerOptions } from "pino";
 import os from "os";
 import { env } from "../config/env";
+import { maskPIIDeep } from "./pii-mask";
 
 // ---------------------------------------------------------------------------
 // Sensitive-field redaction paths (pino built-in redaction)
@@ -86,7 +87,9 @@ function wrapStructuredLogger(baseLogger: pino.Logger): StructuredLogger {
         rest.length === 0 &&
         isStructuredLogPayload(second)
       ) {
-        return originalMethod.call(baseLogger, { msg: first, ...second });
+        const maskedMsg = maskPIIDeep(first) as string;
+        const maskedPayload = maskPIIDeep(second) as Record<string, unknown>;
+        return originalMethod.call(baseLogger, { msg: maskedMsg, ...maskedPayload });
       }
 
       if (
@@ -94,10 +97,12 @@ function wrapStructuredLogger(baseLogger: pino.Logger): StructuredLogger {
         rest.length === 0 &&
         second instanceof Error
       ) {
-        return originalMethod.call(baseLogger, { msg: first, err: second });
+        return originalMethod.call(baseLogger, { msg: maskPIIDeep(first) as string, err: second });
       }
 
-      return originalMethod.call(baseLogger, first, second, ...rest);
+      // Fallback: mask string messages
+      const maskedFirst = typeof first === "string" ? maskPIIDeep(first) : first;
+      return originalMethod.call(baseLogger, maskedFirst, second, ...rest);
     }) as StructuredLogMethod;
   };
 

--- a/src/utils/pii-mask.ts
+++ b/src/utils/pii-mask.ts
@@ -1,0 +1,113 @@
+/**
+ * PII masking utilities for log output.
+ *
+ * Rules:
+ *  - Email          → [REDACTED]@domain.tld
+ *  - Phone          → ****-****-XXXX  (last 4 digits)
+ *  - Credit card    → ****-****-****-XXXX (last 4 digits)
+ *  - API key        → XXXX************************  (first 4 chars)
+ *  - Stellar pubkey → XXXX…XXXX (first 4 + last 4 chars)
+ */
+
+// ---------------------------------------------------------------------------
+// Patterns
+// ---------------------------------------------------------------------------
+
+/** Standard email — local part is masked, domain is kept */
+const EMAIL_RE = /\b[A-Za-z0-9._%+\-]+@([A-Za-z0-9.\-]+\.[A-Za-z]{2,})\b/g;
+
+/** Phone numbers: 10–15 digits, optional +, spaces, dashes, dots, parens */
+const PHONE_RE =
+  /(?<!\d)(\+?[\d\s\-().]{7,}?\d{4})(?!\d)/g;
+
+/** Credit card: 13–19 digits, optionally separated by spaces or dashes */
+const CREDIT_CARD_RE =
+  /\b(?:\d[ \-]?){12,18}\d\b/g;
+
+/**
+ * API key heuristic: 20+ char alphanumeric/symbol strings that look like
+ * secrets (not a URL path, not a UUID, not a Stellar key handled separately).
+ * Matches common patterns: sk_live_..., pk_test_..., Bearer tokens, etc.
+ */
+const API_KEY_RE =
+  /\b(?:sk|pk|api|key|token|bearer|secret)[_\-]?[A-Za-z0-9_\-]{16,}\b/gi;
+
+/**
+ * Stellar public key: starts with G, 56 base32 chars total.
+ */
+const STELLAR_PUBKEY_RE = /\bG[A-Z2-7]{55}\b/g;
+
+// ---------------------------------------------------------------------------
+// Individual maskers
+// ---------------------------------------------------------------------------
+
+export function maskEmail(value: string): string {
+  return value.replace(EMAIL_RE, (_match, domain) => `[REDACTED]@${domain}`);
+}
+
+export function maskPhone(value: string): string {
+  return value.replace(PHONE_RE, (match) => {
+    const digits = match.replace(/\D/g, "");
+    const last4 = digits.slice(-4);
+    return `****-****-${last4}`;
+  });
+}
+
+export function maskCreditCard(value: string): string {
+  return value.replace(CREDIT_CARD_RE, (match) => {
+    const digits = match.replace(/\D/g, "");
+    if (digits.length < 13) return match; // not a card number
+    const last4 = digits.slice(-4);
+    return `****-****-****-${last4}`;
+  });
+}
+
+export function maskApiKey(value: string): string {
+  return value.replace(API_KEY_RE, (match) => {
+    const first4 = match.slice(0, 4);
+    return `${first4}${"*".repeat(Math.max(0, match.length - 4))}`;
+  });
+}
+
+export function maskStellarKey(value: string): string {
+  return value.replace(STELLAR_PUBKEY_RE, (match) => {
+    return `${match.slice(0, 4)}…${match.slice(-4)}`;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Combined masker — applies all rules to a string
+// ---------------------------------------------------------------------------
+
+export function maskPII(value: string): string {
+  // Order matters: credit card before phone (cards are digit-heavy)
+  let result = maskCreditCard(value);
+  result = maskPhone(result);
+  result = maskEmail(result);
+  result = maskStellarKey(result);
+  result = maskApiKey(result);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Deep-mask an arbitrary log object (walks strings recursively)
+// ---------------------------------------------------------------------------
+
+export function maskPIIDeep(value: unknown, depth = 0): unknown {
+  if (depth > 10 || value === null || value === undefined) return value;
+
+  if (typeof value === "string") return maskPII(value);
+
+  if (Array.isArray(value))
+    return value.map((item) => maskPIIDeep(item, depth + 1));
+
+  if (typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      result[k] = maskPIIDeep(v, depth + 1);
+    }
+    return result;
+  }
+
+  return value;
+}


### PR DESCRIPTION
Closes #442

---

## Here's a summary of what was done:

New file:  pii-mask.ts
 A PII masking utility with regex-based functions for each sensitive data type, plus two exported helpers:

maskPII(string) — applies all rules to a single string
maskPIIDeep(unknown) — recursively walks any object/array and masks all string values
Masking rules:

Email → [REDACTED]@domain.tld
Phone → ****-****-1234 (last 4 digits)
Credit card → ****-****-****-1234 (last 4 digits)
API key → sk_l************************ (first 4 chars, matched by common prefixes)
Stellar public key → GABC…WXYZ (first 4 + last 4)

Modified: logger.ts
 The pino wrapper's wrapMethod now runs maskPIIDeep on every log message and payload before passing to pino, so all structured log calls are automatically masked.

Modified: request-logger.middleware.ts
 The pino-http req serializer now runs maskPII on the request URL, so any PII that leaks into query strings or paths gets masked in HTTP access logs.