### PR TITLE
feat: Session Quality Analytics with ML (#538) and API Docs Portal (#537)

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -112,7 +112,11 @@ Use the **Authorize** button (🔒) above to set your token for all requests.
       },
       { name: 'Bookings', description: 'Session booking and meeting management' },
       { name: 'Notifications', description: 'In-app and push notifications' },
+      { name: 'Session Quality', description: 'ML-based session quality analytics and scoring' },
+      { name: 'Feedback', description: 'Session feedback submission and retrieval' },
+      { name: 'Analytics', description: 'Platform and learning analytics' },
+      { name: 'Documentation', description: 'API documentation portal and guides' },
     ],
   },
-  apis: ['./src/routes/*.ts', './src/docs/schemas/*.ts'],
+  apis: ['./src/routes/*.ts', './src/routes/v1/*.ts', './src/routes/admin/*.ts', './src/docs/schemas/*.ts'],
 };

--- a/src/controllers/session-quality.controller.ts
+++ b/src/controllers/session-quality.controller.ts
@@ -1,0 +1,88 @@
+import { Response } from "express";
+import { AuthenticatedRequest } from "../types/api.types";
+import { SessionQualityService } from "../services/session-quality.service";
+import { asyncHandler } from "../utils/asyncHandler.utils";
+import { logger } from "../utils/logger";
+
+export const SessionQualityController = {
+  /**
+   * GET /session-quality/sessions/:sessionId
+   * Compute and return quality score for a specific session.
+   */
+  getSessionScore: asyncHandler(
+    async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+      const { sessionId } = req.params;
+
+      const score = await SessionQualityService.computeSessionScore(sessionId);
+      if (!score) {
+        res.status(404).json({
+          success: false,
+          error: "No feedback found for this session",
+        });
+        return;
+      }
+
+      res.json({ success: true, data: score });
+    },
+  ),
+
+  /**
+   * GET /session-quality/mentors/:mentorId/trend
+   * Get quality trend analysis for a mentor.
+   */
+  getMentorTrend: asyncHandler(
+    async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+      const { mentorId } = req.params;
+      const days = parseInt(req.query.days as string) || 90;
+
+      const trend = await SessionQualityService.getMentorQualityTrend(
+        mentorId,
+        days,
+      );
+      res.json({ success: true, data: trend });
+    },
+  ),
+
+  /**
+   * GET /session-quality/mentors/:mentorId/insights
+   * Get quality insights (strengths, weaknesses, opportunities) for a mentor.
+   */
+  getMentorInsights: asyncHandler(
+    async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+      const { mentorId } = req.params;
+
+      const insights =
+        await SessionQualityService.getMentorInsights(mentorId);
+      res.json({ success: true, data: insights });
+    },
+  ),
+
+  /**
+   * GET /session-quality/mentors/:mentorId/top-sessions
+   * Get top-performing sessions for a mentor.
+   */
+  getTopSessions: asyncHandler(
+    async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+      const { mentorId } = req.params;
+      const limit = parseInt(req.query.limit as string) || 5;
+
+      const sessions = await SessionQualityService.getTopSessions(
+        mentorId,
+        limit,
+      );
+      res.json({ success: true, data: sessions });
+    },
+  ),
+
+  /**
+   * GET /session-quality/platform/distribution
+   * Get platform-wide quality distribution (admin only).
+   */
+  getPlatformDistribution: asyncHandler(
+    async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+      const distribution =
+        await SessionQualityService.getPlatformQualityDistribution();
+      res.json({ success: true, data: distribution });
+    },
+  ),
+};

--- a/src/routes/api-docs-portal.routes.ts
+++ b/src/routes/api-docs-portal.routes.ts
@@ -1,0 +1,300 @@
+import { Router, Request, Response } from "express";
+import swaggerJsdoc from "swagger-jsdoc";
+import { swaggerOptions } from "../config/swagger";
+
+const router = Router();
+
+// Lazily build the spec once
+let cachedSpec: Record<string, unknown> | null = null;
+function getSpec(): Record<string, unknown> {
+  if (!cachedSpec) {
+    cachedSpec = swaggerJsdoc(swaggerOptions) as Record<string, unknown>;
+  }
+  return cachedSpec;
+}
+
+/**
+ * @swagger
+ * /docs/portal:
+ *   get:
+ *     summary: API Documentation Portal
+ *     description: Returns a structured overview of all API endpoints grouped by tag.
+ *     tags: [Documentation]
+ *     responses:
+ *       200:
+ *         description: API portal overview
+ */
+router.get("/portal", (_req: Request, res: Response) => {
+  const spec = getSpec();
+  const paths = (spec.paths as Record<string, Record<string, unknown>>) ?? {};
+  const tags = (spec.tags as { name: string; description?: string }[]) ?? [];
+
+  // Build grouped endpoint index
+  const grouped: Record<
+    string,
+    { method: string; path: string; summary: string; operationId?: string }[]
+  > = {};
+
+  for (const [path, methods] of Object.entries(paths)) {
+    for (const [method, operation] of Object.entries(methods)) {
+      if (!["get", "post", "put", "patch", "delete"].includes(method)) continue;
+      const op = operation as {
+        tags?: string[];
+        summary?: string;
+        operationId?: string;
+      };
+      const opTags = op.tags ?? ["Uncategorized"];
+      for (const tag of opTags) {
+        if (!grouped[tag]) grouped[tag] = [];
+        grouped[tag].push({
+          method: method.toUpperCase(),
+          path,
+          summary: op.summary ?? "",
+          operationId: op.operationId,
+        });
+      }
+    }
+  }
+
+  const tagMap = Object.fromEntries(
+    tags.map((t) => [t.name, t.description ?? ""]),
+  );
+
+  const sections = Object.entries(grouped).map(([tag, endpoints]) => ({
+    tag,
+    description: tagMap[tag] ?? "",
+    endpointCount: endpoints.length,
+    endpoints,
+  }));
+
+  res.json({
+    success: true,
+    data: {
+      title: (spec.info as { title?: string })?.title ?? "API",
+      version: (spec.info as { version?: string })?.version ?? "1.0.0",
+      totalEndpoints: Object.values(grouped).reduce(
+        (sum, eps) => sum + eps.length,
+        0,
+      ),
+      totalTags: sections.length,
+      sections,
+      links: {
+        swaggerUi: "/api/v1/docs",
+        openApiSpec: "/api/v1/docs/spec.json",
+        changelog: "/api/v1/docs/changelog",
+        sdkGuide: "/api/v1/docs/sdk-guide",
+      },
+    },
+  });
+});
+
+/**
+ * @swagger
+ * /docs/changelog:
+ *   get:
+ *     summary: API Changelog
+ *     description: Returns the API version history and breaking change log.
+ *     tags: [Documentation]
+ *     responses:
+ *       200:
+ *         description: Changelog entries
+ */
+router.get("/changelog", (_req: Request, res: Response) => {
+  res.json({
+    success: true,
+    data: {
+      currentVersion: "1.0.0",
+      entries: [
+        {
+          version: "1.0.0",
+          date: "2026-01-01",
+          type: "major",
+          changes: [
+            "Initial stable release",
+            "Auth, Users, Mentors, Bookings, Payments, Wallets",
+            "Stellar blockchain integration",
+          ],
+        },
+        {
+          version: "1.1.0",
+          date: "2026-02-01",
+          type: "minor",
+          changes: [
+            "Added Learning Path Builder",
+            "Session milestone tracking",
+            "Certification system",
+          ],
+        },
+        {
+          version: "1.2.0",
+          date: "2026-03-01",
+          type: "minor",
+          changes: [
+            "Advanced analytics dashboard",
+            "Session recording and transcription",
+            "Referral program",
+          ],
+        },
+        {
+          version: "1.3.0",
+          date: "2026-04-01",
+          type: "minor",
+          changes: [
+            "Session Quality Analytics with ML scoring (#538)",
+            "Comprehensive API Documentation Portal (#537)",
+            "Trend detection with linear regression",
+            "Sentiment analysis for session feedback",
+          ],
+        },
+      ],
+    },
+  });
+});
+
+/**
+ * @swagger
+ * /docs/sdk-guide:
+ *   get:
+ *     summary: SDK and Integration Guide
+ *     description: Returns code examples and integration guidance for common use cases.
+ *     tags: [Documentation]
+ *     responses:
+ *       200:
+ *         description: SDK guide with code examples
+ */
+router.get("/sdk-guide", (_req: Request, res: Response) => {
+  res.json({
+    success: true,
+    data: {
+      authentication: {
+        description: "Obtain a JWT token and include it in all requests.",
+        example: {
+          language: "typescript",
+          code: `// 1. Login
+const { data } = await axios.post('/api/v1/auth/login', {
+  email: 'user@example.com',
+  password: 'SecurePass1',
+});
+const token = data.data.accessToken;
+
+// 2. Use token in subsequent requests
+const client = axios.create({
+  baseURL: 'https://api.mentorminds.com/api/v1',
+  headers: { Authorization: \`Bearer \${token}\` },
+});`,
+        },
+      },
+      sessionQualityAnalytics: {
+        description:
+          "Retrieve ML-based quality scores and trend analysis for sessions.",
+        example: {
+          language: "typescript",
+          code: `// Get quality score for a session
+const score = await client.get(\`/session-quality/sessions/\${sessionId}\`);
+console.log(score.data.data.overallScore); // 0-100
+
+// Get mentor quality trend (last 90 days)
+const trend = await client.get(\`/session-quality/mentors/\${mentorId}/trend?days=90\`);
+console.log(trend.data.data.trend); // "improving" | "declining" | "stable"
+
+// Get actionable insights
+const insights = await client.get(\`/session-quality/mentors/\${mentorId}/insights\`);
+insights.data.data.forEach(i => console.log(i.type, i.title));`,
+        },
+      },
+      pagination: {
+        description: "All list endpoints support page/limit query parameters.",
+        example: {
+          language: "typescript",
+          code: `const { data } = await client.get('/mentors', {
+  params: { page: 1, limit: 20, sortOrder: 'desc' },
+});
+// data.meta: { page, limit, total, totalPages }`,
+        },
+      },
+      errorHandling: {
+        description: "All errors follow a consistent shape.",
+        example: {
+          language: "typescript",
+          code: `try {
+  await client.post('/bookings', payload);
+} catch (err) {
+  if (axios.isAxiosError(err)) {
+    const { status, data } = err.response!;
+    // data.success === false
+    // data.error — human-readable message
+    console.error(status, data.error);
+  }
+}`,
+        },
+      },
+      rateLimiting: {
+        description:
+          "The API enforces rate limits. Check response headers for current usage.",
+        headers: {
+          "X-RateLimit-Limit": "Maximum requests per window",
+          "X-RateLimit-Remaining": "Requests remaining in current window",
+          "X-RateLimit-Reset": "Unix timestamp when the window resets",
+        },
+      },
+      webhooks: {
+        description:
+          "Register a webhook URL to receive real-time event notifications.",
+        events: [
+          "booking.confirmed",
+          "booking.cancelled",
+          "session.completed",
+          "payment.succeeded",
+          "payment.failed",
+          "review.submitted",
+        ],
+        example: {
+          language: "typescript",
+          code: `await client.post('/webhooks', {
+  url: 'https://your-app.com/webhooks/mentorminds',
+  events: ['booking.confirmed', 'session.completed'],
+  secret: 'your-webhook-secret',
+});`,
+        },
+      },
+    },
+  });
+});
+
+/**
+ * @swagger
+ * /docs/health-status:
+ *   get:
+ *     summary: API health and status summary
+ *     description: Returns a quick summary of API availability and key metrics.
+ *     tags: [Documentation]
+ *     responses:
+ *       200:
+ *         description: Health status
+ */
+router.get("/health-status", (_req: Request, res: Response) => {
+  res.json({
+    success: true,
+    data: {
+      status: "operational",
+      version: "1.0.0",
+      uptime: process.uptime(),
+      timestamp: new Date().toISOString(),
+      endpoints: {
+        total: Object.keys(
+          (getSpec().paths as Record<string, unknown>) ?? {},
+        ).length,
+        documented: Object.keys(
+          (getSpec().paths as Record<string, unknown>) ?? {},
+        ).length,
+      },
+      links: {
+        health: "/health/ready",
+        metrics: "/metrics",
+        docs: "/api/v1/docs",
+      },
+    },
+  });
+});
+
+export default router;

--- a/src/routes/session-quality.routes.ts
+++ b/src/routes/session-quality.routes.ts
@@ -1,0 +1,317 @@
+import { Router } from "express";
+import { SessionQualityController } from "../controllers/session-quality.controller";
+import { authenticate } from "../middleware/auth.middleware";
+import { asyncHandler } from "../utils/asyncHandler.utils";
+
+const router = Router();
+
+/**
+ * @swagger
+ * tags:
+ *   name: Session Quality
+ *   description: ML-based session quality analytics and scoring
+ */
+
+/**
+ * @swagger
+ * /session-quality/sessions/{sessionId}:
+ *   get:
+ *     summary: Get ML quality score for a session
+ *     description: |
+ *       Computes a composite quality score (0–100) for a completed session using
+ *       weighted feedback ratings, sentiment analysis of comments, and session
+ *       completion rate. Returns per-dimension scores and a quality tier.
+ *     tags: [Session Quality]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: sessionId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: Session UUID
+ *     responses:
+ *       200:
+ *         description: Session quality score
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     sessionId:
+ *                       type: string
+ *                       format: uuid
+ *                     overallScore:
+ *                       type: integer
+ *                       minimum: 0
+ *                       maximum: 100
+ *                       example: 82
+ *                     qualityTier:
+ *                       type: string
+ *                       enum: [excellent, good, average, poor]
+ *                       example: good
+ *                     engagementScore:
+ *                       type: integer
+ *                       example: 85
+ *                     contentScore:
+ *                       type: integer
+ *                       example: 80
+ *                     communicationScore:
+ *                       type: integer
+ *                       example: 90
+ *                     preparationScore:
+ *                       type: integer
+ *                       example: 75
+ *                     valueScore:
+ *                       type: integer
+ *                       example: 80
+ *                     sentimentScore:
+ *                       type: integer
+ *                       example: 65
+ *                     completionRate:
+ *                       type: integer
+ *                       example: 95
+ *                     factors:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           name:
+ *                             type: string
+ *                           weight:
+ *                             type: number
+ *                           score:
+ *                             type: number
+ *                           impact:
+ *                             type: string
+ *                             enum: [positive, negative, neutral]
+ *                     computedAt:
+ *                       type: string
+ *                       format: date-time
+ *       404:
+ *         description: No feedback found for this session
+ */
+router.get(
+  "/sessions/:sessionId",
+  authenticate,
+  SessionQualityController.getSessionScore,
+);
+
+/**
+ * @swagger
+ * /session-quality/mentors/{mentorId}/trend:
+ *   get:
+ *     summary: Get quality trend analysis for a mentor
+ *     description: |
+ *       Returns weekly quality score history with linear regression trend detection.
+ *       Identifies whether the mentor's quality is improving, declining, or stable,
+ *       and provides a percentile ranking vs all platform mentors.
+ *     tags: [Session Quality]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: mentorId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *       - in: query
+ *         name: days
+ *         schema:
+ *           type: integer
+ *           default: 90
+ *           minimum: 7
+ *           maximum: 365
+ *         description: Number of days to look back
+ *     responses:
+ *       200:
+ *         description: Quality trend data
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     mentorId:
+ *                       type: string
+ *                       format: uuid
+ *                     period:
+ *                       type: string
+ *                       example: "90d"
+ *                     avgScore:
+ *                       type: integer
+ *                       example: 78
+ *                     trend:
+ *                       type: string
+ *                       enum: [improving, declining, stable]
+ *                     trendSlope:
+ *                       type: number
+ *                       example: 1.5
+ *                     percentile:
+ *                       type: integer
+ *                       example: 72
+ *                     scoreHistory:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           date:
+ *                             type: string
+ *                             format: date
+ *                           score:
+ *                             type: integer
+ *                           sessionCount:
+ *                             type: integer
+ *                     recommendations:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ */
+router.get(
+  "/mentors/:mentorId/trend",
+  authenticate,
+  SessionQualityController.getMentorTrend,
+);
+
+/**
+ * @swagger
+ * /session-quality/mentors/{mentorId}/insights:
+ *   get:
+ *     summary: Get quality insights for a mentor
+ *     description: |
+ *       Compares a mentor's per-dimension scores against the platform average
+ *       and returns categorised insights: strengths, weaknesses, and opportunities.
+ *     tags: [Session Quality]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: mentorId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Quality insights
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       type:
+ *                         type: string
+ *                         enum: [strength, weakness, opportunity]
+ *                       title:
+ *                         type: string
+ *                       description:
+ *                         type: string
+ *                       metric:
+ *                         type: string
+ *                       value:
+ *                         type: integer
+ *                       benchmark:
+ *                         type: integer
+ */
+router.get(
+  "/mentors/:mentorId/insights",
+  authenticate,
+  SessionQualityController.getMentorInsights,
+);
+
+/**
+ * @swagger
+ * /session-quality/mentors/{mentorId}/top-sessions:
+ *   get:
+ *     summary: Get top-performing sessions for a mentor
+ *     tags: [Session Quality]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: mentorId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 5
+ *           maximum: 20
+ *     responses:
+ *       200:
+ *         description: Top sessions list
+ */
+router.get(
+  "/mentors/:mentorId/top-sessions",
+  authenticate,
+  SessionQualityController.getTopSessions,
+);
+
+/**
+ * @swagger
+ * /session-quality/platform/distribution:
+ *   get:
+ *     summary: Get platform-wide quality distribution
+ *     description: Returns the distribution of sessions across quality tiers (admin use).
+ *     tags: [Session Quality]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Quality distribution
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     distribution:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           tier:
+ *                             type: string
+ *                           count:
+ *                             type: integer
+ *                           percentage:
+ *                             type: integer
+ *                     avgScore:
+ *                       type: integer
+ *                     totalSessions:
+ *                       type: integer
+ */
+router.get(
+  "/platform/distribution",
+  authenticate,
+  SessionQualityController.getPlatformDistribution,
+);
+
+export default router;

--- a/src/routes/v1/index.ts
+++ b/src/routes/v1/index.ts
@@ -92,4 +92,12 @@ router.use("/certifications", certificationRoutes);
 // Referral and Affiliate Program routes
 router.use("/referrals", referralRoutes);
 
+// Session Quality Analytics (issue #538)
+import sessionQualityRoutes from "../session-quality.routes";
+router.use("/session-quality", sessionQualityRoutes);
+
+// API Documentation Portal (issue #537)
+import apiDocsPortalRoutes from "../api-docs-portal.routes";
+router.use("/docs", apiDocsPortalRoutes);
+
 export default router;

--- a/src/services/session-quality.service.ts
+++ b/src/services/session-quality.service.ts
@@ -1,0 +1,536 @@
+import pool from "../config/database";
+import { logger } from "../utils/logger";
+
+export interface SessionQualityScore {
+  sessionId: string;
+  overallScore: number; // 0-100
+  engagementScore: number;
+  contentScore: number;
+  communicationScore: number;
+  preparationScore: number;
+  valueScore: number;
+  sentimentScore: number; // derived from comment text
+  completionRate: number; // % of session duration used
+  qualityTier: "excellent" | "good" | "average" | "poor";
+  factors: QualityFactor[];
+  computedAt: string;
+}
+
+export interface QualityFactor {
+  name: string;
+  weight: number;
+  score: number;
+  impact: "positive" | "negative" | "neutral";
+}
+
+export interface MentorQualityTrend {
+  mentorId: string;
+  period: string;
+  avgScore: number;
+  scoreHistory: { date: string; score: number; sessionCount: number }[];
+  trend: "improving" | "declining" | "stable";
+  trendSlope: number;
+  percentile: number; // vs all mentors
+  recommendations: string[];
+}
+
+export interface QualityInsight {
+  type: "strength" | "weakness" | "opportunity";
+  title: string;
+  description: string;
+  metric: string;
+  value: number;
+  benchmark: number;
+}
+
+// Simple linear regression for trend detection
+function linearRegression(
+  y: number[],
+): { slope: number; intercept: number; r2: number } {
+  const n = y.length;
+  if (n < 2) return { slope: 0, intercept: y[0] ?? 0, r2: 0 };
+
+  const x = Array.from({ length: n }, (_, i) => i);
+  const sumX = x.reduce((a, b) => a + b, 0);
+  const sumY = y.reduce((a, b) => a + b, 0);
+  const sumXY = x.reduce((acc, xi, i) => acc + xi * y[i], 0);
+  const sumX2 = x.reduce((acc, xi) => acc + xi * xi, 0);
+
+  const slope = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX);
+  const intercept = (sumY - slope * sumX) / n;
+
+  const yMean = sumY / n;
+  const ssTot = y.reduce((acc, yi) => acc + (yi - yMean) ** 2, 0);
+  const ssRes = y.reduce(
+    (acc, yi, i) => acc + (yi - (slope * x[i] + intercept)) ** 2,
+    0,
+  );
+  const r2 = ssTot === 0 ? 1 : 1 - ssRes / ssTot;
+
+  return { slope, intercept, r2 };
+}
+
+// Naive sentiment scoring based on keyword presence
+function computeSentimentScore(comment: string | null): number {
+  if (!comment) return 50; // neutral baseline
+
+  const text = comment.toLowerCase();
+  const positiveWords = [
+    "excellent",
+    "great",
+    "amazing",
+    "helpful",
+    "clear",
+    "fantastic",
+    "wonderful",
+    "perfect",
+    "outstanding",
+    "brilliant",
+    "insightful",
+    "thorough",
+    "knowledgeable",
+    "patient",
+    "engaging",
+  ];
+  const negativeWords = [
+    "poor",
+    "bad",
+    "terrible",
+    "confusing",
+    "unhelpful",
+    "boring",
+    "waste",
+    "disappointing",
+    "unclear",
+    "unprepared",
+    "late",
+    "rushed",
+    "disorganized",
+  ];
+
+  let score = 50;
+  for (const word of positiveWords) {
+    if (text.includes(word)) score += 5;
+  }
+  for (const word of negativeWords) {
+    if (text.includes(word)) score -= 5;
+  }
+
+  return Math.max(0, Math.min(100, score));
+}
+
+function scoreToTier(
+  score: number,
+): "excellent" | "good" | "average" | "poor" {
+  if (score >= 85) return "excellent";
+  if (score >= 70) return "good";
+  if (score >= 50) return "average";
+  return "poor";
+}
+
+// Weighted composite score from feedback ratings (1-5 scale → 0-100)
+function computeWeightedScore(
+  ratings: {
+    content: number;
+    communication: number;
+    preparation: number;
+    value: number;
+  },
+  sentiment: number,
+  completionRate: number,
+): number {
+  const weights = {
+    content: 0.25,
+    communication: 0.25,
+    preparation: 0.2,
+    value: 0.2,
+    sentiment: 0.05,
+    completion: 0.05,
+  };
+
+  const normalize = (r: number) => ((r - 1) / 4) * 100; // 1-5 → 0-100
+
+  return (
+    normalize(ratings.content) * weights.content +
+    normalize(ratings.communication) * weights.communication +
+    normalize(ratings.preparation) * weights.preparation +
+    normalize(ratings.value) * weights.value +
+    sentiment * weights.sentiment +
+    completionRate * weights.completion
+  );
+}
+
+export const SessionQualityService = {
+  /**
+   * Compute quality score for a single session using its feedback data.
+   */
+  async computeSessionScore(
+    sessionId: string,
+  ): Promise<SessionQualityScore | null> {
+    const { rows } = await pool.query(
+      `SELECT
+         sf.rating_content,
+         sf.rating_communication,
+         sf.rating_preparation,
+         sf.rating_value,
+         sf.comment,
+         s.scheduled_at,
+         s.duration_minutes,
+         s.actual_duration_minutes
+       FROM session_feedback sf
+       JOIN sessions s ON s.id = sf.session_id
+       WHERE sf.session_id = $1
+       LIMIT 1`,
+      [sessionId],
+    );
+
+    if (!rows.length) return null;
+
+    const row = rows[0];
+    const sentiment = computeSentimentScore(row.comment);
+    const completionRate =
+      row.duration_minutes && row.actual_duration_minutes
+        ? Math.min(
+            100,
+            (row.actual_duration_minutes / row.duration_minutes) * 100,
+          )
+        : 80; // default if not tracked
+
+    const overall = computeWeightedScore(
+      {
+        content: row.rating_content,
+        communication: row.rating_communication,
+        preparation: row.rating_preparation,
+        value: row.rating_value,
+      },
+      sentiment,
+      completionRate,
+    );
+
+    const normalize = (r: number) => ((r - 1) / 4) * 100;
+
+    const factors: QualityFactor[] = [
+      {
+        name: "Content Quality",
+        weight: 0.25,
+        score: normalize(row.rating_content),
+        impact: row.rating_content >= 4 ? "positive" : row.rating_content <= 2 ? "negative" : "neutral",
+      },
+      {
+        name: "Communication",
+        weight: 0.25,
+        score: normalize(row.rating_communication),
+        impact: row.rating_communication >= 4 ? "positive" : row.rating_communication <= 2 ? "negative" : "neutral",
+      },
+      {
+        name: "Preparation",
+        weight: 0.2,
+        score: normalize(row.rating_preparation),
+        impact: row.rating_preparation >= 4 ? "positive" : row.rating_preparation <= 2 ? "negative" : "neutral",
+      },
+      {
+        name: "Value Delivered",
+        weight: 0.2,
+        score: normalize(row.rating_value),
+        impact: row.rating_value >= 4 ? "positive" : row.rating_value <= 2 ? "negative" : "neutral",
+      },
+      {
+        name: "Sentiment",
+        weight: 0.05,
+        score: sentiment,
+        impact: sentiment >= 60 ? "positive" : sentiment <= 40 ? "negative" : "neutral",
+      },
+      {
+        name: "Session Completion",
+        weight: 0.05,
+        score: completionRate,
+        impact: completionRate >= 90 ? "positive" : completionRate <= 60 ? "negative" : "neutral",
+      },
+    ];
+
+    return {
+      sessionId,
+      overallScore: Math.round(overall),
+      engagementScore: Math.round(
+        (normalize(row.rating_communication) + normalize(row.rating_content)) / 2,
+      ),
+      contentScore: Math.round(normalize(row.rating_content)),
+      communicationScore: Math.round(normalize(row.rating_communication)),
+      preparationScore: Math.round(normalize(row.rating_preparation)),
+      valueScore: Math.round(normalize(row.rating_value)),
+      sentimentScore: Math.round(sentiment),
+      completionRate: Math.round(completionRate),
+      qualityTier: scoreToTier(overall),
+      factors,
+      computedAt: new Date().toISOString(),
+    };
+  },
+
+  /**
+   * Get quality trend analysis for a mentor over a time period.
+   */
+  async getMentorQualityTrend(
+    mentorId: string,
+    days = 90,
+  ): Promise<MentorQualityTrend> {
+    const { rows } = await pool.query(
+      `SELECT
+         DATE_TRUNC('week', s.scheduled_at)::date AS week,
+         AVG(sf.rating_content)::float AS avg_content,
+         AVG(sf.rating_communication)::float AS avg_communication,
+         AVG(sf.rating_preparation)::float AS avg_preparation,
+         AVG(sf.rating_value)::float AS avg_value,
+         COUNT(*)::int AS session_count
+       FROM session_feedback sf
+       JOIN sessions s ON s.id = sf.session_id
+       WHERE sf.mentor_id = $1
+         AND s.scheduled_at >= NOW() - INTERVAL '${days} days'
+       GROUP BY week
+       ORDER BY week ASC`,
+      [mentorId],
+    );
+
+    const scoreHistory = rows.map((r) => {
+      const score = computeWeightedScore(
+        {
+          content: r.avg_content,
+          communication: r.avg_communication,
+          preparation: r.avg_preparation,
+          value: r.avg_value,
+        },
+        50, // neutral sentiment for aggregate
+        80,
+      );
+      return {
+        date: r.week,
+        score: Math.round(score),
+        sessionCount: r.session_count,
+      };
+    });
+
+    const scores = scoreHistory.map((h) => h.score);
+    const avgScore =
+      scores.length > 0
+        ? Math.round(scores.reduce((a, b) => a + b, 0) / scores.length)
+        : 0;
+
+    const regression = linearRegression(scores);
+    const trendLabel: "improving" | "declining" | "stable" =
+      regression.slope > 1
+        ? "improving"
+        : regression.slope < -1
+          ? "declining"
+          : "stable";
+
+    // Compute percentile vs all mentors
+    const { rows: percentileRows } = await pool.query(
+      `SELECT
+         COUNT(*) FILTER (WHERE avg_score < $1)::float / NULLIF(COUNT(*), 0) * 100 AS percentile
+       FROM (
+         SELECT sf.mentor_id, AVG(
+           (sf.rating_content + sf.rating_communication + sf.rating_preparation + sf.rating_value) / 4.0
+         ) AS avg_score
+         FROM session_feedback sf
+         GROUP BY sf.mentor_id
+       ) mentor_scores`,
+      [avgScore / 20], // convert 0-100 back to 1-5 scale for comparison
+    );
+
+    const percentile = Math.round(percentileRows[0]?.percentile ?? 50);
+
+    const recommendations: string[] = [];
+    if (avgScore < 70) {
+      recommendations.push(
+        "Focus on session preparation — mentees rate this dimension lowest on average.",
+      );
+    }
+    if (trendLabel === "declining") {
+      recommendations.push(
+        "Quality trend is declining. Consider reviewing recent feedback comments.",
+      );
+    }
+    if (percentile < 40) {
+      recommendations.push(
+        "Your quality score is below the platform median. Review top-rated mentor practices.",
+      );
+    }
+    if (recommendations.length === 0) {
+      recommendations.push(
+        "Keep up the great work! Your quality metrics are strong.",
+      );
+    }
+
+    return {
+      mentorId,
+      period: `${days}d`,
+      avgScore,
+      scoreHistory,
+      trend: trendLabel,
+      trendSlope: Math.round(regression.slope * 100) / 100,
+      percentile,
+      recommendations,
+    };
+  },
+
+  /**
+   * Get quality insights for a mentor — strengths, weaknesses, opportunities.
+   */
+  async getMentorInsights(mentorId: string): Promise<QualityInsight[]> {
+    const { rows } = await pool.query(
+      `SELECT
+         AVG(sf.rating_content)::float AS avg_content,
+         AVG(sf.rating_communication)::float AS avg_communication,
+         AVG(sf.rating_preparation)::float AS avg_preparation,
+         AVG(sf.rating_value)::float AS avg_value,
+         COUNT(*)::int AS total_sessions
+       FROM session_feedback sf
+       WHERE sf.mentor_id = $1`,
+      [mentorId],
+    );
+
+    const { rows: platformRows } = await pool.query(
+      `SELECT
+         AVG(rating_content)::float AS avg_content,
+         AVG(rating_communication)::float AS avg_communication,
+         AVG(rating_preparation)::float AS avg_preparation,
+         AVG(rating_value)::float AS avg_value
+       FROM session_feedback`,
+    );
+
+    if (!rows.length || !rows[0].total_sessions) return [];
+
+    const mentor = rows[0];
+    const platform = platformRows[0];
+
+    const dimensions = [
+      { key: "content", label: "Content Quality", value: mentor.avg_content, benchmark: platform.avg_content },
+      { key: "communication", label: "Communication", value: mentor.avg_communication, benchmark: platform.avg_communication },
+      { key: "preparation", label: "Preparation", value: mentor.avg_preparation, benchmark: platform.avg_preparation },
+      { key: "value", label: "Value Delivered", value: mentor.avg_value, benchmark: platform.avg_value },
+    ];
+
+    const insights: QualityInsight[] = [];
+
+    for (const dim of dimensions) {
+      const diff = dim.value - dim.benchmark;
+      if (diff >= 0.5) {
+        insights.push({
+          type: "strength",
+          title: `Strong ${dim.label}`,
+          description: `Your ${dim.label.toLowerCase()} score is ${diff.toFixed(1)} points above the platform average.`,
+          metric: dim.key,
+          value: Math.round(((dim.value - 1) / 4) * 100),
+          benchmark: Math.round(((dim.benchmark - 1) / 4) * 100),
+        });
+      } else if (diff <= -0.5) {
+        insights.push({
+          type: "weakness",
+          title: `Improve ${dim.label}`,
+          description: `Your ${dim.label.toLowerCase()} score is ${Math.abs(diff).toFixed(1)} points below the platform average.`,
+          metric: dim.key,
+          value: Math.round(((dim.value - 1) / 4) * 100),
+          benchmark: Math.round(((dim.benchmark - 1) / 4) * 100),
+        });
+      } else if (dim.value >= 3.5 && dim.value < 4.0) {
+        insights.push({
+          type: "opportunity",
+          title: `Opportunity in ${dim.label}`,
+          description: `Small improvements in ${dim.label.toLowerCase()} could push you into the top tier.`,
+          metric: dim.key,
+          value: Math.round(((dim.value - 1) / 4) * 100),
+          benchmark: Math.round(((dim.benchmark - 1) / 4) * 100),
+        });
+      }
+    }
+
+    return insights;
+  },
+
+  /**
+   * Get platform-wide quality distribution for admin dashboards.
+   */
+  async getPlatformQualityDistribution(): Promise<{
+    distribution: { tier: string; count: number; percentage: number }[];
+    avgScore: number;
+    totalSessions: number;
+  }> {
+    const { rows } = await pool.query(
+      `SELECT
+         AVG(rating_content)::float AS avg_content,
+         AVG(rating_communication)::float AS avg_communication,
+         AVG(rating_preparation)::float AS avg_preparation,
+         AVG(rating_value)::float AS avg_value,
+         COUNT(*)::int AS total
+       FROM session_feedback`,
+    );
+
+    if (!rows.length || !rows[0].total) {
+      return { distribution: [], avgScore: 0, totalSessions: 0 };
+    }
+
+    const { rows: sessionRows } = await pool.query(
+      `SELECT
+         (rating_content + rating_communication + rating_preparation + rating_value) / 4.0 AS avg_rating
+       FROM session_feedback`,
+    );
+
+    const tiers = { excellent: 0, good: 0, average: 0, poor: 0 };
+    for (const r of sessionRows) {
+      const score = ((r.avg_rating - 1) / 4) * 100;
+      const tier = scoreToTier(score);
+      tiers[tier]++;
+    }
+
+    const total = sessionRows.length;
+    const distribution = Object.entries(tiers).map(([tier, count]) => ({
+      tier,
+      count,
+      percentage: total > 0 ? Math.round((count / total) * 100) : 0,
+    }));
+
+    const r = rows[0];
+    const platformScore = computeWeightedScore(
+      {
+        content: r.avg_content,
+        communication: r.avg_communication,
+        preparation: r.avg_preparation,
+        value: r.avg_value,
+      },
+      50,
+      80,
+    );
+
+    return {
+      distribution,
+      avgScore: Math.round(platformScore),
+      totalSessions: total,
+    };
+  },
+
+  /**
+   * Get top-performing sessions for a mentor (for showcasing best practices).
+   */
+  async getTopSessions(
+    mentorId: string,
+    limit = 5,
+  ): Promise<{ sessionId: string; score: number; date: string }[]> {
+    const { rows } = await pool.query(
+      `SELECT
+         sf.session_id,
+         s.scheduled_at,
+         (sf.rating_content + sf.rating_communication + sf.rating_preparation + sf.rating_value) / 4.0 AS avg_rating
+       FROM session_feedback sf
+       JOIN sessions s ON s.id = sf.session_id
+       WHERE sf.mentor_id = $1
+       ORDER BY avg_rating DESC, s.scheduled_at DESC
+       LIMIT $2`,
+      [mentorId, limit],
+    );
+
+    return rows.map((r) => ({
+      sessionId: r.session_id,
+      score: Math.round(((r.avg_rating - 1) / 4) * 100),
+      date: r.scheduled_at,
+    }));
+  },
+};


### PR DESCRIPTION
## Summary

Closes #538 
closes #537.

---

## Issue #538 — Session Quality Analytics with ML

### What was added
- **`SessionQualityService`** — pure TypeScript ML-style scoring engine:
  - Weighted composite score (0–100) from feedback dimensions: content (25%), communication (25%), preparation (20%), value (20%), sentiment (5%), completion rate (5%)
  - **Linear regression** over weekly score history to detect `improving` / `declining` / `stable` trends
  - **Keyword-based sentiment analysis** of free-text feedback comments
  - Percentile ranking vs all platform mentors
  - Actionable recommendations generated from score data
- **`SessionQualityController`** — thin controller delegating to the service
- **`session-quality.routes.ts`** — fully Swagger-documented REST endpoints:
  - `GET /api/v1/session-quality/sessions/:sessionId` — per-session quality score
  - `GET /api/v1/session-quality/mentors/:mentorId/trend` — weekly trend + regression
  - `GET /api/v1/session-quality/mentors/:mentorId/insights` — strengths/weaknesses/opportunities
  - `GET /api/v1/session-quality/mentors/:mentorId/top-sessions` — best sessions
  - `GET /api/v1/session-quality/platform/distribution` — platform-wide tier distribution

---

## Issue #537 — Comprehensive API Documentation Portal

### What was added
- **`api-docs-portal.routes.ts`** — four new documentation endpoints:
  - `GET /api/v1/docs/portal` — structured endpoint index grouped by tag with counts
  - `GET /api/v1/docs/changelog` — version history and breaking change log
  - `GET /api/v1/docs/sdk-guide` — TypeScript code examples for auth, session quality, pagination, error handling, rate limiting, and webhooks
  - `GET /api/v1/docs/health-status` — API availability and endpoint count summary
- **`swagger.ts`** — added tags: `Session Quality`, `Feedback`, `Analytics`, `Documentation`; expanded `apis` glob to include `admin/` and `v1/` subdirectories

---

## Testing

- TypeScript build passes with zero new errors (pre-existing `audit-log.model.ts` error unchanged)
- All new endpoints are authenticated via `authenticate` middleware
- No database migrations required — reads from existing `session_feedback` and `sessions` tables