### PR TITLE
fix(escrow): initialize all escrow fields and add integration test suite

### DIFF
--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -589,19 +589,6 @@ impl EscrowContract {
         session_end_time: u64,
         total_sessions: u32,
     ) -> u64 {
-            (Symbol::new(&env, "Escrow"), Symbol::new(&env, "Created"), count),
-            EscrowCreatedEventData {
-                escrow_id: count,
-                mentor,
-                learner,
-                amount,
-                session_id,
-                token_address,
-                session_end_time,
-            },
-        );
-
-        count
         Self::_create_escrow_internal(
             env,
             mentor,
@@ -616,7 +603,6 @@ impl EscrowContract {
             token_address,
             total_sessions,
         )
-
     }
 
     /// Release funds to the mentor (called by learner or admin).
@@ -700,24 +686,13 @@ impl EscrowContract {
             panic!("Caller not authorized");
         }
 
-        // Calculate amount to release: total_amount / total_sessions
-        // Note: For the last session, we release whatever is remaining to handle rounding.
-        let amount_to_release = if escrow.sessions_completed + 1 == escrow.total_sessions {
-            escrow.amount
-        } else {
-            // We use the original amount (quoted_token_amount) to calculate partials
-            // to ensure they are equal. But since 'amount' is what's currently held,
-            // and it might decrease if we were doing it differently, 
-            // the logic from Acceptance Criteria says "releases amount / total_sessions".
-            // I'll assume 'amount' here refers to the total locked amount at creation.
-            // Since we update escrow.amount in this implementation (based on line 258),
-            // we should probably use a fixed reference. 
-            // Actually, the existing release_partial (line 218) was taking an 'amount_to_release' arg.
-            // The NEW requirement says "release amount / total_sessions".
-            
-            // Let's use quoted_token_amount as the total original amount.
-            escrow.quoted_token_amount.checked_div(escrow.total_sessions as i128).expect("Division error")
-        };
+        // Divide remaining balance by remaining sessions so every release uses the
+        // same formula (avoids mixing quoted_token_amount with escrow.amount).
+        let remaining_sessions = (escrow.total_sessions - escrow.sessions_completed) as i128;
+        let amount_to_release = escrow
+            .amount
+            .checked_div(remaining_sessions)
+            .expect("Division error");
 
         let fee_bps: u32 = env.storage().persistent().get(&FEE_BPS).unwrap_or(0u32);
         env.storage()
@@ -1355,6 +1330,130 @@ impl EscrowContract {
             .get::<_, bool>(&key)
             .unwrap_or(false)
     }
+
+    fn load_escrow(env: &Env, key: &(Symbol, u64)) -> Escrow {
+        env.storage()
+            .persistent()
+            .get(key)
+            .expect("Escrow not found")
+    }
+
+    fn _create_escrow_internal(
+        env: Env,
+        mentor: Address,
+        learner: Address,
+        amount: i128,
+        session_id: Symbol,
+        token_address: Address,
+        session_end_time: u64,
+        usd_amount: i128,
+        quoted_token_amount: i128,
+        send_asset: Address,
+        dest_asset: Address,
+        total_sessions: u32,
+    ) -> u64 {
+        if amount <= 0 {
+            panic!("Amount must be greater than zero");
+        }
+        if total_sessions == 0 {
+            panic!("Total sessions must be greater than zero");
+        }
+        if !Self::_is_token_approved(&env, &token_address) {
+            panic!("Token not approved");
+        }
+
+        learner.require_auth();
+
+        let token_client = token::Client::new(&env, &token_address);
+        if token_client.balance(&learner) < amount {
+            panic!("Insufficient token balance");
+        }
+
+        let session_key = (SESSION_KEY, session_id.clone());
+        if env.storage().persistent().has(&session_key) {
+            panic!("Session already has an escrow");
+        }
+        env.storage().persistent().set(&session_key, &true);
+        env.storage()
+            .persistent()
+            .extend_ttl(&session_key, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+
+        let mut count: u64 = env.storage().persistent().get(&ESCROW_COUNT).unwrap_or(0);
+        count += 1;
+        env.storage().persistent().set(&ESCROW_COUNT, &count);
+        env.storage()
+            .persistent()
+            .extend_ttl(&ESCROW_COUNT, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+
+        token_client.transfer(&learner, &env.current_contract_address(), &amount);
+
+        let auto_release_delay: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AutoRelDelay)
+            .unwrap_or(DEFAULT_AUTO_RELEASE_DELAY);
+
+        let escrow = Escrow {
+            id: count,
+            mentor: mentor.clone(),
+            learner: learner.clone(),
+            amount,
+            session_id: session_id.clone(),
+            status: EscrowStatus::Active,
+            created_at: env.ledger().timestamp(),
+            token_address: token_address.clone(),
+            platform_fee: 0,
+            net_amount: 0,
+            session_end_time,
+            auto_release_delay,
+            dispute_reason: symbol_short!(""),
+            resolved_at: 0,
+            usd_amount,
+            quoted_token_amount,
+            send_asset,
+            dest_asset,
+            total_sessions,
+            sessions_completed: 0,
+        };
+        let key = (symbol_short!("ESCROW"), count);
+        env.storage().persistent().set(&key, &escrow);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+
+        let mentor_key = (MENTOR_ESCROWS, mentor.clone());
+        let mut mentor_escrows: Vec<u64> =
+            env.storage().persistent().get(&mentor_key).unwrap_or(Vec::new(&env));
+        mentor_escrows.push_back(count);
+        env.storage().persistent().set(&mentor_key, &mentor_escrows);
+        env.storage()
+            .persistent()
+            .extend_ttl(&mentor_key, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+
+        let learner_key = (LEARNER_ESCROWS, learner.clone());
+        let mut learner_escrows: Vec<u64> =
+            env.storage().persistent().get(&learner_key).unwrap_or(Vec::new(&env));
+        learner_escrows.push_back(count);
+        env.storage().persistent().set(&learner_key, &learner_escrows);
+        env.storage()
+            .persistent()
+            .extend_ttl(&learner_key, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
+
+        env.events().publish(
+            (Symbol::new(&env, "Escrow"), Symbol::new(&env, "Created"), count),
+            EscrowCreatedEventData {
+                escrow_id: count,
+                mentor,
+                learner,
+                amount,
+                session_id,
+                token_address,
+                session_end_time,
+            },
+        );
+
+        count
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1446,100 +1545,6 @@ mod test {
         }
         panic!("Escrow not found");
     }
-    fn _create_escrow_internal(
-        env: Env,
-        contract_id: Address,
-        admin: Address,
-        mentor: Address,
-        learner: Address,
-        treasury: Address,
-        token_address: Address,
-        session_end_time: u64,
-        usd_amount: i128,
-        quoted_token_amount: i128,
-        send_asset: Address,
-        dest_asset: Address,
-        total_sessions: u32,
-    ) -> u64 {
-        if amount <= 0 {
-            panic!("Amount must be greater than zero");
-        }
-        if !Self::_is_token_approved(&env, &token_address) {
-            panic!("Token not approved");
-        }
-
-        fn client(&self) -> EscrowContractClient {
-            EscrowContractClient::new(&self.env, &self.contract_id)
-        }
-        fn token(&self) -> TokenClient {
-            TokenClient::new(&self.env, &self.token_address)
-        }
-        fn sac(&self) -> StellarAssetClient {
-            StellarAssetClient::new(&self.env, &self.token_address)
-        }
-
-        fn create_escrow_at(&self, amount: i128, session_end_time: u64) -> u64 {
-            self.client().create_escrow(
-                &self.mentor,
-                &self.learner,
-                &amount,
-                &symbol_short!("S1"),
-                &self.token_address,
-                &session_end_time,
-            )
-        }
-
-        fn open_dispute(&self, escrow_id: u64) {
-            self.client()
-                .dispute(&self.learner, &escrow_id, &symbol_short!("NO_SHOW"));
-        }
-        env.storage().persistent().set(&session_key, &true);
-        let mut count: u64 = env.storage().persistent().get(&ESCROW_COUNT).unwrap_or(0);
-        count += 1;
-        env.storage().persistent().set(&ESCROW_COUNT, &count);
-        token_client.transfer(&learner, &env.current_contract_address(), &amount);
-        let escrow = Escrow {
-            id: count,
-            mentor: mentor.clone(),
-            learner: learner.clone(),
-            amount,
-            session_id: session_id.clone(),
-            status: EscrowStatus::Active,
-            created_at: env.ledger().timestamp(),
-            token_address: token_address.clone(),
-            platform_fee: 0,
-            net_amount: 0,
-            session_end_time,
-            auto_release_delay,
-            dispute_reason: symbol_short!(""),
-            resolved_at: 0,
-            usd_amount,
-            quoted_token_amount,
-            send_asset,
-            dest_asset,
-            total_sessions,
-            sessions_completed: 0,
-        };
-        let key = (symbol_short!("ESCROW"), count);
-        env.storage().persistent().set(&key, &escrow);
-
-        // Update index maps
-        let mentor_key = (MENTOR_ESCROWS, mentor.clone());
-        let mut mentor_escrows: Vec<u64> = env.storage().persistent().get(&mentor_key).unwrap_or(Vec::new(&env));
-        mentor_escrows.push_back(count);
-        env.storage().persistent().set(&mentor_key, &mentor_escrows);
-        env.storage().persistent().extend_ttl(&mentor_key, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
-
-        let learner_key = (LEARNER_ESCROWS, learner.clone());
-        let mut learner_escrows: Vec<u64> = env.storage().persistent().get(&learner_key).unwrap_or(Vec::new(&env));
-        learner_escrows.push_back(count);
-        env.storage().persistent().set(&learner_key, &learner_escrows);
-        env.storage().persistent().extend_ttl(&learner_key, ESCROW_TTL_THRESHOLD, ESCROW_TTL_BUMP);
-
-        env.events().publish((symbol_short!("created"), count), (mentor, learner, amount, token_address));
-        count
-    }
-
     fn setup_disputed(f: &TestFixture) -> u64 {
         let id = f.create_escrow_at(1_000, 0);
         f.open_dispute(id);

--- a/src/__tests__/factories/index.ts
+++ b/src/__tests__/factories/index.ts
@@ -1,0 +1,5 @@
+export * from "./user.factory";
+export * from "./mentor.factory";
+export * from "./booking.factory";
+export * from "./payment.factory";
+export * from "./review.factory";

--- a/src/__tests__/integration/full-flow.integration.test.ts
+++ b/src/__tests__/integration/full-flow.integration.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Comprehensive integration tests covering the full mentoring journey:
+ * registration → mentor profile → search → booking → payment → session → escrow release.
+ */
+import { testPool } from "../setup/testDb";
+import { stellarService } from "../../services/stellar.service";
+import { SorobanEscrowService } from "../../services/sorobanEscrow.service";
+import { EscrowModel } from "../../models/escrow.model";
+import {
+  registerUser,
+  createMentorProfile,
+  searchMentors,
+  createBooking,
+  initiatePayment,
+  confirmPayment,
+  completeSession,
+  releaseEscrow,
+} from "./helpers/flow.helpers";
+import { createBooking as createBookingFactory } from "../factories/booking.factory";
+import { createPayment } from "../factories/payment.factory";
+
+jest.mock("../../services/stellar.service");
+jest.mock("../../services/socket.service");
+jest.mock("../../services/sorobanEscrow.service", () => ({
+  SorobanEscrowService: {
+    isConfigured: jest.fn().mockReturnValue(false),
+    createEscrow: jest.fn(),
+    releaseFunds: jest.fn(),
+    startPendingEscrowMonitoring: jest.fn(),
+  },
+}));
+
+const mockStellarService = stellarService as jest.Mocked<typeof stellarService>;
+
+describe("Complete Mentoring Flow", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should complete full booking and payment flow", async () => {
+    const mentor = await registerUser({ role: "mentor" });
+    const mentee = await registerUser({ role: "mentee" });
+
+    await createMentorProfile(mentor.userId);
+
+    const results = await searchMentors(mentee.token, { skill: "JavaScript" });
+    expect(results.mentors.length).toBeGreaterThan(0);
+
+    const foundMentor = results.mentors.find((m) => m.id === mentor.userId);
+    expect(foundMentor).toBeDefined();
+
+    const booking = await createBooking(mentee.userId, mentor.userId);
+    expect(booking.mentee_id).toBe(mentee.userId);
+    expect(booking.mentor_id).toBe(mentor.userId);
+
+    const payment = await initiatePayment(
+      mentee.userId,
+      booking.id,
+      booking.amount,
+    );
+    expect(payment.status).toBe("pending");
+
+    const txHash = "integration-tx-hash-complete-flow";
+    mockStellarService.getTransaction.mockResolvedValue({
+      successful: true,
+      hash: txHash,
+      source_account: "GABC123",
+    } as any);
+    mockStellarService.getTransactionOperations.mockResolvedValue([
+      { type: "payment", amount: booking.amount },
+    ] as any);
+
+    const confirmed = await confirmPayment(payment.id, mentee.userId, txHash);
+    expect(confirmed.status).toBe("completed");
+
+    const escrow = await EscrowModel.create({
+      learnerId: mentee.userId,
+      mentorId: mentor.userId,
+      amount: booking.amount,
+      currency: "XLM",
+      description: booking.topic,
+    });
+    await EscrowModel.updateStatus(escrow.id, "funded");
+
+    const completed = await completeSession(mentor.userId, booking.id);
+    expect(completed.status).toBe("completed");
+
+    const release = await releaseEscrow(escrow.id, mentee.userId);
+    expect(release.status).toBe("released");
+  });
+});
+
+describe("Payment Flow Integration", () => {
+  it("should initiate, confirm, and refund a payment end-to-end", async () => {
+    const { booking, mentee } = await createBookingFactory({
+      paymentStatus: "unpaid",
+      status: "pending",
+    });
+
+    const payment = await initiatePayment(
+      mentee.id,
+      booking.id,
+      booking.amount,
+    );
+    expect(payment.booking_id).toBe(booking.id);
+
+    const txHash = "integration-refund-flow-tx";
+    mockStellarService.getTransaction.mockResolvedValue({
+      successful: true,
+      hash: txHash,
+      source_account: "GABC123",
+    } as any);
+    mockStellarService.getTransactionOperations.mockResolvedValue([
+      { type: "payment", amount: booking.amount },
+    ] as any);
+
+    await confirmPayment(payment.id, mentee.id, txHash);
+
+    const refunded = await (
+      await import("../../services/payments.service")
+    ).PaymentsService.refundPayment(payment.id, mentee.id, "Integration test refund");
+
+    expect(refunded.status).toBe("refunded");
+
+    const bookingRow = await testPool.query(
+      "SELECT payment_status FROM bookings WHERE id = $1",
+      [booking.id],
+    );
+    expect(bookingRow.rows[0].payment_status).toBe("refunded");
+  });
+});
+
+describe("Database Integration", () => {
+  it("should persist booking and payment records via factories", async () => {
+    const { booking, mentor, mentee } = await createBookingFactory();
+    const { payment } = await createPayment({
+      userId: mentee.id,
+      amount: parseFloat(booking.amount),
+      status: "completed",
+    });
+
+    const bookingRow = await testPool.query(
+      "SELECT * FROM bookings WHERE id = $1",
+      [booking.id],
+    );
+    const paymentRow = await testPool.query(
+      "SELECT * FROM transactions WHERE id = $1",
+      [payment.id],
+    );
+
+    expect(bookingRow.rows[0].mentor_id).toBe(mentor.id);
+    expect(bookingRow.rows[0].mentee_id).toBe(mentee.id);
+    expect(paymentRow.rows[0].user_id).toBe(mentee.id);
+  });
+});
+
+describe("Blockchain Interaction (mocked)", () => {
+  it("should skip on-chain calls when Soroban is not configured", async () => {
+    expect(SorobanEscrowService.isConfigured()).toBe(false);
+
+    const mentor = await registerUser({ role: "mentor" });
+    const mentee = await registerUser({ role: "mentee" });
+    const booking = await createBooking(mentee.userId, mentor.userId);
+
+    const payment = await initiatePayment(
+      mentee.userId,
+      booking.id,
+      booking.amount,
+    );
+
+    expect(payment).toBeDefined();
+    expect(SorobanEscrowService.createEscrow).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/integration/helpers/flow.helpers.ts
+++ b/src/__tests__/integration/helpers/flow.helpers.ts
@@ -1,0 +1,126 @@
+/**
+ * Shared helpers for end-to-end integration tests.
+ */
+import { AuthService } from "../../../services/auth.service";
+import { MentorsService } from "../../../services/mentors.service";
+import { SearchService } from "../../../services/search.service";
+import { BookingsService } from "../../../services/bookings.service";
+import { PaymentsService } from "../../../services/payments.service";
+import { EscrowApiService } from "../../../services/escrow-api.service";
+import { testPool } from "../../setup/testDb";
+
+export interface RegisteredUser {
+  userId: string;
+  token: string;
+  email: string;
+}
+
+export async function registerUser(input: {
+  role: "mentor" | "mentee";
+  email?: string;
+}): Promise<RegisteredUser> {
+  const email =
+    input.email ??
+    `${input.role}-${Date.now()}-${Math.random().toString(36).slice(2)}@test.com`;
+
+  const result = await AuthService.register({
+    email,
+    password: "TestPassword123!",
+    firstName: "Test",
+    lastName: input.role === "mentor" ? "Mentor" : "Mentee",
+    role: input.role,
+  });
+
+  return {
+    userId: result.userId,
+    token: result.accessToken,
+    email,
+  };
+}
+
+export async function createMentorProfile(userId: string): Promise<void> {
+  const profile = await MentorsService.createProfile(userId, {
+    bio: "Experienced JavaScript mentor",
+    hourlyRate: 50,
+    expertise: ["JavaScript", "TypeScript", "Node.js"],
+    yearsOfExperience: 5,
+    timezone: "UTC",
+  });
+
+  if (!profile) {
+    throw new Error("Failed to create mentor profile");
+  }
+}
+
+export async function searchMentors(
+  _token: string,
+  filters: { skill?: string } = {},
+) {
+  return SearchService.searchMentors({
+    query: filters.skill ?? "",
+    skills: filters.skill,
+    page: 1,
+    limit: 10,
+  });
+}
+
+export async function createBooking(
+  menteeId: string,
+  mentorId: string,
+  topic = "JavaScript mentoring session",
+) {
+  const scheduledAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+
+  const booking = await BookingsService.createBooking({
+    menteeId,
+    mentorId,
+    scheduledAt,
+    durationMinutes: 60,
+    topic,
+  });
+
+  await testPool.query(
+    `UPDATE bookings SET status = 'confirmed', payment_status = 'pending' WHERE id = $1`,
+    [booking.id],
+  );
+
+  return { ...booking, status: "confirmed" as const };
+}
+
+export async function initiatePayment(
+  userId: string,
+  bookingId: string,
+  amount: string,
+) {
+  return PaymentsService.initiatePayment({
+    userId,
+    bookingId,
+    amount,
+    currency: "XLM",
+    description: "Mentoring session payment",
+  });
+}
+
+export async function confirmPayment(
+  paymentId: string,
+  userId: string,
+  txHash: string,
+) {
+  return PaymentsService.confirmPayment(paymentId, userId, txHash);
+}
+
+export async function completeSession(mentorId: string, bookingId: string) {
+  await testPool.query(
+    `UPDATE bookings
+     SET scheduled_at = NOW() - INTERVAL '2 hours',
+         duration_minutes = 60
+     WHERE id = $1`,
+    [bookingId],
+  );
+
+  return BookingsService.completeBooking(bookingId, mentorId);
+}
+
+export async function releaseEscrow(escrowId: string, userId: string) {
+  return EscrowApiService.releaseEscrow(escrowId, userId);
+}


### PR DESCRIPTION
## Summary

closes #581
closes #583 
closes #584 
closes #585


Fixes four open-source issues in MentorsMind-Backend covering escrow contract bugs and integration test coverage.

### Task 1 & 4 — `create_escrow` missing struct fields
- Removed broken inline `Escrow` construction in `create_escrow` that omitted `usd_amount`, `quoted_token_amount`, `send_asset`, `dest_asset`, `total_sessions`, and `sessions_completed`
- Added canonical `_create_escrow_internal` helper that always initializes every `Escrow` field
- All entry points (`create_escrow`, `create_escrow_usd`, `create_escrow_with_path_payment`) now route through the shared internal function

### Task 3 — `release_partial` inconsistent per-session amounts
- Fixed per-session calculation to divide **remaining balance by remaining sessions** instead of mixing `quoted_token_amount / total_sessions` with `escrow.amount` on the final session
- Eliminates rounding inconsistencies across multi-session escrow packages

### Task 2 — Comprehensive integration test suite
- Added `full-flow.integration.test.ts` covering:
  - Full user journey: register → mentor profile → search → booking → payment → session completion → escrow release
  - Payment initiation, confirmation, and refund flows
  - Database persistence via test factories
  - Mocked blockchain interaction tests (Soroban/Stellar)
- Added reusable flow helpers and factory index exports

## Test plan
- [ ] Run escrow contract unit tests: `cargo test -p escrow`
- [ ] Run integration tests: `npm run test:integration -- full-flow.integration.test.ts`
- [ ] Verify `create_escrow` stores all fields via `get_escrow`
- [ ] Verify `release_partial` on a 3-session package releases equal per-session amounts