### PR TITLE
Migrate job processing to BullMQ with prioritization and retry improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "prom-client": "^15.1.3",
         "qrcode": "^1.5.4",
         "rate-limit-redis": "^4.3.1",
-        "socket.io": "^4.8.1",
+        "socket.io": "^4.8.0",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
         "uuid": "^13.0.0",
@@ -187,7 +187,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1777,7 +1776,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2308,7 +2306,6 @@
       "resolved": "https://registry.npmjs.org/@bull-board/ui/-/ui-6.20.6.tgz",
       "integrity": "sha512-nEXRgMHHd48ssINgvDqT7b4p/+57XRf3CUcTGQ7UIJb4F7n/kRRj8+ZQvQmMFsYGdNmbNU2eNheQ05vXSYiqdQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bull-board/api": "6.20.6"
       }
@@ -3323,7 +3320,6 @@
       "integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "30.3.0",
         "@jest/expect": "30.3.0",
@@ -3735,7 +3731,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3818,7 +3813,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
       "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -3831,7 +3825,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
       "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -5097,7 +5090,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
       "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
@@ -5144,7 +5136,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -7474,7 +7465,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -7940,7 +7930,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -8517,7 +8506,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9330,7 +9318,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10922,7 +10909,6 @@
       "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -11258,7 +11244,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -11302,7 +11287,6 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
       "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ip-address": "10.1.0"
       },
@@ -12388,7 +12372,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
       "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -13182,7 +13165,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -15796,7 +15778,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -17406,7 +17387,6 @@
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
       "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "~4.4.1",
         "ws": "~8.18.3"
@@ -18692,7 +18672,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -18901,7 +18880,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/config/queue.ts
+++ b/src/config/queue.ts
@@ -54,6 +54,37 @@ export const QUEUE_NAMES = {
 
 export type QueueName = (typeof QUEUE_NAMES)[keyof typeof QUEUE_NAMES];
 
+export enum JobType {
+  EMAIL = "email",
+  PAYMENT = "payment",
+  NOTIFICATION = "notification",
+  REPORT = "report",
+  ANALYTICS = "analytics",
+  BLOCKCHAIN = "blockchain",
+}
+
+export interface JobBackoffConfig {
+  type: 'fixed' | 'exponential';
+  delay: number;
+}
+
+export interface JobConfig {
+  name: string;
+  priority?: number;
+  attempts?: number;
+  backoff?: JobBackoffConfig;
+  timeout?: number;
+  removeOnComplete?: boolean | { count: number };
+  removeOnFail?: boolean | { count: number };
+}
+
+export const JOB_RATE_LIMITS = {
+  EMAIL: { max: 60, duration: 60_000 },
+  NOTIFICATIONS: { max: 120, duration: 60_000 },
+} as const;
+
+export type JobRateLimit = (typeof JOB_RATE_LIMITS)[keyof typeof JOB_RATE_LIMITS];
+
 /** Worker concurrency per queue. */
 export const CONCURRENCY = {
   EMAIL: 10,

--- a/src/queues/email.queue.ts
+++ b/src/queues/email.queue.ts
@@ -1,10 +1,7 @@
-import { Queue } from 'bullmq';
-import {
-  redisConnection,
-  defaultJobOptions,
-  QUEUE_NAMES,
-} from './queue.config';
+import { traceStore } from '../middleware/tracing.middleware';
 import type { EmailRequest } from '../services/email.service';
+import { createManagedQueue, buildJobOptions, JobConfig } from './queue.manager';
+import { JOB_RATE_LIMITS, QUEUE_NAMES } from './queue.config';
 
 export interface EmailJobData extends EmailRequest {
   jobType: 'send-email';
@@ -12,31 +9,33 @@ export interface EmailJobData extends EmailRequest {
   correlationId?: string;
 }
 
-export const emailQueue = new Queue<EmailJobData>(QUEUE_NAMES.EMAIL, {
-  connection: redisConnection,
-  defaultJobOptions,
+export const emailQueue = createManagedQueue<EmailJobData>(QUEUE_NAMES.EMAIL, {
+  limiter: JOB_RATE_LIMITS.EMAIL,
 });
-
-import { traceStore } from '../middleware/tracing.middleware';
 
 /**
  * Enqueue an email send job.
  * @param data - Email request payload
- * @param priority - Optional BullMQ priority (lower = higher priority)
+ * @param priorityOrConfig - Optional BullMQ priority or advanced job config
  */
 export async function enqueueEmail(
   data: EmailRequest,
-  priority?: number,
+  priorityOrConfig?: number | Partial<JobConfig>,
 ): Promise<void> {
+  const options: Partial<JobConfig> =
+    typeof priorityOrConfig === 'number'
+      ? { priority: priorityOrConfig }
+      : priorityOrConfig ?? {};
+
   const context = traceStore.getStore();
   await emailQueue.add(
-    'send-email',
-    { 
-      ...data, 
+    options.name ?? 'send-email',
+    {
+      ...data,
       jobType: 'send-email',
       requestId: context?.requestId,
       correlationId: context?.correlationId,
     },
-    { priority },
+    buildJobOptions(options),
   );
 }

--- a/src/queues/export.queue.ts
+++ b/src/queues/export.queue.ts
@@ -1,5 +1,6 @@
-import { Queue, Worker, Job } from 'bullmq';
-import config from '../config';
+import { Worker, Job } from 'bullmq';
+import { createManagedQueue, enableJobResultCache } from './queue.manager';
+import { QUEUE_NAMES, redisConnection } from './queue.config';
 import { ExportService } from '../services/export.service';
 import { EarningsReportService } from '../services/earningsReport.service';
 import { ExportJobModel } from '../models/export-job.model';
@@ -7,22 +8,25 @@ import { AuditLoggerService } from '../services/audit-logger.service';
 import { LogLevel } from '../utils/log-formatter.utils';
 import { logger } from '../utils/logger';
 
-const redisUrl = config.redis.url || 'redis://localhost:6379';
-const url = new URL(redisUrl);
+export interface ExportJobData {
+  userId: string;
+  jobId: string;
+  type?: 'earnings-export' | 'data-export';
+  format?: string;
+  period?: string;
+  startDate?: string;
+  endDate?: string;
+}
 
-const connection = {
-  host: url.hostname,
-  port: parseInt(url.port, 10) || 6379,
-  password: url.password || undefined,
-};
-
-export const exportQueue = new Queue("export-queue", { connection });
+export const exportQueue = createManagedQueue<ExportJobData>(QUEUE_NAMES.EXPORT);
+// Cache export job results for monitoring and UI lookups.
+enableJobResultCache(exportQueue, 3600);
 
 export const exportWorker = new Worker(
-  "export-queue",
-  async (job: Job) => {
+  QUEUE_NAMES.EXPORT,
+  async (job: Job<ExportJobData>) => {
     const { userId, jobId, type } = job.data;
-    
+
     if (type === 'earnings-export') {
       const { format, period, startDate, endDate } = job.data;
       await EarningsReportService.processQueuedExport(jobId, userId, format, period, startDate, endDate);
@@ -31,25 +35,25 @@ export const exportWorker = new Worker(
       await ExportService.processExport(userId, jobId);
     }
   },
-  { connection, concurrency: 5 },
+  { connection: redisConnection, concurrency: 5 },
 );
 
-exportWorker.on("completed", (job) => {
+exportWorker.on('completed', (job) => {
   logger.info(`Export job ${job.id} completed`);
 });
 
-exportWorker.on("failed", async (job, err) => {
+exportWorker.on('failed', async (job, err) => {
   logger.error(`Export job ${job?.id} failed`, { error: err.message });
   if (job) {
     const { jobId, userId } = job.data;
-    await ExportJobModel.updateStatus(jobId, "failed", undefined, err.message);
+    await ExportJobModel.updateStatus(jobId, 'failed', undefined, err.message);
 
     await AuditLoggerService.logEvent({
       level: LogLevel.ERROR,
-      action: "DATA_EXPORT_FAILED",
+      action: 'DATA_EXPORT_FAILED',
       message: `Data export failed for user ${userId}: ${err.message}`,
       userId: userId,
-      entityType: "export_job",
+      entityType: 'export_job',
       entityId: jobId,
       metadata: { error: err.message },
     });

--- a/src/queues/notification.queue.ts
+++ b/src/queues/notification.queue.ts
@@ -1,9 +1,5 @@
-import { Queue } from "bullmq";
-import {
-  redisConnection,
-  defaultJobOptions,
-  QUEUE_NAMES,
-} from "./queue.config";
+import { createManagedQueue, buildJobOptions, JobConfig } from './queue.manager';
+import { JOB_RATE_LIMITS, QUEUE_NAMES } from './queue.config';
 
 export interface NotificationJobData {
   /** Target user ID. */
@@ -11,7 +7,7 @@ export interface NotificationJobData {
   /** Notification type (maps to NotificationType enum values). */
   type: string;
   /** Channels to fan-out: 'websocket' | 'push' | 'email'. */
-  channels: Array<"websocket" | "push" | "email">;
+  channels: Array<'websocket' | 'push' | 'email'>;
   title: string;
   message: string;
   /** Optional stored notification record ID for delivery tracking. */
@@ -21,17 +17,21 @@ export interface NotificationJobData {
 }
 
 /** BullMQ queue for notification fan-out (WebSocket + push). */
-export const notificationQueue = new Queue<NotificationJobData>(
+export const notificationQueue = createManagedQueue<NotificationJobData>(
   QUEUE_NAMES.NOTIFICATIONS,
   {
-    connection: redisConnection,
-    defaultJobOptions,
+    limiter: JOB_RATE_LIMITS.NOTIFICATIONS,
   },
 );
 
 /** Enqueue a notification fan-out job. */
 export async function enqueueNotification(
   data: NotificationJobData,
+  options?: Partial<JobConfig>,
 ): Promise<void> {
-  await notificationQueue.add("fan-out-notification", data);
+  await notificationQueue.add(
+    options?.name ?? 'fan-out-notification',
+    data,
+    buildJobOptions(options),
+  );
 }

--- a/src/queues/payment-poll.queue.ts
+++ b/src/queues/payment-poll.queue.ts
@@ -1,9 +1,5 @@
-import { Queue } from 'bullmq';
-import {
-  redisConnection,
-  defaultJobOptions,
-  QUEUE_NAMES,
-} from './queue.config';
+import { createManagedQueue, buildJobOptions, JobConfig } from './queue.manager';
+import { defaultJobOptions, QUEUE_NAMES } from './queue.config';
 
 export interface PaymentPollJobData {
   paymentId: string;
@@ -11,10 +7,9 @@ export interface PaymentPollJobData {
   transactionHash: string | null;
 }
 
-export const paymentPollQueue = new Queue<PaymentPollJobData>(
+export const paymentPollQueue = createManagedQueue<PaymentPollJobData>(
   QUEUE_NAMES.PAYMENT_POLL,
   {
-    connection: redisConnection,
     defaultJobOptions: {
       ...defaultJobOptions,
       // Poll every 30 seconds, up to 20 attempts (10 minutes total)
@@ -30,9 +25,15 @@ export const paymentPollQueue = new Queue<PaymentPollJobData>(
  */
 export async function enqueuePaymentPoll(
   data: PaymentPollJobData,
+  options?: Partial<JobConfig>,
 ): Promise<void> {
   // Deduplicate by paymentId — only one active poll per payment
-  await paymentPollQueue.add('poll-payment', data, {
-    jobId: `payment-poll:${data.paymentId}`,
-  });
+  await paymentPollQueue.add(
+    options?.name ?? 'poll-payment',
+    data,
+    {
+      ...buildJobOptions(options),
+      jobId: `payment-poll:${data.paymentId}`,
+    },
+  );
 }

--- a/src/queues/queue.config.ts
+++ b/src/queues/queue.config.ts
@@ -7,5 +7,10 @@ export {
   defaultJobOptions,
   QUEUE_NAMES,
   CONCURRENCY,
+  JOB_RATE_LIMITS,
+  JobConfig,
+  JobType,
+  JobBackoffConfig,
+  JobRateLimit,
 } from "../config/queue";
 export type { QueueName } from "../config/queue";

--- a/src/queues/queue.manager.ts
+++ b/src/queues/queue.manager.ts
@@ -1,0 +1,122 @@
+import { Queue, QueueEvents, JobsOptions } from 'bullmq';
+import { CacheService } from '../services/cache.service';
+import { redisConnection, defaultJobOptions } from '../config/queue';
+
+type QueueJobOptions = JobsOptions & {
+  timeout?: number;
+  removeOnComplete?: boolean | { count: number };
+  removeOnFail?: boolean | { count: number };
+};
+
+export interface JobBackoffConfig {
+  type: 'fixed' | 'exponential';
+  delay: number;
+}
+
+export interface JobConfig {
+  name: string;
+  priority?: number;
+  attempts?: number;
+  backoff?: JobBackoffConfig;
+  timeout?: number;
+  removeOnComplete?: boolean | { count: number };
+  removeOnFail?: boolean | { count: number };
+}
+
+export enum JobType {
+  EMAIL = 'email',
+  PAYMENT = 'payment',
+  NOTIFICATION = 'notification',
+  REPORT = 'report',
+  ANALYTICS = 'analytics',
+  BLOCKCHAIN = 'blockchain',
+}
+
+export interface JobResult {
+  status: 'completed' | 'failed';
+  result?: unknown;
+  error?: string;
+}
+
+export function jobResultCacheKey(queueName: string, jobId: string): string {
+  return `job-result:${queueName}:${jobId}`;
+}
+
+export async function getCachedJobResult(
+  queueName: string,
+  jobId: string,
+): Promise<JobResult | null> {
+  return CacheService.get<JobResult>(jobResultCacheKey(queueName, jobId));
+}
+
+export function createManagedQueue<T>(
+  name: string,
+  options?: {
+    defaultJobOptions?: JobsOptions;
+    limiter?: { max: number; duration: number };
+  },
+): Queue<T> {
+  const queueOptions: any = {
+    connection: redisConnection,
+    defaultJobOptions: options?.defaultJobOptions ?? defaultJobOptions,
+  };
+
+  if (options?.limiter) {
+    queueOptions.limiter = options.limiter;
+  }
+
+  return new Queue<T>(name, queueOptions);
+}
+
+export function buildJobOptions(config?: Partial<JobConfig>): QueueJobOptions {
+  const options: QueueJobOptions = {} as QueueJobOptions;
+
+  if (!config) {
+    return options;
+  }
+
+  if (config.priority !== undefined) {
+    options.priority = config.priority;
+  }
+  if (config.attempts !== undefined) {
+    options.attempts = config.attempts;
+  }
+  if (config.backoff !== undefined) {
+    options.backoff = config.backoff;
+  }
+  if (config.timeout !== undefined) {
+    options.timeout = config.timeout;
+  }
+  if (config.removeOnComplete !== undefined) {
+    options.removeOnComplete = config.removeOnComplete;
+  }
+  if (config.removeOnFail !== undefined) {
+    options.removeOnFail = config.removeOnFail;
+  }
+
+  return options;
+}
+
+export function enableJobResultCache<T>(queue: Queue<T>, ttlSeconds = 3600): QueueEvents {
+  const events = new QueueEvents(queue.name, { connection: redisConnection });
+
+  events.on('completed', async ({ jobId, returnvalue }) => {
+    if (!jobId) return;
+    await CacheService.set<JobResult>(
+      jobResultCacheKey(queue.name, jobId),
+      { status: 'completed', result: returnvalue },
+      ttlSeconds,
+    );
+  });
+
+  events.on('failed', async ({ jobId, failedReason }) => {
+    if (!jobId) return;
+    await CacheService.set<JobResult>(
+      jobResultCacheKey(queue.name, jobId),
+      { status: 'failed', error: failedReason },
+      ttlSeconds,
+    );
+  });
+
+  return events;
+}

--- a/src/queues/report.queue.ts
+++ b/src/queues/report.queue.ts
@@ -1,9 +1,5 @@
-import { Queue } from 'bullmq';
-import {
-  redisConnection,
-  defaultJobOptions,
-  QUEUE_NAMES,
-} from './queue.config';
+import { createManagedQueue, buildJobOptions, enableJobResultCache, JobConfig } from './queue.manager';
+import { QUEUE_NAMES } from './queue.config';
 
 export type ReportType = 'weekly-earnings';
 
@@ -17,16 +13,17 @@ export interface ReportJobData {
   mentorId?: string;
 }
 
-export const reportQueue = new Queue<ReportJobData>(QUEUE_NAMES.REPORT, {
-  connection: redisConnection,
-  defaultJobOptions,
-});
+export const reportQueue = createManagedQueue<ReportJobData>(QUEUE_NAMES.REPORT);
+
+// Cache report job outcomes for tenant dashboards and monitoring.
+enableJobResultCache(reportQueue, 6 * 3600);
 
 /**
  * Enqueue a weekly earnings report generation job.
  */
 export async function enqueueWeeklyEarningsReport(
   mentorId?: string,
+  options?: Partial<JobConfig>,
 ): Promise<void> {
   const now = new Date();
   const periodEnd = now.toISOString();
@@ -35,9 +32,10 @@ export async function enqueueWeeklyEarningsReport(
   ).toISOString();
 
   await reportQueue.add(
-    'weekly-earnings',
+    options?.name ?? 'weekly-earnings',
     { reportType: 'weekly-earnings', periodStart, periodEnd, mentorId },
     {
+      ...buildJobOptions(options),
       jobId: `weekly-earnings:${mentorId ?? 'platform'}:${periodStart.slice(0, 10)}`,
     },
   );

--- a/src/queues/stellar-tx.queue.ts
+++ b/src/queues/stellar-tx.queue.ts
@@ -1,9 +1,5 @@
-import { Queue } from "bullmq";
-import {
-  redisConnection,
-  defaultJobOptions,
-  QUEUE_NAMES,
-} from "./queue.config";
+import { createManagedQueue, buildJobOptions, JobConfig } from './queue.manager';
+import { defaultJobOptions, QUEUE_NAMES } from './queue.config';
 
 export interface StellarTxJobData {
   /** Base64-encoded signed transaction envelope XDR. */
@@ -24,15 +20,14 @@ export interface StellarTxJobData {
   description?: string;
 }
 
-export const stellarTxQueue = new Queue<StellarTxJobData>(
+export const stellarTxQueue = createManagedQueue<StellarTxJobData>(
   QUEUE_NAMES.STELLAR_TX,
   {
-    connection: redisConnection,
     defaultJobOptions: {
       ...defaultJobOptions,
       // Poll every 15 seconds, up to 40 attempts (~10 minutes total)
       attempts: 40,
-      backoff: { type: "fixed", delay: 15_000 },
+      backoff: { type: 'fixed', delay: 15_000 },
     },
   },
 );
@@ -44,8 +39,14 @@ export const stellarTxQueue = new Queue<StellarTxJobData>(
 export async function enqueueStellarTx(
   data: StellarTxJobData,
   jobId?: string,
+  options?: Partial<JobConfig>,
 ): Promise<void> {
-  await stellarTxQueue.add("submit-stellar-tx", data, {
-    jobId: jobId ?? `stellar-tx:${data.paymentId ?? Date.now()}`,
-  });
+  await stellarTxQueue.add(
+    options?.name ?? 'submit-stellar-tx',
+    data,
+    {
+      ...buildJobOptions(options),
+      jobId: jobId ?? `stellar-tx:${data.paymentId ?? Date.now()}`,
+    },
+  );
 }

--- a/src/services/queue.service.ts
+++ b/src/services/queue.service.ts
@@ -16,8 +16,7 @@ import type { EmailRequest } from "../services/email.service";
 import type { StellarTxJobData } from "../queues/stellar-tx.queue";
 import type { EscrowReleaseJobData } from "../queues/escrow-release.queue";
 import type { NotificationJobData } from "../queues/notification.queue";
-import type { PaymentPollJobData } from "../queues/payment-poll.queue";
-
+import type { PaymentPollJobData } from "../queues/payment-poll.queue";import type { JobConfig } from '../queues/queue.manager';
 export const QueueService = {
   /**
    * Enqueue an outbound email.
@@ -33,8 +32,12 @@ export const QueueService = {
    * @param data - Transaction payload including the raw XDR envelope
    * @param jobId - Optional deduplication key (defaults to paymentId or timestamp)
    */
-  async submitStellarTx(data: StellarTxJobData, jobId?: string): Promise<void> {
-    await enqueueStellarTx(data, jobId);
+  async submitStellarTx(
+    data: StellarTxJobData,
+    jobId?: string,
+    options?: Partial<JobConfig>,
+  ): Promise<void> {
+    await enqueueStellarTx(data, jobId, options);
   },
 
   /**
@@ -55,15 +58,21 @@ export const QueueService = {
   /**
    * Fan-out a notification to WebSocket and/or push channels.
    */
-  async sendNotification(data: NotificationJobData): Promise<void> {
-    await enqueueNotification(data);
+  async sendNotification(
+    data: NotificationJobData,
+    options?: Partial<JobConfig>,
+  ): Promise<void> {
+    await enqueueNotification(data, options);
   },
 
   /**
    * Poll a Stellar payment until confirmed or the attempt limit is reached.
    */
-  async pollPayment(data: PaymentPollJobData): Promise<void> {
-    await enqueuePaymentPoll(data);
+  async pollPayment(
+    data: PaymentPollJobData,
+    options?: Partial<JobConfig>,
+  ): Promise<void> {
+    await enqueuePaymentPoll(data, options);
   },
 };
 


### PR DESCRIPTION
Closes #539

---

This PR adds a shared BullMQ queue manager, standardizes job priority/retry/backoff configuration, introduces queue rate limiting, and enables job result caching for selected queues. It also updates existing queue wrappers and the unified QueueService facade to use the new manager.