### PR TITLE
Feature/issues 667 681 659 679

### DIFF
--- a/api-validation.md
+++ b/api-validation.md
@@ -1,0 +1,84 @@
+# API Input Validation
+
+This document describes the input validation approach for the v1 API (issue #667).
+
+## Pattern
+
+Every route that accepts `body`, `query`, or `params` is validated with a
+[Zod](https://zod.dev) schema through a single middleware factory:
+
+```ts
+import { validate } from "../middleware/validation.middleware";
+import { createBookingSchema } from "../validators/schemas/bookings.schemas";
+
+router.post("/", validate(createBookingSchema), asyncHandler(BookingsController.create));
+```
+
+`validate(schema)` runs `schema.safeParse({ body, query, params })`. On failure it
+responds **HTTP 422** with a structured, field-level error list:
+
+```json
+{
+  "success": false,
+  "errors": [
+    { "field": "body.topic", "message": "String must contain at most 500 character(s)", "code": "too_big" }
+  ]
+}
+```
+
+Schemas live in `src/validators/schemas/<domain>.schemas.ts`, one file per
+domain (`admin`, `disputes`, `payments`, `bookings`, `users`, ...), and are
+wired into the matching `src/routes/<domain>.routes.ts`.
+
+## Shared primitives (`src/validators/schemas/common.schemas.ts`)
+
+| Schema | Purpose |
+|---|---|
+| `uuidSchema` | Strict UUID v4 — used for every `:id` route param |
+| `idParamSchema` | `{ params: { id: uuidSchema } }` shortcut |
+| `paginationSchema` | `page`/`limit` (bounded, prevents integer overflow) + `sortBy`/`sortOrder` |
+| `cursorPaginationSchema` | Cursor-based pagination variant |
+| `emailSchema` / `passwordSchema` | Auth primitives |
+| `stellarAddressSchema` / `stellarTxHashSchema` | Stellar G-address / tx hash format checks |
+| `nameSchema` / `shortTextSchema` (≤500) / `longTextSchema` (≤2000) | Bounded text fields |
+| `urlSchema` | http(s)-only URL |
+
+Field length limits follow the issue's spec: **bio ≤ 2000 chars**, **topic ≤ 500
+chars**, **notes ≤ 5000 chars** (notes use an explicit `.max(5000)` per-schema,
+since it exceeds the shared `longTextSchema` bound).
+
+## Route params
+
+All `:id`-style params are validated as UUID v4 and rejected with **422** if
+malformed (non-UUID strings, path traversal attempts, SQL injection payloads,
+etc. never reach a controller or service). A small number of params are
+intentionally *not* UUIDs (e.g. onboarding `stepId` slugs, calendar sync
+tokens, a 4-digit tax `year`) — those get an explicit bounded
+string/regex/number schema instead, documented inline in the schema file.
+
+## `req.params` / `req.query` sanitization note
+
+Express 5 makes `req.params` and `req.query` read-only getters, so the global
+`sanitizeInput` middleware (`src/middleware/security.middleware.ts`) cannot
+mutate them in place. It still runs SQL-injection **detection/logging** on
+both, but the actual **rejection** of malformed params/query values is
+enforced entirely through per-route Zod schemas via `validate()`.
+
+## Coverage
+
+Zero unvalidated endpoints remain in the v1 route files touched by this PR —
+see the PR description for the full file list. Pre-existing `express-validator`
+usage in `advanced-analytics.routes.ts`, `learning-path.routes.ts`, and
+`progress.routes.ts` was left as-is; migrating those to Zod is tracked as
+follow-up work, out of scope for this pass.
+
+## Testing
+
+The repo has no test runner installed. Rather than add one as a side effect
+of this PR, schema behavior is covered by a minimal dependency-free harness:
+
+```bash
+npm run test:validators
+```
+
+See `src/validators/__tests__/`.

--- a/database/migrations/083_add_usd_equivalent_to_bookings.sql
+++ b/database/migrations/083_add_usd_equivalent_to_bookings.sql
@@ -1,0 +1,1 @@
+ALTER TABLE bookings ADD COLUMN IF NOT EXISTS usd_equivalent VARCHAR(32);

--- a/database/migrations/084_add_downloaded_at_to_export_jobs.sql
+++ b/database/migrations/084_add_downloaded_at_to_export_jobs.sql
@@ -1,0 +1,8 @@
+-- =============================================================================
+-- Migration: 084_add_downloaded_at_to_export_jobs.sql
+-- Description: Track when a completed data export was actually downloaded
+-- =============================================================================
+
+ALTER TABLE export_jobs ADD COLUMN IF NOT EXISTS downloaded_at TIMESTAMP WITH TIME ZONE;
+
+COMMENT ON COLUMN export_jobs.downloaded_at IS 'Timestamp of the first successful presigned URL access, NULL if never downloaded';

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "node dist/bootstrap.js",
     "start:worker": "node dist/worker-bootstrap.js",
     "lint": "node --max-old-space-size=4096 node_modules/eslint/bin/eslint.js .",
+    "test:validators": "ts-node --transpile-only src/validators/__tests__/run.ts",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"src/**/*.ts\"",
     "seed": "ts-node --project tsconfig.seed.json database/seeds/index.ts",

--- a/src/controllers/export.controller.ts
+++ b/src/controllers/export.controller.ts
@@ -1,6 +1,7 @@
 import { StorageService } from "../services/storage.service";
 import { Response } from "express";
 import { ExportService } from "../services/export.service";
+import { ExportJobModel } from "../models/export-job.model";
 import { ResponseUtil } from "../utils/response.utils";
 import { AuthenticatedRequest } from "../types/api.types";
 
@@ -50,6 +51,8 @@ export const ExportController = {
       job.storage_key,
       3600,
     );
+
+    await ExportJobModel.markDownloaded(jobId);
 
     return ResponseUtil.success(res, { downloadUrl }, "Download URL generated");
   },

--- a/src/controllers/oracle.controller.ts
+++ b/src/controllers/oracle.controller.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from 'express';
+import { OracleService } from '../services/oracle.service';
+import { ResponseUtil } from '../utils/response.utils';
+
+export const OracleController = {
+  /** GET /api/v1/oracle/price/:asset - Current oracle price with staleness indicator */
+  async getPrice(req: Request, res: Response): Promise<void> {
+    const asset = req.params.asset as string;
+
+    if (!OracleService.isConfigured()) {
+      ResponseUtil.error(res, 'Oracle contract is not configured', 503);
+      return;
+    }
+
+    try {
+      const price = await OracleService.getPrice(asset.toUpperCase());
+      ResponseUtil.success(res, price, 'Oracle price retrieved successfully');
+    } catch (error) {
+      ResponseUtil.error(
+        res,
+        error instanceof Error ? error.message : 'Failed to retrieve oracle price',
+      );
+    }
+  },
+};

--- a/src/controllers/trace.controller.ts
+++ b/src/controllers/trace.controller.ts
@@ -1,0 +1,19 @@
+import { Request, Response } from "express";
+import { JaegerService } from "../services/jaeger.service";
+import { ResponseUtil } from "../utils/response.utils";
+
+export const TraceController = {
+  /** GET /api/v1/admin/trace/:traceId - Full trace lookup from Jaeger */
+  async getTrace(req: Request, res: Response): Promise<void> {
+    const traceId = req.params.traceId as string;
+
+    const trace = await JaegerService.getTraceById(traceId);
+
+    if (!trace) {
+      ResponseUtil.error(res, "Trace not found", 404);
+      return;
+    }
+
+    ResponseUtil.success(res, trace, "Trace retrieved successfully");
+  },
+};

--- a/src/jobs/email.worker.ts
+++ b/src/jobs/email.worker.ts
@@ -7,39 +7,35 @@ import {
 import { EmailService } from "../services/email.service";
 import { logger } from "../utils/logger.utils";
 import type { EmailJobData } from "../queues/email.queue";
+import { runWithJobTraceContext } from "../utils/trace-context.utils";
+import { wrapWithSpan } from "../config/tracing";
 
 const emailService = new EmailService();
 
-import { traceStore } from "../middleware/tracing.middleware";
-
 async function processEmailJob(job: Job<EmailJobData>): Promise<void> {
-  const { jobType: _jobType, requestId, correlationId, ...emailRequest } = job.data;
+  const { jobType: _jobType, requestId, correlationId, traceId, spanId, ...emailRequest } = job.data;
 
-  const context = {
-    requestId: requestId || job.id || 'job-unknown',
-    correlationId: correlationId || job.id || 'job-unknown',
-    startTime: Date.now(),
-  };
+  await runWithJobTraceContext({ requestId, correlationId, traceId, spanId }, () =>
+    wrapWithSpan("queue.email", async () => {
+      logger.info("Email job started", {
+        jobId: job.id,
+        to: emailRequest.to,
+        subject: emailRequest.subject,
+        attempt: job.attemptsMade + 1,
+      });
 
-  return traceStore.run(context, async () => {
-    logger.info("Email job started", {
-      jobId: job.id,
-      to: emailRequest.to,
-      subject: emailRequest.subject,
-      attempt: job.attemptsMade + 1,
-    });
+      const result = await emailService.sendEmail(emailRequest);
 
-    const result = await emailService.sendEmail(emailRequest);
+      if (!result.success) {
+        throw new Error(result.error || "Email send failed");
+      }
 
-    if (!result.success) {
-      throw new Error(result.error || "Email send failed");
-    }
-
-    logger.info("Email job completed", {
-      jobId: job.id,
-      messageId: result.messageId,
-    });
-  });
+      logger.info("Email job completed", {
+        jobId: job.id,
+        messageId: result.messageId,
+      });
+    }, { attributes: { "queue.name": "email", "job.id": job.id ?? "" } }),
+  );
 }
 
 export const emailWorker = new Worker<EmailJobData>(

--- a/src/middleware/security.middleware.ts
+++ b/src/middleware/security.middleware.ts
@@ -25,12 +25,23 @@ export const securityMiddleware = helmet({
 import { sanitizeObject, detectAndLogSqlInjection } from '../utils/sanitization.utils';
 
 export const sanitizeInput = (req: Request, _res: Response, next: NextFunction): void => {
+  const requestId = req.headers['x-request-id'] as string;
+
   if (req.body) {
     req.body = sanitizeObject(req.body);
-    // Optional: detect and log SQL injection on the entire body stringified
-    detectAndLogSqlInjection(JSON.stringify(req.body), 'body', req.headers['x-request-id'] as string);
+    detectAndLogSqlInjection(JSON.stringify(req.body), 'body', requestId);
   }
-  // req.query and req.params are read-only getters in Express 5
-  // sanitize body only; query/params are validated via Zod schemas
+
+  // req.query and req.params are read-only getters in Express 5 — they
+  // cannot be mutated in place, so we only run detection logging here.
+  // Rejection of malicious/malformed input happens via Zod schemas in
+  // the `validate()` middleware applied per-route.
+  if (req.query && Object.keys(req.query).length > 0) {
+    detectAndLogSqlInjection(JSON.stringify(req.query), 'query', requestId);
+  }
+  if (req.params && Object.keys(req.params).length > 0) {
+    detectAndLogSqlInjection(JSON.stringify(req.params), 'params', requestId);
+  }
+
   next();
 };

--- a/src/models/booking.model.ts
+++ b/src/models/booking.model.ts
@@ -11,6 +11,7 @@ export interface BookingRecord {
   status: "pending" | "confirmed" | "completed" | "cancelled" | "rescheduled";
   amount: string;
   currency: string;
+  usd_equivalent: string | null;
   payment_status: "pending" | "paid" | "refunded" | "failed";
   stellar_tx_hash: string | null;
   transaction_id: string | null;
@@ -32,10 +33,11 @@ export const BookingModel = {
     notes?: string;
     amount: string;
     currency: string;
+    usdEquivalent?: string | null;
   }): Promise<BookingRecord> {
     const { rows } = await db.query(
-      `INSERT INTO bookings (mentee_id, mentor_id, scheduled_at, duration_minutes, topic, notes, amount, currency)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+      `INSERT INTO bookings (mentee_id, mentor_id, scheduled_at, duration_minutes, topic, notes, amount, currency, usd_equivalent)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
        RETURNING *`,
       [
         data.menteeId,
@@ -46,6 +48,7 @@ export const BookingModel = {
         data.notes || null,
         data.amount,
         data.currency,
+        data.usdEquivalent ?? null,
       ],
     );
     return rows[0];

--- a/src/models/export-job.model.ts
+++ b/src/models/export-job.model.ts
@@ -8,6 +8,7 @@ export interface ExportJob {
   file_path?: string | null; // Alias for storage_key used by download endpoint
   error_message: string | null;
   expires_at: Date | null;
+  downloaded_at: Date | null;
   metadata?: Record<string, any>;
   created_at: Date;
   updated_at: Date;
@@ -83,6 +84,21 @@ export const ExportJobModel = {
     `;
     const { rows } = await db.query(query, [userId]);
     return rows[0] || null;
+  },
+
+  async markDownloaded(id: string): Promise<void> {
+    await db.query(
+      `UPDATE export_jobs SET downloaded_at = COALESCE(downloaded_at, CURRENT_TIMESTAMP) WHERE id = $1;`,
+      [id],
+    );
+  },
+
+  async findExpiredOlderThan(days: number): Promise<ExportJob[]> {
+    const { rows } = await db.query(
+      `SELECT * FROM export_jobs WHERE created_at < NOW() - ($1::int * INTERVAL '1 day');`,
+      [days],
+    );
+    return rows;
   },
 
   async deleteOlderThan(days: number): Promise<number> {

--- a/src/queues/email.queue.ts
+++ b/src/queues/email.queue.ts
@@ -1,12 +1,10 @@
-import { traceStore } from '../middleware/tracing.middleware';
 import type { EmailRequest } from '../services/email.service';
 import { createManagedQueue, buildJobOptions, JobConfig } from './queue.manager';
 import { JOB_RATE_LIMITS, QUEUE_NAMES } from './queue.config';
+import { captureJobTraceData, JobTraceData } from '../utils/trace-context.utils';
 
-export interface EmailJobData extends EmailRequest {
+export interface EmailJobData extends EmailRequest, JobTraceData {
   jobType: 'send-email';
-  requestId?: string;
-  correlationId?: string;
 }
 
 export const emailQueue = createManagedQueue<EmailJobData>(QUEUE_NAMES.EMAIL, {
@@ -27,14 +25,12 @@ export async function enqueueEmail(
       ? { priority: priorityOrConfig }
       : priorityOrConfig ?? {};
 
-  const context = traceStore.getStore();
   await emailQueue.add(
     options.name ?? 'send-email',
     {
       ...data,
       jobType: 'send-email',
-      requestId: context?.requestId,
-      correlationId: context?.correlationId,
+      ...captureJobTraceData(),
     },
     buildJobOptions(options),
   );

--- a/src/routes/admin.routes.ts
+++ b/src/routes/admin.routes.ts
@@ -18,6 +18,36 @@ import {
   listVerificationsSchema,
 } from "../validators/schemas/verification.schemas";
 import { ConsentController } from "../controllers/consent.controller";
+import { TraceController } from "../controllers/trace.controller";
+import { getTraceSchema } from "../validators/schemas/trace.schemas";
+import {
+  listAdminUsersSchema,
+  updateUserStatusSchema,
+  updateUserTierSchema,
+  suspendUserSchema,
+  banUserSchema,
+  adminIdParamSchema,
+  listAdminTransactionsSchema,
+  listAdminSessionsSchema,
+  listAdminPaymentsSchema,
+  listAdminDisputesSchema,
+  resolveDisputeSchema,
+  getAdminLogsSchema,
+  updateConfigSchema,
+  getAuditLogSchema,
+  exportAuditLogSchema,
+  auditLogStatsSchema,
+  previewEmailTemplateSchema,
+  revenueSummarySchema,
+  dailyRevenueSchema,
+  transactionReportSchema,
+  exportReportSchema,
+  addBlocklistRuleSchema,
+  removeBlocklistRuleSchema,
+  addAllowlistRuleSchema,
+  approveVerificationSchema,
+  retryWebhookDeliverySchema,
+} from "../validators/schemas/admin.schemas";
 
 const router = Router();
 
@@ -53,6 +83,21 @@ router.use(requireAdmin);
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 router.get("/stats", asyncHandler(AdminController.getStats));
+
+/**
+ * @swagger
+ * /admin/trace/{traceId}:
+ *   get:
+ *     summary: Query Jaeger for the full trace by traceId
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ */
+router.get(
+  "/trace/:traceId",
+  validate(getTraceSchema),
+  asyncHandler(TraceController.getTrace),
+);
 
 /**
  * @swagger
@@ -98,7 +143,7 @@ router.get("/stats", asyncHandler(AdminController.getStats));
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  */
-router.get("/users", asyncHandler(AdminController.listUsers));
+router.get("/users", validate(listAdminUsersSchema), asyncHandler(AdminController.listUsers));
 
 /**
  * @swagger
@@ -139,6 +184,7 @@ router.get("/users", asyncHandler(AdminController.listUsers));
  */
 router.put(
   "/users/:id/status",
+  validate(updateUserStatusSchema),
   auditLogMiddleware({
     action: AuditAction.ADMIN_ACTION,
     getEntityDetails: (req) => ({ type: "USER", id: req.params.id as string }),
@@ -172,6 +218,7 @@ router.put(
  */
 router.put(
   "/users/:id/tier",
+  validate(updateUserTierSchema),
   auditLogMiddleware({
     action: AuditAction.ADMIN_ACTION,
     getEntityDetails: (req) => ({ type: "USER", id: req.params.id as string }),
@@ -216,6 +263,7 @@ router.put(
  */
 router.put(
   "/users/:id/suspend",
+  validate(suspendUserSchema),
   auditLogMiddleware({
     action: AuditAction.ADMIN_ACTION,
     getEntityDetails: (req) => ({ type: "USER", id: req.params.id as string }),
@@ -255,6 +303,7 @@ router.put(
  */
 router.put(
   "/users/:id/ban",
+  validate(banUserSchema),
   auditLogMiddleware({
     action: AuditAction.ADMIN_ACTION,
     getEntityDetails: (req) => ({ type: "USER", id: req.params.id as string }),
@@ -280,6 +329,7 @@ router.put(
  */
 router.put(
   "/users/:id/unsuspend",
+  validate(adminIdParamSchema),
   auditLogMiddleware({
     action: AuditAction.ADMIN_ACTION,
     getEntityDetails: (req) => ({ type: "USER", id: req.params.id as string }),
@@ -305,6 +355,7 @@ router.put(
  */
 router.post(
   "/users/:id/unlock",
+  validate(adminIdParamSchema),
   auditLogMiddleware({
     action: AuditAction.ADMIN_ACTION,
     getEntityDetails: (req) => ({ type: "USER", id: req.params.id as string }),
@@ -388,7 +439,7 @@ router.post(
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  */
-router.get("/transactions", asyncHandler(AdminController.listTransactions));
+router.get("/transactions", validate(listAdminTransactionsSchema), asyncHandler(AdminController.listTransactions));
 
 /**
  * @swagger
@@ -412,7 +463,7 @@ router.get("/transactions", asyncHandler(AdminController.listTransactions));
  *       200:
  *         description: Paginated list of sessions
  */
-router.get("/sessions", asyncHandler(AdminController.listSessions));
+router.get("/sessions", validate(listAdminSessionsSchema), asyncHandler(AdminController.listSessions));
 
 /**
  * @swagger
@@ -439,7 +490,7 @@ router.get("/sessions", asyncHandler(AdminController.listSessions));
  *       200:
  *         description: Paginated list of payments
  */
-router.get("/payments", asyncHandler(AdminController.listPayments));
+router.get("/payments", validate(listAdminPaymentsSchema), asyncHandler(AdminController.listPayments));
 
 /**
  * @swagger
@@ -470,7 +521,7 @@ router.get("/payments", asyncHandler(AdminController.listPayments));
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  */
-router.get("/disputes", asyncHandler(AdminController.listDisputes));
+router.get("/disputes", validate(listAdminDisputesSchema), asyncHandler(AdminController.listDisputes));
 
 /**
  * @swagger
@@ -507,6 +558,7 @@ router.get("/disputes", asyncHandler(AdminController.listDisputes));
  */
 router.post(
   "/disputes/:id/resolve",
+  validate(resolveDisputeSchema),
   auditLogMiddleware({
     action: AuditAction.ADMIN_ACTION,
     getEntityDetails: (req) => ({ type: "DISPUTE", id: req.params.id as string }),
@@ -578,7 +630,7 @@ router.get("/system-health", asyncHandler(AdminController.getSystemHealth));
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  */
-router.get("/logs", asyncHandler(AdminController.getLogs));
+router.get("/logs", validate(getAdminLogsSchema), asyncHandler(AdminController.getLogs));
 
 /**
  * @swagger
@@ -611,7 +663,7 @@ router.get("/logs", asyncHandler(AdminController.getLogs));
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  */
-router.post("/config", asyncHandler(AdminController.updateConfig));
+router.post("/config", validate(updateConfigSchema), asyncHandler(AdminController.updateConfig));
 
 // ── Audit Log Routes ─────────────────────────────────────────────────────────
 
@@ -656,7 +708,7 @@ router.post("/config", asyncHandler(AdminController.updateConfig));
  *             schema:
  *               $ref: '#/components/schemas/ApiResponse'
  */
-router.get("/audit-log", asyncHandler(AdminController.getAuditLogs));
+router.get("/audit-log", validate(getAuditLogSchema), asyncHandler(AdminController.getAuditLogs));
 
 /**
  * @swagger
@@ -690,7 +742,7 @@ router.get("/audit-log", asyncHandler(AdminController.getAuditLogs));
  *             schema:
  *               type: string
  */
-router.get("/audit-log/export", asyncHandler(AdminController.exportAuditLogs));
+router.get("/audit-log/export", validate(exportAuditLogSchema), asyncHandler(AdminController.exportAuditLogs));
 
 /**
  * @swagger
@@ -728,7 +780,7 @@ router.get(
  *       200:
  *         description: Audit log statistics
  */
-router.get("/audit-log/stats", asyncHandler(AdminController.getAuditLogStats));
+router.get("/audit-log/stats", validate(auditLogStatsSchema), asyncHandler(AdminController.getAuditLogStats));
 
 // ── Email Template Routes ──────────────────────────────────────────────────────
 
@@ -783,6 +835,7 @@ router.get("/audit-log/stats", asyncHandler(AdminController.getAuditLogStats));
  */
 router.post(
   "/email/preview/:template",
+  validate(previewEmailTemplateSchema),
   asyncHandler(AdminController.previewEmailTemplate),
 );
 
@@ -928,6 +981,7 @@ router.post("/analytics/refresh", AdvancedAnalyticsController.refreshAnalytics);
  */
 router.get(
   "/reports/revenue",
+  validate(revenueSummarySchema),
   asyncHandler(RevenueReportController.getRevenueSummary),
 );
 
@@ -954,6 +1008,7 @@ router.get(
  */
 router.get(
   "/reports/revenue/daily",
+  validate(dailyRevenueSchema),
   asyncHandler(RevenueReportController.getDailyRevenue),
 );
 
@@ -983,6 +1038,7 @@ router.get(
  */
 router.get(
   "/reports/transactions",
+  validate(transactionReportSchema),
   asyncHandler(RevenueReportController.getTransactions),
 );
 
@@ -1014,7 +1070,7 @@ router.get(
  *       200:
  *         description: CSV export generated
  */
-router.get("/reports/export", asyncHandler(AdminController.exportAuditLogs));
+router.get("/reports/export", validate(exportReportSchema), asyncHandler(AdminController.exportAuditLogs));
 
 // ── Security Management Routes ───────────────────────────────────────────────
 
@@ -1053,6 +1109,7 @@ router.get(
 );
 router.post(
   "/security/blocklist",
+  validate(addBlocklistRuleSchema),
   asyncHandler(AdminController.addBlocklistRule),
 );
 
@@ -1075,6 +1132,7 @@ router.post(
  */
 router.delete(
   "/security/blocklist/:id",
+  validate(removeBlocklistRuleSchema),
   asyncHandler(AdminController.removeBlocklistRule),
 );
 
@@ -1101,6 +1159,7 @@ router.delete(
  */
 router.post(
   "/security/allowlist",
+  validate(addAllowlistRuleSchema),
   asyncHandler(AdminController.addAdminAllowlistRule),
 );
 
@@ -1153,6 +1212,7 @@ router.get(
  */
 router.put(
   "/verifications/:id/approve",
+  validate(approveVerificationSchema),
   asyncHandler(VerificationController.approve),
 );
 
@@ -1243,6 +1303,7 @@ router.put(
  */
 router.post(
   "/webhooks/:deliveryId/retry",
+  validate(retryWebhookDeliverySchema),
   auditLogMiddleware({
     action: AuditAction.ADMIN_ACTION,
     getEntityDetails: (req) => ({

--- a/src/routes/analytics.routes.ts
+++ b/src/routes/analytics.routes.ts
@@ -2,6 +2,17 @@ import { Router } from "express";
 import { AnalyticsController } from "../controllers/analytics.controller";
 import { authenticate } from "../middleware/auth.middleware";
 import { requireRole as authorize } from "../middleware/rbac.middleware";
+import { validate } from "../middleware/validation.middleware";
+import {
+  pathAnalyticsSchema,
+  pathMilestonesSchema,
+  pathTrendsSchema,
+  pathBottlenecksSchema,
+  studentProfileSchema,
+  studentPathInsightsSchema,
+  studentPathComparisonSchema,
+  mentorDashboardSchema,
+} from "../validators/schemas/analytics.schemas";
 
 const router = Router();
 
@@ -17,6 +28,7 @@ router.use(authenticate);
 router.get(
   "/paths/:pathId",
   authorize("mentor", "admin"),
+  validate(pathAnalyticsSchema),
   AnalyticsController.getPathAnalytics,
 );
 
@@ -25,6 +37,7 @@ router.get(
 router.get(
   "/paths/:pathId/milestones",
   authorize("mentor", "admin"),
+  validate(pathMilestonesSchema),
   AnalyticsController.getMilestoneAnalytics,
 );
 
@@ -33,6 +46,7 @@ router.get(
 router.get(
   "/paths/:pathId/trends",
   authorize("mentor", "admin"),
+  validate(pathTrendsSchema),
   AnalyticsController.getTrendData,
 );
 
@@ -41,6 +55,7 @@ router.get(
 router.get(
   "/paths/:pathId/bottlenecks",
   authorize("mentor", "admin"),
+  validate(pathBottlenecksSchema),
   AnalyticsController.getBottlenecks,
 );
 
@@ -53,6 +68,7 @@ router.get(
 router.get(
   "/students/:studentId/profile",
   authorize("student", "mentor", "admin"),
+  validate(studentProfileSchema),
   AnalyticsController.getStudentProfile,
 );
 
@@ -61,6 +77,7 @@ router.get(
 router.get(
   "/students/:studentId/paths/:pathId/insights",
   authorize("student", "mentor", "admin"),
+  validate(studentPathInsightsSchema),
   AnalyticsController.getPredictiveInsights,
 );
 
@@ -69,6 +86,7 @@ router.get(
 router.get(
   "/students/:studentId/paths/:pathId/comparison",
   authorize("student", "mentor", "admin"),
+  validate(studentPathComparisonSchema),
   AnalyticsController.getComparisonAnalytics,
 );
 
@@ -81,6 +99,7 @@ router.get(
 router.get(
   "/mentors/:mentorId/dashboard",
   authorize("mentor", "admin"),
+  validate(mentorDashboardSchema),
   AnalyticsController.getMentorDashboard,
 );
 

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -9,6 +9,24 @@ import { authenticate } from "../middleware/auth.middleware";
 import { handleTokenRefresh } from "../middleware/token-refresh.middleware";
 import { asyncHandler } from "../utils/asyncHandler.utils";
 import { loginLockoutCheck } from "../middleware/rate-limit.middleware";
+import { validate } from "../middleware/validation.middleware";
+import {
+  registerSchema,
+  loginSchema,
+  refreshTokenSchema,
+  forgotPasswordSchema,
+  resetPasswordSchema,
+  mfaVerifySetupSchema,
+  mfaDisableSchema,
+  mfaValidateSchema,
+  mfaBackupSchema,
+  mfaOtpSendSchema,
+  mfaOtpSetupSchema,
+  mfaOtpValidateSchema,
+  listAuthSessionsSchema,
+  revokeSessionParamSchema,
+  oauthProviderParamSchema,
+} from "../validators/schemas/auth.schemas";
 
 const router = Router();
 
@@ -25,21 +43,47 @@ const authLimiter = rateLimit({
 });
 
 // Public routes (rate limited)
-router.post("/register", authLimiter, AuthController.register);
+router.post("/register", authLimiter, validate(registerSchema), AuthController.register);
 // loginLockoutCheck runs before the handler to short-circuit locked accounts early
 router.post(
   "/login",
   authLimiter,
+  validate(loginSchema),
   asyncHandler(loginLockoutCheck),
   AuthController.login,
 );
-router.post("/refresh", authLimiter, asyncHandler(handleTokenRefresh));
-router.post("/forgot-password", authLimiter, AuthController.forgotPassword);
-router.post("/reset-password", authLimiter, AuthController.resetPassword);
+router.post(
+  "/refresh",
+  authLimiter,
+  validate(refreshTokenSchema),
+  asyncHandler(handleTokenRefresh),
+);
+router.post(
+  "/forgot-password",
+  authLimiter,
+  validate(forgotPasswordSchema),
+  AuthController.forgotPassword,
+);
+router.post(
+  "/reset-password",
+  authLimiter,
+  validate(resetPasswordSchema),
+  AuthController.resetPassword,
+);
 
 // MFA Public routes
-router.post("/mfa/validate", authLimiter, asyncHandler(MfaController.validate));
-router.post("/mfa/backup", authLimiter, asyncHandler(MfaController.backup));
+router.post(
+  "/mfa/validate",
+  authLimiter,
+  validate(mfaValidateSchema),
+  asyncHandler(MfaController.validate),
+);
+router.post(
+  "/mfa/backup",
+  authLimiter,
+  validate(mfaBackupSchema),
+  asyncHandler(MfaController.backup),
+);
 
 // Protected routes (no strict rate limiting required beyond global)
 router.post("/logout", authenticate, AuthController.logout);
@@ -50,24 +94,33 @@ router.post("/mfa/setup", authenticate, asyncHandler(MfaController.setup));
 router.post(
   "/mfa/verify-setup",
   authenticate,
+  validate(mfaVerifySetupSchema),
   asyncHandler(MfaController.verifySetup),
 );
-router.post("/mfa/disable", authenticate, asyncHandler(MfaController.disable));
+router.post(
+  "/mfa/disable",
+  authenticate,
+  validate(mfaDisableSchema),
+  asyncHandler(MfaController.disable),
+);
 
 // MFA OTP routes (SMS/email)
 router.post(
   "/mfa/otp/send",
   authenticate,
+  validate(mfaOtpSendSchema),
   asyncHandler(MfaOtpController.sendOtp),
 );
 router.post(
   "/mfa/otp/setup",
   authenticate,
+  validate(mfaOtpSetupSchema),
   asyncHandler(MfaOtpController.setupOtp),
 );
 router.post(
   "/mfa/otp/validate",
   authLimiter,
+  validate(mfaOtpValidateSchema),
   asyncHandler(MfaOtpController.validateOtp),
 );
 
@@ -75,6 +128,7 @@ router.post(
 router.get(
   "/sessions",
   authenticate,
+  validate(listAuthSessionsSchema),
   asyncHandler(SessionsController.listSessions),
 );
 router.delete(
@@ -85,6 +139,7 @@ router.delete(
 router.delete(
   "/sessions/:id",
   authenticate,
+  validate(revokeSessionParamSchema),
   asyncHandler(SessionsController.revokeSession),
 );
 
@@ -101,6 +156,7 @@ router.get(
 router.delete(
   "/oauth/:provider",
   authenticate,
+  validate(oauthProviderParamSchema),
   asyncHandler(OAuthController.unlinkProvider),
 );
 

--- a/src/routes/bulk.routes.ts
+++ b/src/routes/bulk.routes.ts
@@ -5,7 +5,7 @@ import { authenticate } from "../middleware/auth.middleware";
 import { requireAdmin } from "../middleware/admin-auth.middleware";
 import { validate } from "../middleware/validation.middleware";
 import { asyncHandler } from "../utils/asyncHandler.utils";
-import { bulkPaymentsSchema } from "../validators/schemas/bulk.schemas";
+import { bulkPaymentsSchema, bulkJobIdParamSchema } from "../validators/schemas/bulk.schemas";
 
 const router = Router();
 const upload = multer({
@@ -27,6 +27,10 @@ router.post(
   asyncHandler(BulkController.processPayments),
 );
 
-router.get("/jobs/:jobId", asyncHandler(BulkController.getJobStatus));
+router.get(
+  "/jobs/:jobId",
+  validate(bulkJobIdParamSchema),
+  asyncHandler(BulkController.getJobStatus),
+);
 
 export default router;

--- a/src/routes/calendar-sync.routes.ts
+++ b/src/routes/calendar-sync.routes.ts
@@ -2,6 +2,12 @@ import { Router } from "express";
 import { CalendarSyncController } from "../controllers/calendar-sync.controller";
 import { authenticate } from "../middleware/auth.middleware";
 import { asyncHandler } from "../utils/asyncHandler.utils";
+import { validate } from "../middleware/validation.middleware";
+import {
+  providerParamSchema,
+  toggleSyncSchema,
+  appleConnectSchema,
+} from "../validators/schemas/calendar-sync.schemas";
 
 const router = Router();
 
@@ -52,6 +58,7 @@ router.get(
 router.patch(
   "/:provider/toggle",
   authenticate,
+  validate(toggleSyncSchema),
   asyncHandler(CalendarSyncController.toggleSync),
 );
 
@@ -75,6 +82,7 @@ router.patch(
 router.delete(
   "/:provider",
   authenticate,
+  validate(providerParamSchema),
   asyncHandler(CalendarSyncController.disconnect),
 );
 
@@ -142,6 +150,7 @@ router.get(
 router.post(
   "/apple/connect",
   authenticate,
+  validate(appleConnectSchema),
   asyncHandler(CalendarSyncController.appleConnect),
 );
 

--- a/src/routes/calendar.routes.ts
+++ b/src/routes/calendar.routes.ts
@@ -3,6 +3,11 @@ import rateLimit from "express-rate-limit";
 import { CalendarController } from "../controllers/calendar.controller";
 import { authenticate } from "../middleware/auth.middleware";
 import { asyncHandler } from "../utils/asyncHandler.utils";
+import { validate } from "../middleware/validation.middleware";
+import {
+  icalTokenParamSchema,
+  googleOAuthCallbackSchema,
+} from "../validators/schemas/calendar.schemas";
 
 const router = Router();
 
@@ -24,6 +29,7 @@ const icalFeedLimiter = rateLimit({
 router.get(
   "/ical/:token",
   icalFeedLimiter,
+  validate(icalTokenParamSchema),
   asyncHandler(CalendarController.getICalFeed),
 );
 
@@ -45,7 +51,11 @@ router.get(
   authenticate,
   asyncHandler(CalendarController.googleConnect),
 );
-router.get("/google/callback", asyncHandler(CalendarController.googleCallback));
+router.get(
+  "/google/callback",
+  validate(googleOAuthCallbackSchema),
+  asyncHandler(CalendarController.googleCallback),
+);
 router.delete(
   "/google/disconnect",
   authenticate,

--- a/src/routes/certification.routes.ts
+++ b/src/routes/certification.routes.ts
@@ -2,6 +2,21 @@ import { Router } from "express";
 import { CertificationController } from "../controllers/certification.controller";
 import { authenticate } from "../middleware/auth.middleware";
 import { requireRole as authorize } from "../middleware/rbac.middleware";
+import { validate } from "../middleware/validation.middleware";
+import {
+  getCertificationTypesSchema,
+  createCertificationSchema,
+  getMentorCertificationsSchema,
+  getCertificationSummarySchema,
+  updateCertificationSchema,
+  verifyCertificationSchema,
+  startSkillTestSchema,
+  submitTestAnswersSchema,
+  initiateBackgroundCheckSchema,
+  getBackgroundCheckSchema,
+  getOnboardingProgressSchema,
+  completeOnboardingStepSchema,
+} from "../validators/schemas/certification.schemas";
 
 const router = Router();
 
@@ -14,7 +29,11 @@ router.use(authenticate);
 
 // Get all certification types
 // GET /api/v1/certifications/types
-router.get("/types", CertificationController.getCertificationTypes);
+router.get(
+  "/types",
+  validate(getCertificationTypesSchema),
+  CertificationController.getCertificationTypes,
+);
 
 /**
  * Certification Management Routes
@@ -25,6 +44,7 @@ router.get("/types", CertificationController.getCertificationTypes);
 router.post(
   "/",
   authorize("mentor"),
+  validate(createCertificationSchema),
   CertificationController.createCertification,
 );
 
@@ -33,6 +53,7 @@ router.post(
 router.get(
   "/mentor/:mentorId",
   authorize("mentor", "admin"),
+  validate(getMentorCertificationsSchema),
   CertificationController.getMentorCertifications,
 );
 
@@ -40,6 +61,7 @@ router.get(
 // GET /api/v1/certifications/mentor/:mentorId/summary
 router.get(
   "/mentor/:mentorId/summary",
+  validate(getCertificationSummarySchema),
   CertificationController.getCertificationSummary,
 );
 
@@ -48,6 +70,7 @@ router.get(
 router.put(
   "/:certificationId",
   authorize("admin"),
+  validate(updateCertificationSchema),
   CertificationController.updateCertification,
 );
 
@@ -56,6 +79,7 @@ router.put(
 router.post(
   "/:certificationId/verify",
   authorize("admin"),
+  validate(verifyCertificationSchema),
   CertificationController.verifyCertification,
 );
 
@@ -68,6 +92,7 @@ router.post(
 router.post(
   "/tests/:testId/start",
   authorize("mentor"),
+  validate(startSkillTestSchema),
   CertificationController.startSkillTest,
 );
 
@@ -76,6 +101,7 @@ router.post(
 router.post(
   "/tests/attempts/:attemptId/submit",
   authorize("mentor"),
+  validate(submitTestAnswersSchema),
   CertificationController.submitTestAnswers,
 );
 
@@ -88,6 +114,7 @@ router.post(
 router.post(
   "/background-checks",
   authorize("mentor"),
+  validate(initiateBackgroundCheckSchema),
   CertificationController.initiateBackgroundCheck,
 );
 
@@ -96,6 +123,7 @@ router.post(
 router.get(
   "/background-checks/:checkId",
   authorize("mentor", "admin"),
+  validate(getBackgroundCheckSchema),
   CertificationController.getBackgroundCheck,
 );
 
@@ -108,6 +136,7 @@ router.get(
 router.get(
   "/onboarding/:mentorId",
   authorize("mentor", "admin"),
+  validate(getOnboardingProgressSchema),
   CertificationController.getOnboardingProgress,
 );
 
@@ -116,6 +145,7 @@ router.get(
 router.post(
   "/onboarding/:mentorId/steps/:stepId/complete",
   authorize("mentor"),
+  validate(completeOnboardingStepSchema),
   CertificationController.completeOnboardingStep,
 );
 

--- a/src/routes/compliance.routes.ts
+++ b/src/routes/compliance.routes.ts
@@ -3,16 +3,37 @@ import { ComplianceController } from "../controllers/compliance.controller";
 import { authenticate } from "../middleware/auth.middleware";
 import { requireRole } from "../middleware/rbac.middleware";
 import { asyncHandler } from "../utils/asyncHandler.utils";
+import { validate } from "../middleware/validation.middleware";
+import {
+  createDSARSchema,
+  dsarIdParamSchema,
+  completeDSARSchema,
+  createRetentionPolicySchema,
+  recordLineageEventSchema,
+  listLineageEventsSchema,
+  complianceReportFiltersSchema,
+} from "../validators/schemas/compliance.schemas";
 
 const router = Router();
 
-router.post("/dsar", authenticate, asyncHandler(ComplianceController.createDSAR));
+router.post(
+  "/dsar",
+  authenticate,
+  validate(createDSARSchema),
+  asyncHandler(ComplianceController.createDSAR),
+);
 router.get("/dsar", authenticate, asyncHandler(ComplianceController.getDSARs));
-router.get("/dsar/:id", authenticate, asyncHandler(ComplianceController.getDSARById));
+router.get(
+  "/dsar/:id",
+  authenticate,
+  validate(dsarIdParamSchema),
+  asyncHandler(ComplianceController.getDSARById),
+);
 router.post(
   "/dsar/:id/complete",
   authenticate,
   requireRole("admin"),
+  validate(completeDSARSchema),
   asyncHandler(ComplianceController.completeDSAR),
 );
 
@@ -20,6 +41,7 @@ router.post(
   "/retention",
   authenticate,
   requireRole("admin"),
+  validate(createRetentionPolicySchema),
   asyncHandler(ComplianceController.createRetentionPolicy),
 );
 router.get(
@@ -38,12 +60,14 @@ router.post(
 router.post(
   "/lineage",
   authenticate,
+  validate(recordLineageEventSchema),
   asyncHandler(ComplianceController.recordLineageEvent),
 );
 router.get(
   "/lineage",
   authenticate,
   requireRole("admin"),
+  validate(listLineageEventsSchema),
   asyncHandler(ComplianceController.getLineageEvents),
 );
 
@@ -51,6 +75,7 @@ router.get(
   "/report",
   authenticate,
   requireRole("admin"),
+  validate(complianceReportFiltersSchema),
   asyncHandler(ComplianceController.generateComplianceReport),
 );
 

--- a/src/routes/conversations.routes.ts
+++ b/src/routes/conversations.routes.ts
@@ -3,6 +3,15 @@ import multer from 'multer';
 import { ConversationsController } from '../controllers/conversations.controller';
 import { authenticate } from '../middleware/auth.middleware';
 import { asyncHandler } from '../utils/asyncHandler.utils';
+import { validate } from '../middleware/validation.middleware';
+import {
+  createOrGetConversationSchema,
+  getMessagesSchema,
+  sendMessageSchema,
+  deleteMessageSchema,
+  markReadSchema,
+  uploadAttachmentSchema,
+} from '../validators/schemas/conversations.schemas';
 
 const router = Router();
 
@@ -44,7 +53,12 @@ const upload = multer({
  *       403:
  *         description: No shared booking between users
  */
-router.post('/', authenticate, asyncHandler(ConversationsController.createOrGet));
+router.post(
+  '/',
+  authenticate,
+  validate(createOrGetConversationSchema),
+  asyncHandler(ConversationsController.createOrGet),
+);
 
 /**
  * @swagger
@@ -89,7 +103,12 @@ router.get('/', authenticate, asyncHandler(ConversationsController.list));
  *       200:
  *         description: Paginated messages with nextCursor
  */
-router.get('/:id/messages', authenticate, asyncHandler(ConversationsController.getMessages));
+router.get(
+  '/:id/messages',
+  authenticate,
+  validate(getMessagesSchema),
+  asyncHandler(ConversationsController.getMessages),
+);
 
 /**
  * @swagger
@@ -120,7 +139,12 @@ router.get('/:id/messages', authenticate, asyncHandler(ConversationsController.g
  *       201:
  *         description: Message sent
  */
-router.post('/:id/messages', authenticate, asyncHandler(ConversationsController.sendMessage));
+router.post(
+  '/:id/messages',
+  authenticate,
+  validate(sendMessageSchema),
+  asyncHandler(ConversationsController.sendMessage),
+);
 
 /**
  * @swagger
@@ -152,6 +176,7 @@ router.post('/:id/messages', authenticate, asyncHandler(ConversationsController.
 router.delete(
   '/:id/messages/:msgId',
   authenticate,
+  validate(deleteMessageSchema),
   asyncHandler(ConversationsController.deleteMessage),
 );
 
@@ -174,7 +199,12 @@ router.delete(
  *       200:
  *         description: Messages marked as read
  */
-router.post('/:id/read', authenticate, asyncHandler(ConversationsController.markRead));
+router.post(
+  '/:id/read',
+  authenticate,
+  validate(markReadSchema),
+  asyncHandler(ConversationsController.markRead),
+);
 
 /**
  * @swagger
@@ -211,6 +241,7 @@ router.post('/:id/read', authenticate, asyncHandler(ConversationsController.mark
 router.post(
   '/:id/attachments',
   authenticate,
+  validate(uploadAttachmentSchema),
   upload.single('file'),
   asyncHandler(ConversationsController.uploadAttachment),
 );

--- a/src/routes/disputes.routes.ts
+++ b/src/routes/disputes.routes.ts
@@ -1,5 +1,13 @@
 import { Router } from "express";
 import { DisputesController } from "../controllers/disputes.controller";
+import { validate } from "../middleware/validation.middleware";
+import {
+  disputeIdParamSchema,
+  openDisputeSchema,
+  uploadEvidenceSchema,
+  resolveDisputeSchema,
+  mediateDisputeSchema,
+} from "../validators/schemas/disputes.schemas";
 
 const router = Router();
 
@@ -8,12 +16,24 @@ const router = Router();
 // User/Admin routes
 router.get("/templates/resolution", DisputesController.getResolutionTemplates);
 router.get("/", DisputesController.listDisputes);
-router.post("/", DisputesController.openDispute);
-router.get("/:id", DisputesController.getDispute);
-router.post("/:id/evidence", DisputesController.uploadEvidence);
+router.post("/", validate(openDisputeSchema), DisputesController.openDispute);
+router.get("/:id", validate(disputeIdParamSchema), DisputesController.getDispute);
+router.post(
+  "/:id/evidence",
+  validate(uploadEvidenceSchema),
+  DisputesController.uploadEvidence,
+);
 
 // Admin-only routes
-router.post("/:id/resolve", DisputesController.resolveDispute);
-router.post("/:id/mediate", DisputesController.mediateDispute);
+router.post(
+  "/:id/resolve",
+  validate(resolveDisputeSchema),
+  DisputesController.resolveDispute,
+);
+router.post(
+  "/:id/mediate",
+  validate(mediateDisputeSchema),
+  DisputesController.mediateDispute,
+);
 
 export default router;

--- a/src/routes/escrow.routes.ts
+++ b/src/routes/escrow.routes.ts
@@ -2,7 +2,17 @@ import { Router } from "express";
 import { authenticate } from "../middleware/auth.middleware";
 import { requireRole } from "../middleware/rbac.middleware";
 import { idempotency } from "../middleware/idempotency.middleware";
+import { validate } from "../middleware/validation.middleware";
 import { EscrowController } from "../controllers/escrow.controller";
+import {
+  createEscrowSchema,
+  releaseEscrowSchema,
+  disputeEscrowSchema,
+  resolveDisputeSchema,
+  refundEscrowSchema,
+  listEscrowsSchema,
+  getEscrowByIdSchema,
+} from "../validators/schemas/escrow.schemas";
 
 const router = Router();
 
@@ -10,27 +20,55 @@ const router = Router();
 router.use(authenticate);
 
 // POST /escrow — create escrow (learner only)
-router.post("/", requireRole("user"), idempotency, EscrowController.createEscrow);
+router.post(
+  "/",
+  requireRole("user"),
+  validate(createEscrowSchema),
+  idempotency,
+  EscrowController.createEscrow,
+);
 
 // GET /escrow — list user's escrows
-router.get("/", EscrowController.listEscrows);
+router.get("/", validate(listEscrowsSchema), EscrowController.listEscrows);
 
 // GET /escrow/:id — get escrow details
-router.get("/:id", EscrowController.getEscrow);
+router.get("/:id", validate(getEscrowByIdSchema), EscrowController.getEscrow);
 
 // GET /escrow/:id/status — get escrow status
-router.get("/:id/status", EscrowController.getEscrowStatus);
+router.get("/:id/status", validate(getEscrowByIdSchema), EscrowController.getEscrowStatus);
 
 // POST /escrow/:id/release — release funds to mentor (learner or admin)
-router.post("/:id/release", idempotency, EscrowController.releaseEscrow);
+router.post(
+  "/:id/release",
+  validate(releaseEscrowSchema),
+  idempotency,
+  EscrowController.releaseEscrow,
+);
 
 // POST /escrow/:id/refund — refund to learner (admin only)
-router.post("/:id/refund", requireRole("admin"), idempotency, EscrowController.refundEscrow);
+router.post(
+  "/:id/refund",
+  requireRole("admin"),
+  validate(refundEscrowSchema),
+  idempotency,
+  EscrowController.refundEscrow,
+);
 
 // POST /escrow/:id/dispute — open dispute (learner or mentor)
-router.post("/:id/dispute", idempotency, EscrowController.openDispute);
+router.post(
+  "/:id/dispute",
+  validate(disputeEscrowSchema),
+  idempotency,
+  EscrowController.openDispute,
+);
 
 // POST /escrow/:id/resolve — resolve dispute (admin only)
-router.post("/:id/resolve", requireRole("admin"), idempotency, EscrowController.resolveDispute);
+router.post(
+  "/:id/resolve",
+  requireRole("admin"),
+  validate(resolveDisputeSchema),
+  idempotency,
+  EscrowController.resolveDispute,
+);
 
 export default router;

--- a/src/routes/feature-flag.routes.ts
+++ b/src/routes/feature-flag.routes.ts
@@ -2,23 +2,38 @@ import { Router } from 'express';
 import { FeatureFlagController } from '../controllers/feature-flag.controller';
 import { authenticate } from '../middleware/auth.middleware';
 import { requireAdmin } from '../middleware/rbac.middleware';
+import { validate } from '../middleware/validation.middleware';
+import {
+  flagKeyParamSchema,
+  flagIdParamSchema,
+  evaluateFlagSchema,
+  trackConversionSchema,
+  createFeatureFlagSchema,
+  updateFeatureFlagSchema,
+  getMetricsSchema,
+} from '../validators/schemas/feature-flag.schemas';
 
 const router = Router();
 
 // ── Public evaluation (requires auth to identify user) ───────────────────────
-router.get('/evaluate/:key', authenticate, FeatureFlagController.evaluate);
-router.post('/evaluate/:key/conversion', authenticate, FeatureFlagController.trackConversion);
+router.get('/evaluate/:key', authenticate, validate(evaluateFlagSchema), FeatureFlagController.evaluate);
+router.post(
+  '/evaluate/:key/conversion',
+  authenticate,
+  validate(trackConversionSchema),
+  FeatureFlagController.trackConversion,
+);
 
 // ── Admin CRUD (admin only) ───────────────────────────────────────────────────
 router.use(authenticate, requireAdmin);
 
 router.get('/', FeatureFlagController.list);
-router.post('/', FeatureFlagController.create);
-router.get('/key/:key', FeatureFlagController.getByKey);
-router.get('/:id', FeatureFlagController.getById);
-router.put('/:id', FeatureFlagController.update);
-router.delete('/:id', FeatureFlagController.remove);
-router.post('/:id/disable', FeatureFlagController.disable);
-router.get('/metrics/:key', FeatureFlagController.getMetrics);
+router.post('/', validate(createFeatureFlagSchema), FeatureFlagController.create);
+router.get('/key/:key', validate(flagKeyParamSchema), FeatureFlagController.getByKey);
+router.get('/:id', validate(flagIdParamSchema), FeatureFlagController.getById);
+router.put('/:id', validate(updateFeatureFlagSchema), FeatureFlagController.update);
+router.delete('/:id', validate(flagIdParamSchema), FeatureFlagController.remove);
+router.post('/:id/disable', validate(flagIdParamSchema), FeatureFlagController.disable);
+router.get('/metrics/:key', validate(getMetricsSchema), FeatureFlagController.getMetrics);
 
 export default router;

--- a/src/routes/goal.routes.ts
+++ b/src/routes/goal.routes.ts
@@ -1,6 +1,14 @@
 import { Router } from 'express';
 import { GoalController } from '../controllers/goal.controller';
 import { authenticate } from '../middleware/auth.middleware';
+import { validate } from '../middleware/validation.middleware';
+import {
+  createGoalSchema,
+  goalIdParamSchema,
+  updateGoalSchema,
+  updateGoalProgressSchema,
+  linkSessionSchema,
+} from '../validators/schemas/goal.schemas';
 
 const router = Router();
 
@@ -15,7 +23,7 @@ router.use(authenticate as any);
  *     tags: [Goals]
  *     security: [{ bearerAuth: [] }]
  */
-router.post('/', GoalController.create);
+router.post('/', validate(createGoalSchema), GoalController.create);
 
 /**
  * @swagger
@@ -34,7 +42,7 @@ router.get('/', GoalController.list);
  *     summary: Get specific goal
  *     tags: [Goals]
  */
-router.get('/:id', GoalController.get);
+router.get('/:id', validate(goalIdParamSchema), GoalController.get);
 
 /**
  * @swagger
@@ -43,7 +51,7 @@ router.get('/:id', GoalController.get);
  *     summary: Update goal title, description, or target_date
  *     tags: [Goals]
  */
-router.put('/:id', GoalController.update);
+router.put('/:id', validate(updateGoalSchema), GoalController.update);
 
 /**
  * @swagger
@@ -52,7 +60,7 @@ router.put('/:id', GoalController.update);
  *     summary: Delete goal
  *     tags: [Goals]
  */
-router.delete('/:id', GoalController.delete);
+router.delete('/:id', validate(goalIdParamSchema), GoalController.delete);
 
 /**
  * @swagger
@@ -62,7 +70,7 @@ router.delete('/:id', GoalController.delete);
  *     tags: [Goals]
  *     security: [{ bearerAuth: [] }]
  */
-router.post('/:id/progress', GoalController.updateProgress);
+router.post('/:id/progress', validate(updateGoalProgressSchema), GoalController.updateProgress);
 
 /**
  * @swagger
@@ -72,7 +80,7 @@ router.post('/:id/progress', GoalController.updateProgress);
  *     tags: [Goals]
  *     security: [{ bearerAuth: [] }]
  */
-router.get('/:id/progress', GoalController.getProgress);
+router.get('/:id/progress', validate(goalIdParamSchema), GoalController.getProgress);
 
 /**
  * @swagger
@@ -81,6 +89,6 @@ router.get('/:id/progress', GoalController.getProgress);
  *     summary: Link session (booking) to goal
  *     tags: [Goals]
  */
-router.post('/:id/link-session', GoalController.linkSession);
+router.post('/:id/link-session', validate(linkSessionSchema), GoalController.linkSession);
 
 export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -27,6 +27,7 @@ import emailWebhookRoutes from "./emailWebhook.routes";
 import sessionRecordingRoutes from "./session-recording.routes";
 import subscriptionRoutes from "./subscriptions.routes";
 import taxRoutes from "./tax.routes";
+import oracleRoutes from "./oracle.routes";
 import { BookingsService } from "../services/bookings.service";
 import { notificationCleanupService } from "../services/notification-cleanup.service";
 import {
@@ -91,6 +92,7 @@ router.use("/calendar/sync", calendarSyncRoutes);
 router.use("/developer", developerRoutes);
 router.use("/subscriptions", subscriptionRoutes);
 router.use("/tax", taxRoutes);
+router.use("/oracle", oracleRoutes);
 router.use("/", exportRoutes);
 
 // JWKS public endpoint — no auth required

--- a/src/routes/integrations.routes.ts
+++ b/src/routes/integrations.routes.ts
@@ -3,6 +3,14 @@ import { asyncHandler } from "../utils/asyncHandler.utils";
 import { ResponseUtil } from "../utils/response.utils";
 import { ZapierController } from "../controllers/zapier.controller";
 import { ZapierService } from "../services/zapier.service";
+import { validate } from "../middleware/validation.middleware";
+import {
+  zapierSubscribeSchema,
+  zapierUnsubscribeSchema,
+  zapierTriggerSampleParamSchema,
+  zapierActionSampleParamSchema,
+  zapierExecuteActionSchema,
+} from "../validators/schemas/integrations.schemas";
 
 interface ZapierRequest extends Request {
   zapier?: Awaited<ReturnType<typeof ZapierService.authenticateApiKey>>;
@@ -31,10 +39,30 @@ async function authenticateZapier(
 
 router.use("/zapier", asyncHandler(authenticateZapier));
 router.get("/zapier/triggers", asyncHandler(ZapierController.listTriggers));
-router.post("/zapier/subscribe", asyncHandler(ZapierController.subscribe));
-router.delete("/zapier/unsubscribe", asyncHandler(ZapierController.unsubscribe));
-router.get("/zapier/sample/:trigger", asyncHandler(ZapierController.sample));
-router.get("/zapier/actions/:action/sample", asyncHandler(ZapierController.sampleAction));
-router.post("/zapier/actions/:action", asyncHandler(ZapierController.executeAction));
+router.post(
+  "/zapier/subscribe",
+  validate(zapierSubscribeSchema),
+  asyncHandler(ZapierController.subscribe),
+);
+router.delete(
+  "/zapier/unsubscribe",
+  validate(zapierUnsubscribeSchema),
+  asyncHandler(ZapierController.unsubscribe),
+);
+router.get(
+  "/zapier/sample/:trigger",
+  validate(zapierTriggerSampleParamSchema),
+  asyncHandler(ZapierController.sample),
+);
+router.get(
+  "/zapier/actions/:action/sample",
+  validate(zapierActionSampleParamSchema),
+  asyncHandler(ZapierController.sampleAction),
+);
+router.post(
+  "/zapier/actions/:action",
+  validate(zapierExecuteActionSchema),
+  asyncHandler(ZapierController.executeAction),
+);
 
 export default router;

--- a/src/routes/invoice.routes.ts
+++ b/src/routes/invoice.routes.ts
@@ -1,12 +1,24 @@
 import { Router } from "express";
 import { InvoiceController } from "../controllers/invoice.controller";
+import { validate } from "../middleware/validation.middleware";
+import {
+  createInvoiceSchema,
+  invoiceIdParamSchema,
+  listInvoicesSchema,
+  updateInvoiceStatusSchema,
+  bulkExportInvoicesSchema,
+} from "../validators/schemas/invoice.schemas";
 
 const router = Router();
 
-router.post("/invoices", InvoiceController.createInvoice);
-router.get("/invoices", InvoiceController.listInvoices);
-router.get("/invoices/export", InvoiceController.bulkExport);
-router.get("/invoices/:invoiceId", InvoiceController.getInvoice);
-router.patch("/invoices/:invoiceId/status", InvoiceController.updateStatus);
+router.post("/invoices", validate(createInvoiceSchema), InvoiceController.createInvoice);
+router.get("/invoices", validate(listInvoicesSchema), InvoiceController.listInvoices);
+router.get("/invoices/export", validate(bulkExportInvoicesSchema), InvoiceController.bulkExport);
+router.get("/invoices/:invoiceId", validate(invoiceIdParamSchema), InvoiceController.getInvoice);
+router.patch(
+  "/invoices/:invoiceId/status",
+  validate(updateInvoiceStatusSchema),
+  InvoiceController.updateStatus,
+);
 
 export default router;

--- a/src/routes/loyalty.routes.ts
+++ b/src/routes/loyalty.routes.ts
@@ -5,6 +5,11 @@ import {
 } from "../middleware/auth.middleware";
 import { LoyaltyService } from "../services/loyalty.service";
 import { asyncHandler } from "../utils/asyncHandler.utils";
+import { validate } from "../middleware/validation.middleware";
+import {
+  earnTokensSchema,
+  redeemTokensSchema,
+} from "../validators/schemas/loyalty.schemas";
 
 const router = Router();
 
@@ -89,6 +94,7 @@ router.get(
 router.post(
   "/earn",
   authenticate,
+  validate(earnTokensSchema),
   asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
     const { action } = req.body;
     const account = await LoyaltyService.earnTokens(req.user!.userId, action);
@@ -120,6 +126,7 @@ router.post(
 router.post(
   "/redeem",
   authenticate,
+  validate(redeemTokensSchema),
   asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
     const { tokens } = req.body;
     const account = await LoyaltyService.redeemTokens(

--- a/src/routes/mentor-onboarding.routes.ts
+++ b/src/routes/mentor-onboarding.routes.ts
@@ -1,7 +1,13 @@
 import { Router } from 'express';
 import { authenticate } from '../middleware/auth.middleware';
 import { requireAdmin } from '../middleware/admin-auth.middleware';
+import { validate } from '../middleware/validation.middleware';
 import { MentorOnboardingController } from '../controllers/mentor-onboarding.controller';
+import {
+  completeOnboardingStepFlowSchema,
+  pauseOnboardingSchema,
+  completeChecklistItemSchema,
+} from '../validators/schemas/mentor-onboarding-flow.schemas';
 
 const router = Router();
 
@@ -9,8 +15,12 @@ router.use(authenticate);
 
 router.post('/initialize', MentorOnboardingController.initialize);
 router.get('/progress', MentorOnboardingController.progress);
-router.post('/steps/:stepId/complete', MentorOnboardingController.completeStep);
-router.post('/pause', MentorOnboardingController.pause);
+router.post(
+  '/steps/:stepId/complete',
+  validate(completeOnboardingStepFlowSchema),
+  MentorOnboardingController.completeStep,
+);
+router.post('/pause', validate(pauseOnboardingSchema), MentorOnboardingController.pause);
 router.post('/resume', MentorOnboardingController.resume);
 router.get('/wizard-steps', MentorOnboardingController.wizardSteps);
 router.get('/profile-score', MentorOnboardingController.profileScore);
@@ -18,7 +28,11 @@ router.post('/profile-score/refresh', MentorOnboardingController.refreshProfileS
 router.get('/suggestions', MentorOnboardingController.suggestions);
 router.get('/email-sequences', MentorOnboardingController.emailSequences);
 router.get('/checklist', MentorOnboardingController.checklist);
-router.post('/checklist/:itemKey/complete', MentorOnboardingController.completeChecklistItem);
+router.post(
+  '/checklist/:itemKey/complete',
+  validate(completeChecklistItemSchema),
+  MentorOnboardingController.completeChecklistItem,
+);
 router.get('/analytics', MentorOnboardingController.analytics);
 
 router.get('/admin/analytics', requireAdmin, MentorOnboardingController.adminAnalytics);

--- a/src/routes/moderation.routes.ts
+++ b/src/routes/moderation.routes.ts
@@ -3,11 +3,28 @@ import { ModerationController } from "../controllers/moderation.controller";
 import { asyncHandler } from "../utils/asyncHandler.utils";
 import { authenticate } from "../middleware/auth.middleware";
 import { requireAdmin } from "../middleware/admin-auth.middleware";
+import { validate } from "../middleware/validation.middleware";
+import {
+  moderationFlagIdParamSchema,
+  getModerationQueueSchema,
+  getAIQueueSchema,
+  triggerAIScanSchema,
+  approveContentSchema,
+  rejectContentSchema,
+  escalateFlagSchema,
+  deleteFlagSchema,
+  getAppealsSchema,
+  resolveAppealSchema,
+} from "../validators/schemas/moderation.schemas";
 
 const router = Router();
 
 // Add DELETE endpoint for flag deletion
-router.delete("/:id", asyncHandler(ModerationController.deleteFlag));
+router.delete(
+  "/:id",
+  validate(deleteFlagSchema),
+  asyncHandler(ModerationController.deleteFlag),
+);
 
 // ── All moderation routes require authentication + admin role ─────────────────
 router.use(authenticate, requireAdmin);
@@ -31,7 +48,7 @@ router.use(authenticate, requireAdmin);
  *       200:
  *         description: Paginated moderation queue
  */
-router.get("/queue", asyncHandler(ModerationController.getQueue));
+router.get("/queue", validate(getModerationQueueSchema), asyncHandler(ModerationController.getQueue));
 
 /**
  * @swagger
@@ -42,7 +59,7 @@ router.get("/queue", asyncHandler(ModerationController.getQueue));
  *     security:
  *       - bearerAuth: []
  */
-router.get("/ai-queue", asyncHandler(ModerationController.getAIQueue));
+router.get("/ai-queue", validate(getAIQueueSchema), asyncHandler(ModerationController.getAIQueue));
 
 /**
  * @swagger
@@ -75,7 +92,7 @@ router.get("/stats", asyncHandler(ModerationController.getStats));
  *               contentType: { type: string, enum: [profile, review, message] }
  *               text:       { type: string }
  */
-router.post("/scan", asyncHandler(ModerationController.triggerAIScan));
+router.post("/scan", validate(triggerAIScanSchema), asyncHandler(ModerationController.triggerAIScan));
 
 /**
  * @swagger
@@ -91,7 +108,7 @@ router.post("/scan", asyncHandler(ModerationController.triggerAIScan));
  *         required: true
  *         schema: { type: string }
  */
-router.put("/:id/approve", asyncHandler(ModerationController.approveContent));
+router.put("/:id/approve", validate(approveContentSchema), asyncHandler(ModerationController.approveContent));
 
 /**
  * @swagger
@@ -102,7 +119,7 @@ router.put("/:id/approve", asyncHandler(ModerationController.approveContent));
  *     security:
  *       - bearerAuth: []
  */
-router.put("/:id/reject", asyncHandler(ModerationController.rejectContent));
+router.put("/:id/reject", validate(rejectContentSchema), asyncHandler(ModerationController.rejectContent));
 
 /**
  * @swagger
@@ -113,7 +130,7 @@ router.put("/:id/reject", asyncHandler(ModerationController.rejectContent));
  *     security:
  *       - bearerAuth: []
  */
-router.put("/:id/escalate", asyncHandler(ModerationController.escalateFlag));
+router.put("/:id/escalate", validate(escalateFlagSchema), asyncHandler(ModerationController.escalateFlag));
 
 /**
  * @swagger
@@ -124,7 +141,7 @@ router.put("/:id/escalate", asyncHandler(ModerationController.escalateFlag));
  *     security:
  *       - bearerAuth: []
  */
-router.delete("/:id", asyncHandler(ModerationController.deleteFlag));
+router.delete("/:id", validate(deleteFlagSchema), asyncHandler(ModerationController.deleteFlag));
 
 // ── Appeals ──────────────────────────────────────────────────────────────────
 
@@ -150,7 +167,7 @@ router.delete("/:id", asyncHandler(ModerationController.deleteFlag));
  *       200:
  *         description: Paginated appeals queue
  */
-router.get("/appeals", asyncHandler(ModerationController.getAppeals));
+router.get("/appeals", validate(getAppealsSchema), asyncHandler(ModerationController.getAppeals));
 
 /**
  * @swagger
@@ -173,6 +190,7 @@ router.get("/appeals", asyncHandler(ModerationController.getAppeals));
  */
 router.put(
   "/appeals/:id/resolve",
+  validate(resolveAppealSchema),
   asyncHandler(ModerationController.resolveAppeal),
 );
 

--- a/src/routes/notifications.routes.ts
+++ b/src/routes/notifications.routes.ts
@@ -3,6 +3,13 @@ import { NotificationsController } from "../controllers/notifications.controller
 import { NotificationPreferencesController } from "../controllers/notificationPreferences.controller";
 import { PushController } from "../controllers/push.controller";
 import { authenticate } from "../middleware/auth.middleware";
+import { validate } from "../middleware/validation.middleware";
+import {
+  listNotificationsSchema,
+  notificationIdParamSchema,
+  updateNotificationPreferencesSchema,
+  pushUnsubscribeSchema,
+} from "../validators/schemas/notifications.schemas";
 
 const router = Router();
 
@@ -63,7 +70,12 @@ const router = Router();
  *                         hasMore:
  *                           type: boolean
  */
-router.get("/", authenticate, NotificationsController.getNotifications);
+router.get(
+  "/",
+  authenticate,
+  validate(listNotificationsSchema),
+  NotificationsController.getNotifications,
+);
 
 /**
  * @swagger
@@ -150,7 +162,12 @@ router.put("/read-all", authenticate, NotificationsController.markAllAsRead);
  *       404:
  *         description: Notification not found
  */
-router.put("/:id/read", authenticate, NotificationsController.markAsRead);
+router.put(
+  "/:id/read",
+  authenticate,
+  validate(notificationIdParamSchema),
+  NotificationsController.markAsRead,
+);
 
 /**
  * @swagger
@@ -174,7 +191,12 @@ router.put("/:id/read", authenticate, NotificationsController.markAsRead);
  *       404:
  *         description: Notification not found
  */
-router.delete("/:id", authenticate, NotificationsController.deleteNotification);
+router.delete(
+  "/:id",
+  authenticate,
+  validate(notificationIdParamSchema),
+  NotificationsController.deleteNotification,
+);
 
 /**
  * @swagger
@@ -214,6 +236,7 @@ router.get(
 router.put(
   "/preferences",
   authenticate,
+  validate(updateNotificationPreferencesSchema),
   NotificationPreferencesController.updatePreferences,
 );
 
@@ -295,7 +318,12 @@ router.post("/push/subscribe", authenticate, PushController.subscribe);
  *       404:
  *         description: Token not found
  */
-router.delete("/push/unsubscribe", authenticate, PushController.unsubscribe);
+router.delete(
+  "/push/unsubscribe",
+  authenticate,
+  validate(pushUnsubscribeSchema),
+  PushController.unsubscribe,
+);
 
 /**
  * @swagger

--- a/src/routes/offline.routes.ts
+++ b/src/routes/offline.routes.ts
@@ -11,6 +11,15 @@ import { Router } from 'express';
 import rateLimit from 'express-rate-limit';
 import { authenticate } from '../middleware/auth.middleware';
 import { OfflineController } from '../controllers/offline.controller';
+import { validate } from '../middleware/validation.middleware';
+import {
+  getSnapshotSchema,
+  getDeltaSchema,
+  getQueueSchema,
+  enqueueActionSchema,
+  syncSchema,
+  resolveConflictSchema,
+} from '../validators/schemas/offline.schemas';
 
 const router = Router();
 
@@ -77,7 +86,12 @@ router.use(authenticate as any);
  *       429:
  *         description: Too many requests
  */
-router.get('/snapshot', snapshotLimiter, OfflineController.getSnapshot);
+router.get(
+  '/snapshot',
+  snapshotLimiter,
+  validate(getSnapshotSchema),
+  OfflineController.getSnapshot,
+);
 
 /**
  * @swagger
@@ -123,7 +137,7 @@ router.get('/sync-state', OfflineController.getSyncState);
  *       400:
  *         description: Invalid parameters
  */
-router.get('/delta', OfflineController.getDelta);
+router.get('/delta', validate(getDeltaSchema), OfflineController.getDelta);
 
 /**
  * @swagger
@@ -169,7 +183,7 @@ router.get('/queue/status', OfflineController.getQueueStatus);
  *       200:
  *         description: List of queued actions
  */
-router.get('/queue', OfflineController.getQueue);
+router.get('/queue', validate(getQueueSchema), OfflineController.getQueue);
 
 /**
  * @swagger
@@ -212,7 +226,7 @@ router.get('/queue', OfflineController.getQueue);
  *       400:
  *         description: Invalid request
  */
-router.post('/queue', OfflineController.enqueueAction);
+router.post('/queue', validate(enqueueActionSchema), OfflineController.enqueueAction);
 
 /**
  * @swagger
@@ -271,7 +285,7 @@ router.post('/queue', OfflineController.enqueueAction);
  *       429:
  *         description: Too many sync requests
  */
-router.post('/sync', syncLimiter, OfflineController.sync);
+router.post('/sync', syncLimiter, validate(syncSchema), OfflineController.sync);
 
 /**
  * @swagger
@@ -316,6 +330,10 @@ router.post('/sync', syncLimiter, OfflineController.sync);
  *       404:
  *         description: Action not found
  */
-router.post('/conflicts/:id/resolve', OfflineController.resolveConflict);
+router.post(
+  '/conflicts/:id/resolve',
+  validate(resolveConflictSchema),
+  OfflineController.resolveConflict,
+);
 
 export default router;

--- a/src/routes/oracle.routes.ts
+++ b/src/routes/oracle.routes.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import { OracleController } from "../controllers/oracle.controller";
+import { validate } from "../middleware/validation.middleware";
+import { getOraclePriceSchema } from "../validators/schemas/oracle.schemas";
+
+const router = Router();
+
+// GET /oracle/price/:asset — public price lookup, no auth required
+router.get("/price/:asset", validate(getOraclePriceSchema), OracleController.getPrice);
+
+export default router;

--- a/src/routes/referral.routes.ts
+++ b/src/routes/referral.routes.ts
@@ -2,6 +2,20 @@ import { Router } from "express";
 import { ReferralController } from "../controllers/referral.controller";
 import { authenticate } from "../middleware/auth.middleware";
 import { requireRole as authorize } from "../middleware/rbac.middleware";
+import { validate } from "../middleware/validation.middleware";
+import {
+  createReferralCodeSchema,
+  referralCodeParamSchema,
+  applyReferralCodeSchema,
+  listUserReferralsSchema,
+  referralStatsQuerySchema,
+  referralIdParamSchema,
+  updateReferralSchema,
+  createAffiliateProfileSchema,
+  affiliateUserIdParamSchema,
+  updateAffiliateProfileSchema,
+  requestPayoutSchema,
+} from "../validators/schemas/referral.schemas";
 
 const router = Router();
 
@@ -14,7 +28,7 @@ router.use(authenticate);
 
 // Create referral code
 // POST /api/v1/referrals/codes
-router.post("/codes", ReferralController.createReferralCode);
+router.post("/codes", validate(createReferralCodeSchema), ReferralController.createReferralCode);
 
 // Get user's referral codes
 // GET /api/v1/referrals/codes
@@ -22,7 +36,11 @@ router.get("/codes", ReferralController.getUserReferralCodes);
 
 // Validate referral code
 // GET /api/v1/referrals/codes/:code/validate
-router.get("/codes/:code/validate", ReferralController.validateReferralCode);
+router.get(
+  "/codes/:code/validate",
+  validate(referralCodeParamSchema),
+  ReferralController.validateReferralCode,
+);
 
 /**
  * Referral Tracking Routes
@@ -30,21 +48,22 @@ router.get("/codes/:code/validate", ReferralController.validateReferralCode);
 
 // Apply referral code (create referral)
 // POST /api/v1/referrals/apply
-router.post("/apply", ReferralController.applyReferralCode);
+router.post("/apply", validate(applyReferralCodeSchema), ReferralController.applyReferralCode);
 
 // Get user's referrals
 // GET /api/v1/referrals
-router.get("/", ReferralController.getUserReferrals);
+router.get("/", validate(listUserReferralsSchema), ReferralController.getUserReferrals);
 
 // Get referral statistics
 // GET /api/v1/referrals/stats
-router.get("/stats", ReferralController.getReferralStats);
+router.get("/stats", validate(referralStatsQuerySchema), ReferralController.getReferralStats);
 
 // Update referral status (admin only)
 // PUT /api/v1/referrals/:referralId
 router.put(
   "/:referralId",
   authorize("admin"),
+  validate(updateReferralSchema),
   ReferralController.updateReferral,
 );
 
@@ -54,20 +73,33 @@ router.put(
 
 // Create affiliate profile
 // POST /api/v1/referrals/affiliate
-router.post("/affiliate", ReferralController.createAffiliateProfile);
+router.post(
+  "/affiliate",
+  validate(createAffiliateProfileSchema),
+  ReferralController.createAffiliateProfile,
+);
 
 // Get affiliate profile
 // GET /api/v1/referrals/affiliate/:userId
-router.get("/affiliate/:userId", ReferralController.getAffiliateProfile);
+router.get(
+  "/affiliate/:userId",
+  validate(affiliateUserIdParamSchema),
+  ReferralController.getAffiliateProfile,
+);
 
 // Update affiliate profile
 // PUT /api/v1/referrals/affiliate/:userId
-router.put("/affiliate/:userId", ReferralController.updateAffiliateProfile);
+router.put(
+  "/affiliate/:userId",
+  validate(updateAffiliateProfileSchema),
+  ReferralController.updateAffiliateProfile,
+);
 
 // Get affiliate dashboard
 // GET /api/v1/referrals/affiliate/:userId/dashboard
 router.get(
   "/affiliate/:userId/dashboard",
+  validate(affiliateUserIdParamSchema),
   ReferralController.getAffiliateDashboard,
 );
 
@@ -76,6 +108,7 @@ router.get(
 router.post(
   "/affiliate/:userId/approve",
   authorize("admin"),
+  validate(affiliateUserIdParamSchema),
   ReferralController.approveAffiliateProfile,
 );
 
@@ -96,6 +129,7 @@ router.get("/tiers", ReferralController.getRewardTiers);
 router.post(
   "/affiliate/:userId/payout",
   authorize("admin"),
+  validate(requestPayoutSchema),
   ReferralController.requestPayout,
 );
 

--- a/src/routes/session-feedback.routes.ts
+++ b/src/routes/session-feedback.routes.ts
@@ -2,6 +2,13 @@ import { Router } from "express";
 import { SessionFeedbackController } from "../controllers/session-feedback.controller";
 import { authenticate } from "../middleware/auth.middleware";
 import { asyncHandler } from "../utils/asyncHandler.utils";
+import { validate } from "../middleware/validation.middleware";
+import {
+  submitFeedbackSchema,
+  sessionIdParamSchema,
+  mentorFeedbackParamSchema,
+  mentorIdParamSchema,
+} from "../validators/schemas/session-feedback.schemas";
 
 const router = Router();
 
@@ -37,7 +44,12 @@ const router = Router();
  *       403:
  *         description: Not authorized
  */
-router.post("/", authenticate, asyncHandler(SessionFeedbackController.submit));
+router.post(
+  "/",
+  authenticate,
+  validate(submitFeedbackSchema),
+  asyncHandler(SessionFeedbackController.submit),
+);
 
 /**
  * @swagger
@@ -59,6 +71,7 @@ router.post("/", authenticate, asyncHandler(SessionFeedbackController.submit));
 router.get(
   "/session/:sessionId",
   authenticate,
+  validate(sessionIdParamSchema),
   asyncHandler(SessionFeedbackController.getForSession),
 );
 
@@ -85,6 +98,7 @@ router.get(
  */
 router.get(
   "/mentor/:mentorId",
+  validate(mentorFeedbackParamSchema),
   asyncHandler(SessionFeedbackController.getMentorFeedback),
 );
 
@@ -105,6 +119,7 @@ router.get(
  */
 router.get(
   "/mentor/:mentorId/stats",
+  validate(mentorIdParamSchema),
   asyncHandler(SessionFeedbackController.getMentorStats),
 );
 

--- a/src/routes/session-milestone.routes.ts
+++ b/src/routes/session-milestone.routes.ts
@@ -2,6 +2,18 @@ import { Router } from "express";
 import { SessionMilestoneController } from "../controllers/session-milestone.controller";
 import { authenticate as authenticateToken } from "../middleware/auth.middleware";
 import { apiLimiter as rateLimitMiddleware } from "../middleware/rate-limit.middleware";
+import { validate } from "../middleware/validation.middleware";
+import {
+  bookingIdParamSchema,
+  milestoneIdParamSchema,
+  mentorIdParamSchema,
+  mentorStudentParamSchema,
+  linkSessionToMilestoneSchema,
+  updateSessionMappingSchema,
+  createSessionOutcomeSchema,
+  createContextualBookingSchema,
+  updateHybridModeConfigSchema,
+} from "../validators/schemas/session-milestone.schemas";
 
 const router = Router();
 
@@ -180,6 +192,7 @@ router.use(rateLimitMiddleware);
  */
 router.post(
   "/sessions/:bookingId/milestone",
+  validate(linkSessionToMilestoneSchema),
   SessionMilestoneController.linkSessionToMilestone,
 );
 
@@ -206,6 +219,7 @@ router.post(
  */
 router.delete(
   "/sessions/:bookingId/milestone",
+  validate(bookingIdParamSchema),
   SessionMilestoneController.unlinkSessionFromMilestone,
 );
 
@@ -249,6 +263,7 @@ router.delete(
  */
 router.patch(
   "/sessions/:bookingId/milestone",
+  validate(updateSessionMappingSchema),
   SessionMilestoneController.updateSessionMapping,
 );
 
@@ -280,6 +295,7 @@ router.patch(
  */
 router.get(
   "/sessions/:bookingId/context",
+  validate(bookingIdParamSchema),
   SessionMilestoneController.getSessionContext,
 );
 
@@ -313,6 +329,7 @@ router.get(
  */
 router.get(
   "/milestones/:milestoneId/sessions/available",
+  validate(milestoneIdParamSchema),
   SessionMilestoneController.getAvailableSessionsForMilestone,
 );
 
@@ -351,6 +368,7 @@ router.get(
  */
 router.get(
   "/milestones/:milestoneId/sessions",
+  validate(milestoneIdParamSchema),
   SessionMilestoneController.getSessionsForMilestone,
 );
 
@@ -422,6 +440,7 @@ router.get(
  */
 router.post(
   "/bookings/contextual",
+  validate(createContextualBookingSchema),
   SessionMilestoneController.createContextualBooking,
 );
 
@@ -461,6 +480,7 @@ router.post(
  */
 router.get(
   "/bookings/context/:mentorId/:studentId",
+  validate(mentorStudentParamSchema),
   SessionMilestoneController.getLearningPathContext,
 );
 
@@ -500,6 +520,7 @@ router.get(
  */
 router.get(
   "/bookings/recommendations/:mentorId/:studentId",
+  validate(mentorStudentParamSchema),
   SessionMilestoneController.getBookingRecommendations,
 );
 
@@ -546,6 +567,7 @@ router.get(
  */
 router.get(
   "/bookings/options/:mentorId/:studentId",
+  validate(mentorStudentParamSchema),
   SessionMilestoneController.getBookingOptions,
 );
 
@@ -614,6 +636,7 @@ router.get(
  */
 router.post(
   "/sessions/:bookingId/outcome",
+  validate(createSessionOutcomeSchema),
   SessionMilestoneController.createSessionOutcome,
 );
 
@@ -645,6 +668,7 @@ router.post(
  */
 router.get(
   "/sessions/:bookingId/outcome",
+  validate(bookingIdParamSchema),
   SessionMilestoneController.getSessionOutcome,
 );
 
@@ -676,6 +700,7 @@ router.get(
  */
 router.get(
   "/sessions/:bookingId/impact",
+  validate(bookingIdParamSchema),
   SessionMilestoneController.analyzeSessionImpact,
 );
 
@@ -720,6 +745,7 @@ router.get(
  */
 router.get(
   "/mentors/:mentorId/hybrid-config",
+  validate(mentorIdParamSchema),
   SessionMilestoneController.getHybridModeConfig,
 );
 
@@ -767,6 +793,7 @@ router.get(
  */
 router.patch(
   "/mentors/:mentorId/hybrid-config",
+  validate(updateHybridModeConfigSchema),
   SessionMilestoneController.updateHybridModeConfig,
 );
 

--- a/src/routes/session-quality.routes.ts
+++ b/src/routes/session-quality.routes.ts
@@ -2,6 +2,13 @@ import { Router } from "express";
 import { SessionQualityController } from "../controllers/session-quality.controller";
 import { authenticate } from "../middleware/auth.middleware";
 import { asyncHandler } from "../utils/asyncHandler.utils";
+import { validate } from "../middleware/validation.middleware";
+import {
+  sessionIdParamSchema,
+  mentorTrendSchema,
+  mentorIdParamSchema,
+  topSessionsSchema,
+} from "../validators/schemas/session-quality.schemas";
 
 const router = Router();
 
@@ -102,6 +109,7 @@ const router = Router();
 router.get(
   "/sessions/:sessionId",
   authenticate,
+  validate(sessionIdParamSchema),
   SessionQualityController.getSessionScore,
 );
 
@@ -183,6 +191,7 @@ router.get(
 router.get(
   "/mentors/:mentorId/trend",
   authenticate,
+  validate(mentorTrendSchema),
   SessionQualityController.getMentorTrend,
 );
 
@@ -236,6 +245,7 @@ router.get(
 router.get(
   "/mentors/:mentorId/insights",
   authenticate,
+  validate(mentorIdParamSchema),
   SessionQualityController.getMentorInsights,
 );
 
@@ -267,6 +277,7 @@ router.get(
 router.get(
   "/mentors/:mentorId/top-sessions",
   authenticate,
+  validate(topSessionsSchema),
   SessionQualityController.getTopSessions,
 );
 

--- a/src/routes/session-recording.routes.ts
+++ b/src/routes/session-recording.routes.ts
@@ -2,6 +2,20 @@ import { Router } from 'express';
 import { SessionRecordingController } from '../controllers/session-recording.controller';
 import { authenticate } from '../middleware/auth.middleware';
 import { asyncHandler } from '../utils/asyncHandler.utils';
+import { validate } from '../middleware/validation.middleware';
+import {
+  startRecordingSchema,
+  recordingIdParamSchema,
+  uploadRecordingSchema,
+  completeRecordingSchema,
+  updateConsentSchema,
+  generatePlaybackUrlSchema,
+  startTranscriptionSchema,
+  searchTranscriptionsSchema,
+  createBookmarkSchema,
+  bookmarkIdParamSchema,
+  updateBookmarkSchema,
+} from '../validators/schemas/session-recording.schemas';
 
 const router = Router();
 
@@ -11,36 +25,42 @@ router.use(authenticate);
 // Start recording for a session
 router.post(
   '/sessions/:sessionId/recordings/start',
+  validate(startRecordingSchema),
   asyncHandler(SessionRecordingController.startRecording),
 );
 
 // Upload recording data (typically for streaming or multipart uploads)
 router.post(
   '/recordings/:recordingId/upload',
+  validate(uploadRecordingSchema),
   asyncHandler(SessionRecordingController.uploadRecording),
 );
 
 // Mark recording as complete after processing
 router.post(
   '/recordings/:recordingId/complete',
+  validate(completeRecordingSchema),
   asyncHandler(SessionRecordingController.completeRecording),
 );
 
 // Update consent for a recording
 router.post(
   '/recordings/:recordingId/consent',
+  validate(updateConsentSchema),
   asyncHandler(SessionRecordingController.updateConsent),
 );
 
 // Generate playback URL for a recording
 router.get(
   '/recordings/:recordingId/playback-url',
+  validate(generatePlaybackUrlSchema),
   asyncHandler(SessionRecordingController.generatePlaybackUrl),
 );
 
 // Get recording details
 router.get(
   '/recordings/:recordingId',
+  validate(recordingIdParamSchema),
   asyncHandler(SessionRecordingController.getRecording),
 );
 
@@ -53,33 +73,39 @@ router.get(
 // Delete a recording
 router.delete(
   '/recordings/:recordingId',
+  validate(recordingIdParamSchema),
   asyncHandler(SessionRecordingController.deleteRecording),
 );
 
 // Transcription endpoints
 router.post(
   '/recordings/:recordingId/transcription',
+  validate(startTranscriptionSchema),
   asyncHandler(SessionRecordingController.startTranscription),
 );
 
 router.get(
   '/recordings/:recordingId/transcription',
+  validate(recordingIdParamSchema),
   asyncHandler(SessionRecordingController.getTranscription),
 );
 
 router.get(
   '/transcriptions/search',
+  validate(searchTranscriptionsSchema),
   asyncHandler(SessionRecordingController.searchTranscriptions),
 );
 
 // Bookmark endpoints
 router.post(
   '/recordings/:recordingId/bookmarks',
+  validate(createBookmarkSchema),
   asyncHandler(SessionRecordingController.createBookmark),
 );
 
 router.get(
   '/recordings/:recordingId/bookmarks',
+  validate(recordingIdParamSchema),
   asyncHandler(SessionRecordingController.getBookmarks),
 );
 
@@ -90,16 +116,19 @@ router.get(
 
 router.put(
   '/bookmarks/:bookmarkId',
+  validate(updateBookmarkSchema),
   asyncHandler(SessionRecordingController.updateBookmark),
 );
 
 router.delete(
   '/bookmarks/:bookmarkId',
+  validate(bookmarkIdParamSchema),
   asyncHandler(SessionRecordingController.deleteBookmark),
 );
 
 router.get(
   '/recordings/:recordingId/bookmarks/export',
+  validate(recordingIdParamSchema),
   asyncHandler(SessionRecordingController.exportBookmarks),
 );
 

--- a/src/routes/session-summary.routes.ts
+++ b/src/routes/session-summary.routes.ts
@@ -2,6 +2,13 @@ import { Router } from 'express';
 import { SessionSummaryController } from '../controllers/session-summary.controller';
 import { authenticate } from '../middleware/auth.middleware';
 import { asyncHandler } from '../utils/asyncHandler.utils';
+import { validate } from '../middleware/validation.middleware';
+import {
+  bookingIdParamSchema,
+  generateSummarySchema,
+  sessionIdParamSchema,
+  summaryIdParamSchema,
+} from '../validators/schemas/session-summary.schemas';
 
 const router = Router();
 
@@ -11,24 +18,28 @@ router.use(authenticate);
 // Generate a session summary for a booking
 router.post(
   '/bookings/:bookingId/summaries',
+  validate(generateSummarySchema),
   asyncHandler(SessionSummaryController.generateSummary),
 );
 
 // Get session summary by booking ID
 router.get(
   '/bookings/:bookingId/summaries',
+  validate(bookingIdParamSchema),
   asyncHandler(SessionSummaryController.getSummaryByBooking),
 );
 
 // Get session summary by session ID
 router.get(
   '/sessions/:sessionId/summary',
+  validate(sessionIdParamSchema),
   asyncHandler(SessionSummaryController.getSummaryBySession),
 );
 
 // Get session summary by ID
 router.get(
   '/summaries/:id',
+  validate(summaryIdParamSchema),
   asyncHandler(SessionSummaryController.getSummaryById),
 );
 
@@ -41,12 +52,14 @@ router.get(
 // Regenerate a session summary
 router.post(
   '/summaries/:id/regenerate',
+  validate(summaryIdParamSchema),
   asyncHandler(SessionSummaryController.regenerateSummary),
 );
 
 // Delete a session summary
 router.delete(
   '/summaries/:id',
+  validate(summaryIdParamSchema),
   asyncHandler(SessionSummaryController.deleteSummary),
 );
 

--- a/src/routes/session-transcription.routes.ts
+++ b/src/routes/session-transcription.routes.ts
@@ -1,30 +1,45 @@
 import { Router } from "express";
 import { SessionTranscriptionController } from "../controllers/session-transcription.controller";
+import { validate } from "../middleware/validation.middleware";
+import {
+  sessionIdParamSchema,
+  saveTranscriptSchema,
+  updateTranscriptSchema,
+  searchTranscriptsSchema,
+  translationParamSchema,
+  saveTranslationSchema,
+} from "../validators/schemas/session-transcription.schemas";
 
 const router = Router();
 
 router.get(
   "/sessions/:sessionId/transcript",
+  validate(sessionIdParamSchema),
   SessionTranscriptionController.getTranscript,
 );
 router.post(
   "/sessions/:sessionId/transcript",
+  validate(saveTranscriptSchema),
   SessionTranscriptionController.saveTranscript,
 );
 router.patch(
   "/sessions/:sessionId/transcript",
+  validate(updateTranscriptSchema),
   SessionTranscriptionController.updateTranscript,
 );
 router.get(
   "/transcripts/search",
+  validate(searchTranscriptsSchema),
   SessionTranscriptionController.searchTranscripts,
 );
 router.post(
   "/sessions/:sessionId/transcript/translations/:language",
+  validate(saveTranslationSchema),
   SessionTranscriptionController.saveTranslation,
 );
 router.get(
   "/sessions/:sessionId/transcript/translations/:language",
+  validate(translationParamSchema),
   SessionTranscriptionController.getTranslation,
 );
 

--- a/src/routes/subscriptions.routes.ts
+++ b/src/routes/subscriptions.routes.ts
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { SubscriptionController } from "../controllers/subscription.controller";
 import { authenticate } from "../middleware/auth.middleware";
+import { validate } from "../middleware/validation.middleware";
+import { idParamSchema } from "../validators/schemas/common.schemas";
 
 const router = Router();
 
@@ -24,6 +26,6 @@ router.get("/", authenticate, SubscriptionController.list);
 router.post("/", authenticate, SubscriptionController.subscribe);
 
 /** DELETE /api/v1/subscriptions/:id */
-router.delete("/:id", authenticate, SubscriptionController.cancel);
+router.delete("/:id", authenticate, validate(idParamSchema), SubscriptionController.cancel);
 
 export default router;

--- a/src/routes/tax.routes.ts
+++ b/src/routes/tax.routes.ts
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { TaxReportingController } from "../controllers/tax-reporting.controller";
 import { authenticate } from "../middleware/auth.middleware";
+import { validate } from "../middleware/validation.middleware";
+import { taxYearParamSchema } from "../validators/schemas/tax.schemas";
 
 const router = Router();
 
@@ -15,12 +17,18 @@ const router = Router();
 router.get("/reports", authenticate, TaxReportingController.listReports);
 
 /** GET /api/v1/tax/reports/:year */
-router.get("/reports/:year", authenticate, TaxReportingController.getReport);
+router.get(
+  "/reports/:year",
+  authenticate,
+  validate(taxYearParamSchema),
+  TaxReportingController.getReport,
+);
 
 /** POST /api/v1/tax/reports/:year/generate */
 router.post(
   "/reports/:year/generate",
   authenticate,
+  validate(taxYearParamSchema),
   TaxReportingController.generateReport,
 );
 

--- a/src/routes/tenant.routes.ts
+++ b/src/routes/tenant.routes.ts
@@ -3,6 +3,8 @@ import { TenantController } from "../controllers/tenant.controller";
 import { authenticate } from "../middleware/auth.middleware";
 import { requireRole } from "../middleware/rbac.middleware";
 import { asyncHandler } from "../utils/asyncHandler.utils";
+import { validate } from "../middleware/validation.middleware";
+import { idParamSchema } from "../validators/schemas/common.schemas";
 
 const router = Router();
 
@@ -13,8 +15,8 @@ router.get("/current", asyncHandler(TenantController.getCurrent));
 router.use(authenticate as any, requireRole("admin") as any);
 
 router.get("/", asyncHandler(TenantController.list));
-router.get("/:id", asyncHandler(TenantController.getById));
+router.get("/:id", validate(idParamSchema), asyncHandler(TenantController.getById));
 router.post("/", asyncHandler(TenantController.create));
-router.patch("/:id", asyncHandler(TenantController.update));
+router.patch("/:id", validate(idParamSchema), asyncHandler(TenantController.update));
 
 export default router;

--- a/src/routes/webhooks.routes.ts
+++ b/src/routes/webhooks.routes.ts
@@ -36,16 +36,6 @@ router.post('/:id/test', validate(webhookIdParamSchema),       WebhooksControlle
 // Publicly accessible but API Key protected
 router.post('/incoming', webhookAuth, WebhooksController.receive);
 
-// All other webhook routes require JWT authentication
-router.use(authenticate);
-
-router.post('/', WebhooksController.create);
-router.get('/', WebhooksController.list);
-router.get('/:id', WebhooksController.getOne);
-router.put('/:id', WebhooksController.update);
-router.delete('/:id', WebhooksController.remove);
-router.get('/:id/deliveries', WebhooksController.deliveries);
-router.post('/:id/test', WebhooksController.test);
-router.post('/:id/rotate-api-key', WebhooksController.rotateKey);
+router.post('/:id/rotate-api-key', validate(webhookIdParamSchema), WebhooksController.rotateKey);
 
 export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,10 @@
+import { initTracing } from "./config/tracing";
+
+// OpenTelemetry must be initialised before any other imports so that
+// auto-instrumentations (http, express, pg, ioredis) can patch modules
+// at load time, and so traceparent propagation works on outbound calls.
+initTracing();
+
 import * as Sentry from "@sentry/node";
 import { nodeProfilingIntegration } from "@sentry/profiling-node";
 

--- a/src/services/advanced-export.service.ts
+++ b/src/services/advanced-export.service.ts
@@ -1,5 +1,6 @@
 import { logger } from "../utils/logger";
 import archiver from "archiver";
+import { StorageService } from "./storage.service";
 
 export interface ExportConfig {
   title: string;
@@ -83,18 +84,21 @@ export const AdvancedExportService = {
   },
 
   /**
-   * Generate download link for large files
+   * Upload an export file to S3 and generate a presigned download link.
    */
   async generateDownloadLink(
     fileBuffer: Buffer,
     filename: string,
-    expiresIn: number = 3600
+    expiresIn: number = 3600,
+    userId: string = 'anonymous',
   ): Promise<string> {
     try {
-      // In a real implementation, this would upload to S3 and return a presigned URL
-      // For now, return a placeholder
-      const downloadId = Math.random().toString(36).substring(7);
-      return `/api/v1/analytics/download/${downloadId}`;
+      const key = `exports/${userId}/${Date.now()}/${filename}`;
+      await StorageService.uploadFile(key, fileBuffer, 'application/octet-stream', {
+        userId,
+        filename,
+      });
+      return await StorageService.generatePresignedUrl(key, expiresIn);
     } catch (error) {
       logger.error('Failed to generate download link', { error });
       throw error;

--- a/src/services/assetExchange.service.ts
+++ b/src/services/assetExchange.service.ts
@@ -12,6 +12,7 @@
 import { Asset } from '@stellar/stellar-sdk';
 import { server } from '../config/stellar';
 import { CacheService } from './cache.service';
+import { OracleService } from './oracle.service';
 import { logger } from '../utils/logger.utils';
 import { createError } from '../middleware/errorHandler';
 import { v4 as uuidv4 } from 'uuid';
@@ -80,6 +81,8 @@ export interface ExchangeRate {
   to: string;
   rate: string;       // how many `to` units per 1 `from` unit
   fetchedAt: string;  // ISO timestamp
+  source?: 'oracle' | 'sdex';
+  warning?: 'oracle_stale';
 }
 
 export interface PaymentQuote {
@@ -148,7 +151,7 @@ export const AssetExchangeService = {
     const cached = await CacheService.get<ExchangeRate>(key);
     if (cached) return cached;
 
-    const rate = await this._fetchRateFromDex(from, to);
+    const rate = await this._fetchRate(from, to);
     await CacheService.set(key, rate, RATE_TTL_SECONDS);
     return rate;
   },
@@ -238,7 +241,7 @@ export const AssetExchangeService = {
       await Promise.allSettled(
         pairs.map(async ([from, to]) => {
           try {
-            const rate = await this._fetchRateFromDex(from, to);
+            const rate = await this._fetchRate(from, to);
             await CacheService.set(rateKey(from, to), rate, RATE_TTL_SECONDS);
             logger.debug('Exchange rate refreshed', { from, to, rate: rate.rate });
           } catch (err) {
@@ -277,6 +280,69 @@ export const AssetExchangeService = {
       }
     }
     return pairs;
+  },
+
+  /**
+   * Resolve a rate preferring the on-chain oracle for XLM/USD-equivalent
+   * pairs. Falls back to the SDEX orderbook if the oracle is unconfigured,
+   * unreachable, or reports its price as stale (circuit breaker).
+   */
+  async _fetchRate(from: string, to: string): Promise<ExchangeRate> {
+    const oracleAsset = this._oracleAssetForPair(from, to);
+
+    if (oracleAsset && OracleService.isConfigured()) {
+      try {
+        const oraclePrice = await OracleService.getPrice(oracleAsset.symbol);
+
+        if (!oraclePrice.isStale) {
+          const rate = oracleAsset.invert
+            ? (1 / parseFloat(oraclePrice.price)).toFixed(7)
+            : oraclePrice.price;
+
+          return {
+            from,
+            to,
+            rate,
+            fetchedAt: oraclePrice.updatedAt,
+            source: 'oracle',
+          };
+        }
+
+        logger.warn('Oracle price is stale, falling back to SDEX', {
+          from,
+          to,
+          asset: oracleAsset.symbol,
+        });
+      } catch (err) {
+        logger.warn('Oracle price lookup failed, falling back to SDEX', {
+          from,
+          to,
+          error: err instanceof Error ? err.message : err,
+        });
+      }
+
+      const dexRate = await this._fetchRateFromDex(from, to);
+      return { ...dexRate, source: 'sdex', warning: 'oracle_stale' };
+    }
+
+    const dexRate = await this._fetchRateFromDex(from, to);
+    return { ...dexRate, source: 'sdex' };
+  },
+
+  /**
+   * Maps a supported asset pair to the oracle's asset symbol, if the oracle
+   * publishes a price for that pair. Currently only XLM/USD-equivalents.
+   */
+  _oracleAssetForPair(
+    from: string,
+    to: string,
+  ): { symbol: string; invert: boolean } | null {
+    const isUsdLike = (code: string) => code === 'USDC' || code === 'PYUSD';
+
+    if (from === 'XLM' && isUsdLike(to)) return { symbol: 'XLM', invert: false };
+    if (isUsdLike(from) && to === 'XLM') return { symbol: 'XLM', invert: true };
+
+    return null;
   },
 
   async _fetchRateFromDex(from: string, to: string): Promise<ExchangeRate> {

--- a/src/services/bookings.service.ts
+++ b/src/services/bookings.service.ts
@@ -20,6 +20,7 @@ import {
 import { NotificationType } from "../models/notifications.model";
 import { SessionSummaryModel } from "../models/session-summary.model";
 import { MentorsService } from "./mentors.service";
+import { AssetExchangeService } from "./assetExchange.service";
 
 export interface CreateBookingData {
   menteeId: string;
@@ -146,6 +147,19 @@ export const BookingsService = {
     const hourlyRate = mentorProfile.hourly_rate;
     const amount = ((data.durationMinutes / 60) * hourlyRate).toFixed(7);
 
+    // Best-effort USD equivalent (oracle preferred, SDEX fallback via
+    // AssetExchangeService). Never blocks booking creation on failure.
+    let usdEquivalent: string | null = null;
+    try {
+      const rate = await AssetExchangeService.getRate("XLM", "USDC");
+      usdEquivalent = (parseFloat(amount) * parseFloat(rate.rate)).toFixed(2);
+    } catch (error) {
+      logger.warn("Failed to compute USD equivalent for booking amount", {
+        mentorId: data.mentorId,
+        error: error instanceof Error ? error.message : error,
+      });
+    }
+
     // Create booking
     const booking = await BookingModel.create({
       menteeId: data.menteeId,
@@ -156,6 +170,7 @@ export const BookingsService = {
       notes: data.notes,
       amount,
       currency: "XLM",
+      usdEquivalent,
     });
 
     return booking;

--- a/src/services/export.service.ts
+++ b/src/services/export.service.ts
@@ -278,6 +278,34 @@ export const ExportService = {
     return { data: csv, fileName };
   },
 
+  /**
+   * Delete S3 objects and export_jobs rows older than `days` (GDPR retention limit).
+   */
+  async cleanupExpiredExports(days: number = 30): Promise<number> {
+    const expired = await ExportJobModel.findExpiredOlderThan(days);
+    const keys = expired
+      .map((job) => job.storage_key)
+      .filter((key): key is string => Boolean(key));
+
+    if (keys.length > 0) {
+      await StorageService.deleteFiles(keys);
+    }
+
+    const deletedCount = await ExportJobModel.deleteOlderThan(days);
+
+    if (deletedCount > 0) {
+      await AuditLoggerService.logEvent({
+        level: LogLevel.INFO,
+        action: "DATA_EXPORT_CLEANUP",
+        message: `Cleaned up ${deletedCount} expired export job(s)`,
+        entityType: "export_job",
+        metadata: { deletedCount, s3ObjectsDeleted: keys.length, days },
+      });
+    }
+
+    return deletedCount;
+  },
+
   async getJobStatus(jobId: string, userId: string) {
     const job = await ExportJobModel.findById(jobId);
     if (!job || job.user_id !== userId) {

--- a/src/services/jaeger.service.ts
+++ b/src/services/jaeger.service.ts
@@ -1,0 +1,43 @@
+import { logger } from "../utils/logger.utils";
+
+const JAEGER_QUERY_URL =
+  process.env.JAEGER_QUERY_URL ?? "http://localhost:16686/api/traces";
+
+export interface JaegerTraceResponse {
+  data: unknown[];
+  total?: number;
+}
+
+/**
+ * Queries the Jaeger query API for a full trace by its OpenTelemetry traceId.
+ * Returns null if Jaeger is unreachable or the trace is not found.
+ */
+export const JaegerService = {
+  async getTraceById(traceId: string): Promise<JaegerTraceResponse | null> {
+    const url = `${JAEGER_QUERY_URL}/${traceId}`;
+
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(5000) });
+
+      if (response.status === 404) {
+        return null;
+      }
+
+      if (!response.ok) {
+        logger.warn("Jaeger query returned non-OK status", {
+          traceId,
+          status: response.status,
+        });
+        return null;
+      }
+
+      return (await response.json()) as JaegerTraceResponse;
+    } catch (error) {
+      logger.error("Failed to query Jaeger for trace", {
+        traceId,
+        error: error instanceof Error ? error.message : error,
+      });
+      return null;
+    }
+  },
+};

--- a/src/services/oracle.service.ts
+++ b/src/services/oracle.service.ts
@@ -1,0 +1,274 @@
+/**
+ * OracleService
+ *
+ * Responsibilities:
+ *  - Query the deployed Soroban oracle contract for XLM/USD (and other) prices
+ *  - Cache prices in Redis with a 60 s TTL (matches the oracle's STALE_SECS window)
+ *  - Expose staleness so callers can apply a circuit-breaker fallback (e.g. SDEX)
+ */
+
+import * as StellarSdk from '@stellar/stellar-sdk';
+import { CacheService } from './cache.service';
+import { logger } from '../utils/logger.utils';
+import { createError } from '../middleware/errorHandler';
+import { logWarning } from '../utils/error.utils';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const ORACLE_PRICE_TTL_SECONDS = 60; // matches oracle contract STALE_SECS window
+const PRICE_SCALE = 10_000_000; // 7 decimals, matches Stellar stroop convention
+const MONITORED_ASSETS = ['XLM'];
+const STALENESS_CHECK_INTERVAL_MS = 60_000; // matches ORACLE_PRICE_TTL_SECONDS
+
+const cacheKey = (asset: string) => `mm:oracle:price:${asset}`;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface OraclePrice {
+  asset: string;
+  price: string; // decimal string, e.g. "0.1234567"
+  twap: string; // decimal string
+  isStale: boolean;
+  updatedAt: string; // ISO timestamp
+}
+
+interface OracleContractClient {
+  getPrice(asset: string): Promise<{ price: bigint; updatedAt: number }>;
+  getTwap(asset: string): Promise<bigint>;
+  isPriceStale(asset: string): Promise<boolean>;
+}
+
+// ---------------------------------------------------------------------------
+// Soroban RPC client
+// ---------------------------------------------------------------------------
+
+class StellarOracleClient implements OracleContractClient {
+  private readonly rpcServer: any;
+  private readonly networkPassphrase: string;
+
+  constructor() {
+    const sdkAny = StellarSdk as any;
+    const serverUrl =
+      process.env.SOROBAN_RPC_URL ||
+      process.env.STELLAR_RPC_URL ||
+      process.env.STELLAR_HORIZON_URL ||
+      'https://soroban-testnet.stellar.org';
+
+    const RpcServerCtor = sdkAny.SorobanRpc?.Server || sdkAny.rpc?.Server;
+    this.rpcServer = RpcServerCtor ? new RpcServerCtor(serverUrl) : null;
+
+    this.networkPassphrase =
+      process.env.STELLAR_NETWORK === 'mainnet'
+        ? sdkAny.Networks.PUBLIC
+        : sdkAny.Networks.TESTNET;
+  }
+
+  async getPrice(asset: string): Promise<{ price: bigint; updatedAt: number }> {
+    const result = await this.simulateReadCall('get_price', [asset]);
+    const [price, updatedAt] = result as [bigint, bigint];
+    return { price: BigInt(price), updatedAt: Number(updatedAt) };
+  }
+
+  async getTwap(asset: string): Promise<bigint> {
+    const result = await this.simulateReadCall('get_twap', [asset]);
+    return BigInt(result as bigint);
+  }
+
+  async isPriceStale(asset: string): Promise<boolean> {
+    const result = await this.simulateReadCall('is_price_stale', [asset]);
+    return Boolean(result);
+  }
+
+  private async simulateReadCall(method: string, args: unknown[]): Promise<unknown> {
+    const sdkAny = StellarSdk as any;
+
+    if (!this.rpcServer) {
+      throw new Error('Soroban RPC client is not available in @stellar/stellar-sdk');
+    }
+
+    const contractAddress =
+      process.env.SOROBAN_ORACLE_CONTRACT_ADDRESS ||
+      (() => {
+        throw new Error('SOROBAN_ORACLE_CONTRACT_ADDRESS is required');
+      })();
+
+    // A throwaway source account is sufficient for a read-only simulation call.
+    const sourcePublicKey =
+      process.env.PLATFORM_PUBLIC_KEY ||
+      StellarSdk.Keypair.random().publicKey();
+
+    const account = await this.rpcServer.getAccount(sourcePublicKey);
+    const contract = new sdkAny.Contract(contractAddress);
+    const scArgs = args.map((arg) => sdkAny.nativeToScVal(arg, { type: 'symbol' }));
+
+    const tx = new sdkAny.TransactionBuilder(account, {
+      fee: String(sdkAny.BASE_FEE || '100'),
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(contract.call(method, ...scArgs))
+      .setTimeout(30)
+      .build();
+
+    const simulation = await this.rpcServer.simulateTransaction(tx);
+
+    if (simulation?.error) {
+      throw new Error(String(simulation.error));
+    }
+
+    const SorobanRpc = sdkAny.SorobanRpc || sdkAny.rpc;
+    const returnValue = simulation?.result?.retval;
+
+    if (returnValue && sdkAny.scValToNative) {
+      return sdkAny.scValToNative(returnValue);
+    }
+
+    if (SorobanRpc?.scValToNative && returnValue) {
+      return SorobanRpc.scValToNative(returnValue);
+    }
+
+    throw new Error(`Unable to decode Soroban simulation result for ${method}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+function scaledToDecimalString(value: bigint): string {
+  const negative = value < 0n;
+  const abs = negative ? -value : value;
+  const whole = abs / BigInt(PRICE_SCALE);
+  const frac = (abs % BigInt(PRICE_SCALE)).toString().padStart(7, '0');
+  const sign = negative ? '-' : '';
+  return `${sign}${whole.toString()}.${frac}`;
+}
+
+class OracleServiceImpl {
+  private stalenessTimer: NodeJS.Timeout | null = null;
+  private lastAlertedStale = new Set<string>();
+
+  constructor(private client: OracleContractClient) {}
+
+  setClient(client: OracleContractClient): void {
+    this.client = client;
+  }
+
+  isConfigured(): boolean {
+    return Boolean(this.getContractAddress());
+  }
+
+  getContractAddress(): string | undefined {
+    return process.env.SOROBAN_ORACLE_CONTRACT_ADDRESS || undefined;
+  }
+
+  requireContractAddress(): string {
+    const address = this.getContractAddress();
+    if (!address) {
+      throw new Error('SOROBAN_ORACLE_CONTRACT_ADDRESS is required');
+    }
+    return address;
+  }
+
+  /**
+   * Return the current price for an asset, using a 60 s Redis cache.
+   * `isStale` reflects the oracle contract's own circuit-breaker check
+   * (last update older than its STALE_SECS window), not just cache age.
+   */
+  async getPrice(asset: string): Promise<OraclePrice> {
+    if (!this.isConfigured()) {
+      throw createError('Oracle contract is not configured', 503);
+    }
+
+    const key = cacheKey(asset);
+    const cached = await CacheService.get<OraclePrice>(key);
+    if (cached) return cached;
+
+    const price = await this.fetchPriceFromContract(asset);
+    await CacheService.set(key, price, ORACLE_PRICE_TTL_SECONDS);
+    return price;
+  }
+
+  /**
+   * Bypass cache and query the oracle contract directly.
+   */
+  async fetchPriceFromContract(asset: string): Promise<OraclePrice> {
+    const [{ price, updatedAt }, twap, isStale] = await Promise.all([
+      this.client.getPrice(asset),
+      this.client.getTwap(asset).catch(() => null),
+      this.client.isPriceStale(asset),
+    ]);
+
+    return {
+      asset,
+      price: scaledToDecimalString(price),
+      twap: twap !== null ? scaledToDecimalString(twap) : scaledToDecimalString(price),
+      isStale,
+      updatedAt: new Date(updatedAt * 1000).toISOString(),
+    };
+  }
+
+  /**
+   * Start a background interval that polls the oracle for staleness and
+   * raises a monitoring alert (log + Sentry breadcrumb/warning) the first
+   * time an asset transitions into a stale state. Call once at startup.
+   */
+  startStalenessMonitoring(): void {
+    if (!this.isConfigured() || this.stalenessTimer) return;
+
+    const check = async () => {
+      for (const asset of MONITORED_ASSETS) {
+        try {
+          const price = await this.getPrice(asset);
+          if (price.isStale) {
+            if (!this.lastAlertedStale.has(asset)) {
+              this.lastAlertedStale.add(asset);
+              logger.error('Oracle price reported stale', { asset, updatedAt: price.updatedAt });
+              logWarning(`Oracle price stale for ${asset}`, {
+                asset,
+                updatedAt: price.updatedAt,
+              });
+            }
+          } else {
+            this.lastAlertedStale.delete(asset);
+          }
+        } catch (error) {
+          logger.warn('Oracle staleness check failed', {
+            asset,
+            error: error instanceof Error ? error.message : error,
+          });
+        }
+      }
+    };
+
+    check();
+    this.stalenessTimer = setInterval(check, STALENESS_CHECK_INTERVAL_MS);
+    logger.info('OracleService: staleness monitoring started', {
+      intervalMs: STALENESS_CHECK_INTERVAL_MS,
+      assets: MONITORED_ASSETS,
+    });
+  }
+
+  stopStalenessMonitoring(): void {
+    if (this.stalenessTimer) {
+      clearInterval(this.stalenessTimer);
+      this.stalenessTimer = null;
+    }
+  }
+}
+
+const oracleService = new OracleServiceImpl(new StellarOracleClient());
+
+export const OracleService = {
+  setClient: (client: OracleContractClient) => oracleService.setClient(client),
+  isConfigured: () => oracleService.isConfigured(),
+  getContractAddress: () => oracleService.getContractAddress(),
+  requireContractAddress: () => oracleService.requireContractAddress(),
+  getPrice: (asset: string) => oracleService.getPrice(asset),
+  fetchPriceFromContract: (asset: string) => oracleService.fetchPriceFromContract(asset),
+  startStalenessMonitoring: () => oracleService.startStalenessMonitoring(),
+  stopStalenessMonitoring: () => oracleService.stopStalenessMonitoring(),
+};

--- a/src/services/session-milestone.service.ts
+++ b/src/services/session-milestone.service.ts
@@ -282,6 +282,7 @@ export const SessionMilestoneService = {
         status: row.status,
         amount: row.amount,
         currency: row.currency,
+        usd_equivalent: row.usd_equivalent,
         payment_status: row.payment_status,
         stellar_tx_hash: row.stellar_tx_hash,
         transaction_id: row.transaction_id,

--- a/src/services/storage.service.ts
+++ b/src/services/storage.service.ts
@@ -3,6 +3,7 @@ import {
   PutObjectCommand,
   GetObjectCommand,
   DeleteObjectCommand,
+  DeleteObjectsCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { env } from "../config/env";
@@ -38,6 +39,7 @@ export const StorageService = {
       Body: body,
       ContentType: contentType,
       Metadata: metadata,
+      ServerSideEncryption: "AES256",
     });
 
     await s3Client.send(command);
@@ -71,6 +73,18 @@ export const StorageService = {
       Key: key,
     });
 
+    await s3Client.send(command);
+  },
+
+  /**
+   * Delete multiple objects from S3 in a single batch request (max 1000 keys)
+   */
+  async deleteFiles(keys: string[]): Promise<void> {
+    if (keys.length === 0) return;
+    const command = new DeleteObjectsCommand({
+      Bucket: BUCKET,
+      Delete: { Objects: keys.map((Key) => ({ Key })) },
+    });
     await s3Client.send(command);
   },
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -33,6 +33,7 @@ const IS_TEST = env.NODE_ENV === "test";
 const LOG_LEVEL = env.LOG_LEVEL;
 
 import { traceStore } from "../middleware/tracing.middleware";
+import { trace } from "@opentelemetry/api";
 
 /**
  * Stable identifier for this process/pod.
@@ -132,13 +133,21 @@ export const logger = wrapStructuredLogger(
   pino({
     level: IS_TEST ? "silent" : LOG_LEVEL,
     redact: { paths: REDACT_PATHS, censor: "[REDACTED]" },
-    base: { instanceId: INSTANCE_ID },
+    base: { instanceId: INSTANCE_ID, service: "mentorminds-backend" },
     timestamp: pino.stdTimeFunctions.isoTime,
     mixin() {
       const context = traceStore.getStore();
-      return context
+      const fields: StructuredLogPayload = context
         ? { requestId: context.requestId, correlationId: context.correlationId }
         : {};
+
+      const spanContext = trace.getActiveSpan()?.spanContext();
+      if (spanContext) {
+        fields.traceId = spanContext.traceId;
+        fields.spanId = spanContext.spanId;
+      }
+
+      return fields;
     },
     ...(IS_PRODUCTION
       ? {}

--- a/src/utils/trace-context.utils.ts
+++ b/src/utils/trace-context.utils.ts
@@ -1,0 +1,60 @@
+import { trace, context as otelContext, Context } from "@opentelemetry/api";
+import { traceStore, TraceContext } from "../middleware/tracing.middleware";
+
+/**
+ * Trace fields to embed in BullMQ job payloads so worker logs can be
+ * correlated back to the HTTP request that enqueued the job.
+ */
+export interface JobTraceData {
+  requestId?: string;
+  correlationId?: string;
+  traceId?: string;
+  spanId?: string;
+}
+
+/**
+ * Snapshot the current request's trace/correlation context for embedding
+ * in a BullMQ job payload. Call this at the point a job is enqueued.
+ */
+export function captureJobTraceData(): JobTraceData {
+  const requestContext: TraceContext | undefined = traceStore.getStore();
+  const spanContext = trace.getActiveSpan()?.spanContext();
+
+  return {
+    requestId: requestContext?.requestId,
+    correlationId: requestContext?.correlationId,
+    traceId: spanContext?.traceId,
+    spanId: spanContext?.spanId,
+  };
+}
+
+/**
+ * Run `fn` with the trace/correlation context restored from job data, so
+ * that logger.mixin() picks up the same requestId/traceId as the original
+ * HTTP request, and any spans started inside `fn` link to that traceId via
+ * a remote parent span context.
+ */
+export async function runWithJobTraceContext<T>(
+  jobTraceData: JobTraceData | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const restoredTraceContext: TraceContext = {
+    requestId: jobTraceData?.requestId ?? "unknown",
+    correlationId: jobTraceData?.correlationId ?? "unknown",
+    startTime: Date.now(),
+  };
+
+  const run = () => traceStore.run(restoredTraceContext, fn);
+
+  if (jobTraceData?.traceId && jobTraceData?.spanId) {
+    const remoteParent: Context = trace.setSpanContext(otelContext.active(), {
+      traceId: jobTraceData.traceId,
+      spanId: jobTraceData.spanId,
+      traceFlags: 1,
+      isRemote: true,
+    });
+    return otelContext.with(remoteParent, run);
+  }
+
+  return run();
+}

--- a/src/validators/__tests__/common.schemas.test.ts
+++ b/src/validators/__tests__/common.schemas.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from './test-harness';
+import {
+  uuidSchema,
+  idParamSchema,
+  paginationSchema,
+  emailSchema,
+  passwordSchema,
+  stellarAddressSchema,
+  stellarTxHashSchema,
+  longTextSchema,
+  shortTextSchema,
+  urlSchema,
+} from '../schemas/common.schemas';
+
+const VALID_UUID = '123e4567-e89b-42d3-a456-426614174000';
+const VALID_STELLAR_ADDRESS = 'G' + 'A'.repeat(55);
+const VALID_TX_HASH = 'a'.repeat(64);
+
+describe('uuidSchema', () => {
+  it('accepts a valid UUID v4', () => {
+    expect(uuidSchema.safeParse(VALID_UUID).success).toBe(true);
+  });
+
+  it('rejects a non-UUID string (e.g. path traversal / SQLi attempt)', () => {
+    expect(uuidSchema.safeParse('../../etc/passwd').success).toBe(false);
+    expect(uuidSchema.safeParse("1' OR '1'='1").success).toBe(false);
+  });
+
+  it('rejects an empty string', () => {
+    expect(uuidSchema.safeParse('').success).toBe(false);
+  });
+});
+
+describe('idParamSchema', () => {
+  it('accepts { params: { id: <uuid> } }', () => {
+    expect(idParamSchema.safeParse({ params: { id: VALID_UUID } }).success).toBe(true);
+  });
+
+  it('rejects a non-UUID :id param with a structured error', () => {
+    const result = idParamSchema.safeParse({ params: { id: 'not-a-uuid' } });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('paginationSchema', () => {
+  it('defaults page/limit when absent', () => {
+    const result = paginationSchema.safeParse({ query: {} });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a limit above the configured maximum (integer overflow guard)', () => {
+    const result = paginationSchema.safeParse({ query: { limit: '999999999999' } });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a negative page number', () => {
+    const result = paginationSchema.safeParse({ query: { page: '-1' } });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('emailSchema', () => {
+  it('accepts a valid email and lowercases it', () => {
+    const result = emailSchema.safeParse('User@Example.com');
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toBe('user@example.com');
+  });
+
+  it('rejects an invalid email', () => {
+    expect(emailSchema.safeParse('not-an-email').success).toBe(false);
+  });
+});
+
+describe('passwordSchema', () => {
+  it('accepts a strong password', () => {
+    expect(passwordSchema.safeParse('Str0ngPass1').success).toBe(true);
+  });
+
+  it('rejects a password missing a number', () => {
+    expect(passwordSchema.safeParse('NoNumbersHere').success).toBe(false);
+  });
+
+  it('rejects a password below the minimum length', () => {
+    expect(passwordSchema.safeParse('Sh0rt').success).toBe(false);
+  });
+});
+
+describe('stellarAddressSchema', () => {
+  it('accepts a well-formed G-address', () => {
+    expect(stellarAddressSchema.safeParse(VALID_STELLAR_ADDRESS).success).toBe(true);
+  });
+
+  it('rejects an address with the wrong prefix', () => {
+    expect(stellarAddressSchema.safeParse('X' + 'A'.repeat(55)).success).toBe(false);
+  });
+
+  it('rejects an address of the wrong length', () => {
+    expect(stellarAddressSchema.safeParse('GABC').success).toBe(false);
+  });
+});
+
+describe('stellarTxHashSchema', () => {
+  it('accepts a 64-char hex hash', () => {
+    expect(stellarTxHashSchema.safeParse(VALID_TX_HASH).success).toBe(true);
+  });
+
+  it('rejects a non-hex hash', () => {
+    expect(stellarTxHashSchema.safeParse('z'.repeat(64)).success).toBe(false);
+  });
+});
+
+describe('longTextSchema (bio/notes-style fields, max 2000)', () => {
+  it('accepts text at the 2000 char boundary', () => {
+    expect(longTextSchema.safeParse('a'.repeat(2000)).success).toBe(true);
+  });
+
+  it('rejects text over 2000 chars (long-string attack)', () => {
+    expect(longTextSchema.safeParse('a'.repeat(2001)).success).toBe(false);
+  });
+});
+
+describe('shortTextSchema (title/topic-style fields, max 500)', () => {
+  it('accepts text at the 500 char boundary', () => {
+    expect(shortTextSchema.safeParse('a'.repeat(500)).success).toBe(true);
+  });
+
+  it('rejects text over 500 chars', () => {
+    expect(shortTextSchema.safeParse('a'.repeat(501)).success).toBe(false);
+  });
+});
+
+describe('urlSchema', () => {
+  it('accepts an https URL', () => {
+    expect(urlSchema.safeParse('https://example.com/path').success).toBe(true);
+  });
+
+  it('rejects a non-http(s) protocol (e.g. javascript: XSS vector)', () => {
+    expect(urlSchema.safeParse('javascript:alert(1)').success).toBe(false);
+  });
+});

--- a/src/validators/__tests__/domain-schemas.test.ts
+++ b/src/validators/__tests__/domain-schemas.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from './test-harness';
+import { getOraclePriceSchema } from '../schemas/oracle.schemas';
+import { getTraceSchema } from '../schemas/trace.schemas';
+import {
+  disputeIdParamSchema,
+  openDisputeSchema,
+  resolveDisputeSchema,
+} from '../schemas/disputes.schemas';
+
+const VALID_UUID = '123e4567-e89b-42d3-a456-426614174000';
+
+describe('getOraclePriceSchema', () => {
+  it('accepts an alphanumeric asset symbol', () => {
+    expect(getOraclePriceSchema.safeParse({ params: { asset: 'XLM' } }).success).toBe(true);
+  });
+
+  it('rejects an asset symbol with path-traversal characters', () => {
+    expect(getOraclePriceSchema.safeParse({ params: { asset: '../../secret' } }).success).toBe(false);
+  });
+
+  it('rejects an oversized asset symbol', () => {
+    expect(getOraclePriceSchema.safeParse({ params: { asset: 'A'.repeat(13) } }).success).toBe(false);
+  });
+});
+
+describe('getTraceSchema', () => {
+  it('accepts a 32-char hex traceId', () => {
+    expect(getTraceSchema.safeParse({ params: { traceId: 'a'.repeat(32) } }).success).toBe(true);
+  });
+
+  it('rejects a malformed traceId', () => {
+    expect(getTraceSchema.safeParse({ params: { traceId: 'not-a-trace-id' } }).success).toBe(false);
+  });
+});
+
+describe('disputes schemas', () => {
+  it('disputeIdParamSchema rejects a non-UUID id', () => {
+    expect(disputeIdParamSchema.safeParse({ params: { id: '1; DROP TABLE disputes;' } }).success).toBe(false);
+  });
+
+  it('openDisputeSchema requires session_id, type, reason', () => {
+    const result = openDisputeSchema.safeParse({
+      body: { session_id: VALID_UUID, type: 'payment', reason: 'Session was not delivered as agreed.' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('openDisputeSchema rejects unknown extra fields (.strict())', () => {
+    const result = openDisputeSchema.safeParse({
+      body: {
+        session_id: VALID_UUID,
+        type: 'payment',
+        reason: 'Session was not delivered.',
+        isAdmin: true,
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('resolveDisputeSchema rejects mentor_pct outside 0-100', () => {
+    const result = resolveDisputeSchema.safeParse({
+      params: { id: VALID_UUID },
+      body: { mentor_pct: 150 },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/validators/__tests__/run.ts
+++ b/src/validators/__tests__/run.ts
@@ -1,0 +1,5 @@
+import { run } from './test-harness';
+import './common.schemas.test';
+import './domain-schemas.test';
+
+run();

--- a/src/validators/__tests__/test-harness.ts
+++ b/src/validators/__tests__/test-harness.ts
@@ -1,0 +1,74 @@
+/**
+ * Minimal, dependency-free test harness for Zod validator schemas.
+ *
+ * The repo has no test runner installed (no Jest/Vitest/Mocha). Rather than
+ * adding a new framework as a side effect of a validation PR, this harness
+ * gives `describe`/`it`/`expect`-shaped assertions that run under plain
+ * ts-node. Run all suites with `npm run test:validators`.
+ */
+
+type TestFn = () => void | Promise<void>;
+
+interface TestCase {
+  suite: string;
+  name: string;
+  fn: TestFn;
+}
+
+const cases: TestCase[] = [];
+let currentSuite = '';
+
+export function describe(name: string, fn: () => void): void {
+  currentSuite = name;
+  fn();
+  currentSuite = '';
+}
+
+export function it(name: string, fn: TestFn): void {
+  cases.push({ suite: currentSuite, name, fn });
+}
+
+class AssertionError extends Error {}
+
+export function expect(actual: unknown) {
+  return {
+    toBe(expected: unknown) {
+      if (actual !== expected) {
+        throw new AssertionError(`expected ${JSON.stringify(actual)} to be ${JSON.stringify(expected)}`);
+      }
+    },
+    toBeTruthy() {
+      if (!actual) {
+        throw new AssertionError(`expected ${JSON.stringify(actual)} to be truthy`);
+      }
+    },
+    toBeFalsy() {
+      if (actual) {
+        throw new AssertionError(`expected ${JSON.stringify(actual)} to be falsy`);
+      }
+    },
+  };
+}
+
+export async function run(): Promise<void> {
+  let passed = 0;
+  let failed = 0;
+
+  for (const testCase of cases) {
+    const label = `${testCase.suite} > ${testCase.name}`;
+    try {
+      await testCase.fn();
+      passed++;
+      process.stdout.write(`  ✓ ${label}\n`);
+    } catch (error) {
+      failed++;
+      const message = error instanceof Error ? error.message : String(error);
+      process.stdout.write(`  ✗ ${label}\n    ${message}\n`);
+    }
+  }
+
+  process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
+  if (failed > 0) {
+    process.exitCode = 1;
+  }
+}

--- a/src/validators/schemas/admin.schemas.ts
+++ b/src/validators/schemas/admin.schemas.ts
@@ -1,0 +1,360 @@
+import { z } from 'zod';
+import { uuidSchema, shortTextSchema, longTextSchema } from './common.schemas';
+
+// ---------------------------------------------------------------------------
+// Params
+// ---------------------------------------------------------------------------
+
+export const adminIdParamSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+});
+
+export const adminDeliveryIdParamSchema = z.object({
+    params: z.object({ deliveryId: uuidSchema }),
+});
+
+export const adminTemplateParamSchema = z.object({
+    params: z.object({
+        template: z
+            .string()
+            .trim()
+            .min(1, 'Template name is required')
+            .max(100, 'Template name is too long')
+            .regex(/^[a-zA-Z0-9_-]+$/, 'Template name contains invalid characters'),
+    }),
+});
+
+// ---------------------------------------------------------------------------
+// GET /admin/users
+// ---------------------------------------------------------------------------
+
+export const listAdminUsersSchema = z.object({
+    query: z.object({
+        page: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 1))
+            .refine((v) => Number.isInteger(v) && v >= 1 && v <= 1_000_000, 'Invalid page'),
+        limit: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 50))
+            .refine((v) => Number.isInteger(v) && v >= 1 && v <= 100, 'Limit must be between 1 and 100'),
+        role: z.enum(['mentor', 'mentee', 'admin']).optional(),
+    }),
+});
+
+// ---------------------------------------------------------------------------
+// PUT /admin/users/:id/status
+// ---------------------------------------------------------------------------
+
+export const updateUserStatusSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+    body: z
+        .object({
+            isActive: z.boolean(),
+        })
+        .strict(),
+});
+
+// ---------------------------------------------------------------------------
+// PUT /admin/users/:id/tier
+// ---------------------------------------------------------------------------
+
+export const updateUserTierSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+    body: z
+        .object({
+            tier: z.enum(['free', 'pro', 'enterprise']),
+        })
+        .strict(),
+});
+
+// ---------------------------------------------------------------------------
+// PUT /admin/users/:id/suspend
+// ---------------------------------------------------------------------------
+
+export const suspendUserSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+    body: z
+        .object({
+            reason: shortTextSchema,
+            expiresAt: z.string().datetime().optional(),
+        })
+        .strict(),
+});
+
+// ---------------------------------------------------------------------------
+// PUT /admin/users/:id/ban
+// ---------------------------------------------------------------------------
+
+export const banUserSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+    body: z
+        .object({
+            reason: shortTextSchema,
+        })
+        .strict(),
+});
+
+// ---------------------------------------------------------------------------
+// GET /admin/transactions
+// ---------------------------------------------------------------------------
+
+export const listAdminTransactionsSchema = z.object({
+    query: z.object({
+        page: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 1))
+            .refine((v) => Number.isInteger(v) && v >= 1 && v <= 1_000_000, 'Invalid page'),
+        limit: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 50))
+            .refine((v) => Number.isInteger(v) && v >= 1 && v <= 100, 'Limit must be between 1 and 100'),
+    }),
+});
+
+// ---------------------------------------------------------------------------
+// GET /admin/sessions
+// ---------------------------------------------------------------------------
+
+export const listAdminSessionsSchema = z.object({
+    query: z.object({
+        limit: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 50))
+            .refine((v) => Number.isInteger(v) && v >= 1 && v <= 100, 'Limit must be between 1 and 100'),
+        offset: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 0))
+            .refine((v) => Number.isInteger(v) && v >= 0 && v <= 10_000_000, 'Invalid offset'),
+        status: z.string().trim().max(50).optional(),
+    }),
+});
+
+// ---------------------------------------------------------------------------
+// GET /admin/payments
+// ---------------------------------------------------------------------------
+
+export const listAdminPaymentsSchema = z.object({
+    query: z.object({
+        limit: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 50))
+            .refine((v) => Number.isInteger(v) && v >= 1 && v <= 100, 'Limit must be between 1 and 100'),
+        offset: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 0))
+            .refine((v) => Number.isInteger(v) && v >= 0 && v <= 10_000_000, 'Invalid offset'),
+        startDate: z.string().trim().max(40).optional(),
+        endDate: z.string().trim().max(40).optional(),
+    }),
+});
+
+// ---------------------------------------------------------------------------
+// GET /admin/disputes
+// ---------------------------------------------------------------------------
+
+export const listAdminDisputesSchema = z.object({
+    query: z.object({
+        page: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 1))
+            .refine((v) => Number.isInteger(v) && v >= 1 && v <= 1_000_000, 'Invalid page'),
+        limit: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 50))
+            .refine((v) => Number.isInteger(v) && v >= 1 && v <= 100, 'Limit must be between 1 and 100'),
+    }),
+});
+
+// ---------------------------------------------------------------------------
+// POST /admin/disputes/:id/resolve
+// ---------------------------------------------------------------------------
+
+export const resolveDisputeSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+    body: z
+        .object({
+            status: z.enum(['resolved', 'dismissed']),
+            notes: longTextSchema.optional(),
+        })
+        .strict(),
+});
+
+// ---------------------------------------------------------------------------
+// GET /admin/logs
+// ---------------------------------------------------------------------------
+
+export const getAdminLogsSchema = z.object({
+    query: z.object({
+        page: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 1))
+            .refine((v) => Number.isInteger(v) && v >= 1 && v <= 1_000_000, 'Invalid page'),
+        limit: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 50))
+            .refine((v) => Number.isInteger(v) && v >= 1 && v <= 100, 'Limit must be between 1 and 100'),
+        action: z.string().trim().max(100).optional(),
+        userId: uuidSchema.optional(),
+        level: z.string().trim().max(20).optional(),
+    }),
+});
+
+// ---------------------------------------------------------------------------
+// POST /admin/config
+// ---------------------------------------------------------------------------
+
+export const updateConfigSchema = z.object({
+    body: z
+        .object({
+            key: z.string().trim().min(1).max(200),
+            value: z.union([z.string().max(2000), z.number(), z.boolean()]),
+        })
+        .strict(),
+});
+
+// ---------------------------------------------------------------------------
+// GET /admin/audit-log, /admin/audit-log/export
+// ---------------------------------------------------------------------------
+
+export const getAuditLogSchema = z.object({
+    query: z.object({
+        page: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 1))
+            .refine((v) => Number.isInteger(v) && v >= 1 && v <= 1_000_000, 'Invalid page'),
+        limit: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 50))
+            .refine((v) => Number.isInteger(v) && v >= 1 && v <= 100, 'Limit must be between 1 and 100'),
+        userId: uuidSchema.optional(),
+        action: z.string().trim().max(100).optional(),
+        resourceType: z.string().trim().max(100).optional(),
+        startDate: z.string().trim().max(40).optional(),
+        endDate: z.string().trim().max(40).optional(),
+    }),
+});
+
+export const exportAuditLogSchema = z.object({
+    query: z.object({
+        userId: uuidSchema.optional(),
+        action: z.string().trim().max(100).optional(),
+        resourceType: z.string().trim().max(100).optional(),
+        startDate: z.string().trim().max(40).optional(),
+        endDate: z.string().trim().max(40).optional(),
+    }),
+});
+
+export const auditLogStatsSchema = z.object({
+    query: z.object({
+        startDate: z.string().trim().max(40).optional(),
+        endDate: z.string().trim().max(40).optional(),
+    }),
+});
+
+// ---------------------------------------------------------------------------
+// POST /admin/email/preview/:template
+// ---------------------------------------------------------------------------
+
+export const previewEmailTemplateSchema = z.object({
+    params: z.object({
+        template: z
+            .string()
+            .trim()
+            .min(1, 'Template name is required')
+            .max(100, 'Template name is too long')
+            .regex(/^[a-zA-Z0-9_-]+$/, 'Template name contains invalid characters'),
+    }),
+    body: z.record(z.string(), z.unknown()).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Reports
+// ---------------------------------------------------------------------------
+
+export const revenueSummarySchema = z.object({
+    query: z.object({
+        period: z.enum(['7d', '30d', '90d', '1y']).optional(),
+    }),
+});
+
+export const dailyRevenueSchema = z.object({
+    query: z.object({
+        from: z.string().trim().min(1).max(40),
+        to: z.string().trim().min(1).max(40),
+    }),
+});
+
+export const transactionReportSchema = z.object({
+    query: z.object({
+        status: z.string().trim().max(50).optional(),
+        from: z.string().trim().min(1).max(40),
+        to: z.string().trim().min(1).max(40),
+    }),
+});
+
+export const exportReportSchema = z.object({
+    query: z.object({
+        type: z.enum(['revenue']).optional(),
+        format: z.enum(['csv']).optional(),
+        from: z.string().trim().max(40).optional(),
+        to: z.string().trim().max(40).optional(),
+        status: z.string().trim().max(50).optional(),
+    }),
+});
+
+// ---------------------------------------------------------------------------
+// Security blocklist / allowlist
+// ---------------------------------------------------------------------------
+
+export const addBlocklistRuleSchema = z.object({
+    body: z
+        .object({
+            ipRange: z.string().trim().min(1).max(64),
+            reason: shortTextSchema.optional(),
+        })
+        .strict(),
+});
+
+export const removeBlocklistRuleSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+});
+
+export const addAllowlistRuleSchema = z.object({
+    body: z
+        .object({
+            ipRange: z.string().trim().min(1).max(64),
+            reason: shortTextSchema.optional(),
+        })
+        .strict(),
+});
+
+// ---------------------------------------------------------------------------
+// Verifications
+// ---------------------------------------------------------------------------
+
+export const approveVerificationSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+});
+
+// ---------------------------------------------------------------------------
+// Webhook delivery retry
+// ---------------------------------------------------------------------------
+
+export const retryWebhookDeliverySchema = z.object({
+    params: z.object({ deliveryId: uuidSchema }),
+});

--- a/src/validators/schemas/analytics.schemas.ts
+++ b/src/validators/schemas/analytics.schemas.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+import { uuidSchema } from './common.schemas';
+
+const timeframeQuery = z.object({
+    timeframe: z.enum(['week', 'month', 'quarter', 'year', 'all']).optional(),
+});
+
+export const pathAnalyticsSchema = z.object({
+    params: z.object({ pathId: uuidSchema }),
+    query: timeframeQuery,
+});
+
+export const pathMilestonesSchema = z.object({
+    params: z.object({ pathId: uuidSchema }),
+    query: timeframeQuery,
+});
+
+export const pathTrendsSchema = z.object({
+    params: z.object({ pathId: uuidSchema }),
+    query: timeframeQuery,
+});
+
+export const pathBottlenecksSchema = z.object({
+    params: z.object({ pathId: uuidSchema }),
+    query: timeframeQuery,
+});
+
+export const studentProfileSchema = z.object({
+    params: z.object({ studentId: uuidSchema }),
+    query: z.object({ pathId: uuidSchema.optional() }),
+});
+
+export const studentPathInsightsSchema = z.object({
+    params: z.object({ studentId: uuidSchema, pathId: uuidSchema }),
+});
+
+export const studentPathComparisonSchema = z.object({
+    params: z.object({ studentId: uuidSchema, pathId: uuidSchema }),
+});
+
+export const mentorDashboardSchema = z.object({
+    params: z.object({ mentorId: uuidSchema }),
+    query: timeframeQuery,
+});

--- a/src/validators/schemas/auth.schemas.ts
+++ b/src/validators/schemas/auth.schemas.ts
@@ -4,7 +4,7 @@
  */
 
 import { z } from 'zod';
-import { emailSchema, passwordSchema } from './common.schemas';
+import { emailSchema, passwordSchema, uuidSchema } from './common.schemas';
 
 export const registerSchema = z.object({
     body: z.object({
@@ -62,6 +62,90 @@ export const changePasswordSchema = z.object({
             .min(1, 'Current password is required'),
         newPassword: passwordSchema,
     }).strict(),
+});
+
+// ---------------------------------------------------------------------------
+// MFA (TOTP) schemas
+// ---------------------------------------------------------------------------
+
+export const mfaVerifySetupSchema = z.object({
+    body: z.object({
+        token: z.string().trim().min(1, 'Token is required').max(20),
+    }).strict(),
+});
+
+export const mfaDisableSchema = z.object({
+    body: z.object({
+        token: z.string().trim().min(1, 'Token is required').max(20),
+    }).strict(),
+});
+
+export const mfaValidateSchema = z.object({
+    body: z.object({
+        mfaToken: z.string().trim().min(1, 'mfaToken is required').max(2000),
+        otpToken: z.string().trim().min(1, 'otpToken is required').max(20),
+    }).strict(),
+});
+
+export const mfaBackupSchema = z.object({
+    body: z.object({
+        mfaToken: z.string().trim().min(1, 'mfaToken is required').max(2000),
+        backupCode: z.string().trim().min(1, 'backupCode is required').max(50),
+    }).strict(),
+});
+
+// ---------------------------------------------------------------------------
+// MFA OTP (SMS/email) schemas
+// ---------------------------------------------------------------------------
+
+export const mfaOtpSendSchema = z.object({
+    body: z.object({
+        method: z.enum(['sms', 'email']),
+    }).strict(),
+});
+
+export const mfaOtpSetupSchema = z.object({
+    body: z.object({
+        method: z.enum(['sms', 'email']),
+        code: z.string().trim().min(1, 'code is required').max(20),
+        phone: z.string().trim().min(5).max(20).optional(),
+    }).strict(),
+});
+
+export const mfaOtpValidateSchema = z.object({
+    body: z.object({
+        mfaToken: z.string().trim().min(1, 'mfaToken is required').max(2000),
+        code: z.string().trim().min(1, 'code is required').max(20),
+    }).strict(),
+});
+
+// ---------------------------------------------------------------------------
+// Session management schemas
+// ---------------------------------------------------------------------------
+
+export const listAuthSessionsSchema = z.object({
+    query: z.object({
+        cursor: z.string().trim().max(500).optional(),
+        limit: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 20))
+            .refine((v) => Number.isInteger(v) && v >= 1 && v <= 100, 'Limit must be between 1 and 100'),
+    }),
+});
+
+export const revokeSessionParamSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+});
+
+// ---------------------------------------------------------------------------
+// OAuth schemas
+// ---------------------------------------------------------------------------
+
+export const oauthProviderParamSchema = z.object({
+    params: z.object({
+        provider: z.enum(['google', 'github']),
+    }),
 });
 
 export type RegisterInput = z.infer<typeof registerSchema>['body'];

--- a/src/validators/schemas/bulk.schemas.ts
+++ b/src/validators/schemas/bulk.schemas.ts
@@ -1,4 +1,9 @@
 import { z } from "zod";
+import { uuidSchema } from "./common.schemas";
+
+export const bulkJobIdParamSchema = z.object({
+  params: z.object({ jobId: uuidSchema }),
+});
 
 export const bulkPaymentsSchema = z.object({
   body: z.object({

--- a/src/validators/schemas/calendar-sync.schemas.ts
+++ b/src/validators/schemas/calendar-sync.schemas.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+// `provider` is a fixed enum slug (google/outlook/apple), not a UUID.
+const providerEnum = z.enum(['google', 'outlook', 'apple']);
+
+export const providerParamSchema = z.object({
+    params: z.object({ provider: providerEnum }),
+});
+
+export const toggleSyncSchema = z.object({
+    params: z.object({ provider: providerEnum }),
+    body: z
+        .object({
+            enabled: z.boolean(),
+        })
+        .strict(),
+});
+
+export const appleConnectSchema = z.object({
+    body: z
+        .object({
+            apple_id: z.string().trim().min(1).max(254),
+            app_password: z.string().trim().min(1).max(200),
+        })
+        .strict(),
+});

--- a/src/validators/schemas/calendar.schemas.ts
+++ b/src/validators/schemas/calendar.schemas.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const icalTokenParamSchema = z.object({
+    params: z.object({
+        token: z
+            .string()
+            .trim()
+            .length(64, 'Token must be exactly 64 characters')
+            .regex(/^[a-fA-F0-9]+$/, 'Token must be hexadecimal'),
+    }),
+});
+
+export const googleOAuthCallbackSchema = z.object({
+    query: z.object({
+        code: z.string().trim().max(2048).optional(),
+        state: z.string().trim().max(500).optional(),
+        error: z.string().trim().max(200).optional(),
+    }),
+});

--- a/src/validators/schemas/certification.schemas.ts
+++ b/src/validators/schemas/certification.schemas.ts
@@ -1,0 +1,115 @@
+import { z } from 'zod';
+import { uuidSchema, longTextSchema } from './common.schemas';
+
+export const getCertificationTypesSchema = z.object({
+    query: z.object({
+        activeOnly: z.enum(['true', 'false']).optional(),
+    }),
+});
+
+export const createCertificationSchema = z.object({
+    body: z
+        .object({
+            certificationTypeId: uuidSchema,
+            verificationMethod: z.string().trim().min(1).max(100),
+            metadata: z.record(z.string(), z.unknown()).optional(),
+            notes: longTextSchema.optional(),
+        })
+        .strict(),
+});
+
+export const getMentorCertificationsSchema = z.object({
+    params: z.object({ mentorId: uuidSchema }),
+    query: z.object({
+        includeExpired: z.enum(['true', 'false']).optional(),
+    }),
+});
+
+export const getCertificationSummarySchema = z.object({
+    params: z.object({ mentorId: uuidSchema }),
+});
+
+export const certificationStatusEnum = z.enum([
+    'pending',
+    'approved',
+    'rejected',
+    'revoked',
+    'expired',
+]);
+
+export const updateCertificationSchema = z.object({
+    params: z.object({ certificationId: uuidSchema }),
+    body: z
+        .object({
+            status: certificationStatusEnum.optional(),
+            score: z.number().min(0).max(100).optional(),
+            metadata: z.record(z.string(), z.unknown()).optional(),
+            notes: longTextSchema.optional(),
+            revocationReason: longTextSchema.optional(),
+        })
+        .strict(),
+});
+
+export const verifyCertificationSchema = z.object({
+    params: z.object({ certificationId: uuidSchema }),
+    body: z
+        .object({
+            status: certificationStatusEnum,
+            notes: longTextSchema.optional(),
+        })
+        .strict(),
+});
+
+export const startSkillTestSchema = z.object({
+    params: z.object({ testId: uuidSchema }),
+    body: z
+        .object({
+            certificationId: uuidSchema.optional(),
+        })
+        .strict()
+        .optional(),
+});
+
+export const submitTestAnswersSchema = z.object({
+    params: z.object({ attemptId: uuidSchema }),
+    body: z
+        .object({
+            answers: z.array(z.unknown()).min(1).max(500),
+        })
+        .strict(),
+});
+
+export const initiateBackgroundCheckSchema = z.object({
+    body: z
+        .object({
+            certificationId: uuidSchema.optional(),
+            checkType: z.string().trim().min(1).max(100),
+            provider: z.string().trim().min(1).max(100),
+        })
+        .strict(),
+});
+
+export const getBackgroundCheckSchema = z.object({
+    params: z.object({ checkId: uuidSchema }),
+});
+
+export const getOnboardingProgressSchema = z.object({
+    params: z.object({ mentorId: uuidSchema }),
+});
+
+export const completeOnboardingStepSchema = z.object({
+    params: z.object({
+        mentorId: uuidSchema,
+        stepId: z.string().trim().min(1).max(100),
+    }),
+});
+
+export const getPendingCertificationsSchema = z.object({
+    query: z.object({
+        limit: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 50))
+            .refine((v) => Number.isInteger(v) && v >= 1 && v <= 100, 'Limit must be between 1 and 100'),
+    }),
+});

--- a/src/validators/schemas/compliance.schemas.ts
+++ b/src/validators/schemas/compliance.schemas.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod';
+import { uuidSchema, longTextSchema } from './common.schemas';
+
+export const createDSARSchema = z.object({
+    body: z
+        .object({
+            type: z.enum(['access', 'deletion', 'portability', 'rectification']),
+            metadata: z.record(z.string(), z.unknown()).optional(),
+        })
+        .strict(),
+});
+
+export const dsarIdParamSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+});
+
+export const completeDSARSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+    body: z
+        .object({
+            data: z.record(z.string(), z.unknown()).optional(),
+        })
+        .strict()
+        .optional(),
+});
+
+export const createRetentionPolicySchema = z.object({
+    body: z
+        .object({
+            dataType: z.string().trim().min(1).max(200),
+            retentionPeriod: z.number().int().min(1).max(36_500, 'retentionPeriod must not exceed 100 years'),
+            deletionMethod: z.enum(['soft', 'hard', 'anonymize']),
+            legalBasis: z.string().trim().min(1).max(500),
+        })
+        .strict(),
+});
+
+export const recordLineageEventSchema = z.object({
+    body: z
+        .object({
+            dataType: z.string().trim().min(1).max(200),
+            sourceSystem: z.string().trim().min(1).max(200),
+            destinationSystem: z.string().trim().min(1).max(200),
+            description: longTextSchema,
+            metadata: z.record(z.string(), z.unknown()).optional(),
+        })
+        .strict(),
+});
+
+export const complianceReportFiltersSchema = z.object({
+    query: z.object({
+        startDate: z.string().trim().max(40).optional(),
+        endDate: z.string().trim().max(40).optional(),
+        userId: uuidSchema.optional(),
+    }),
+});
+
+export const listLineageEventsSchema = z.object({
+    query: z.object({
+        page: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 1))
+            .refine((v) => Number.isInteger(v) && v >= 1 && v <= 1_000_000, 'Invalid page'),
+        limit: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 50))
+            .refine((v) => Number.isInteger(v) && v >= 1 && v <= 100, 'Limit must be between 1 and 100'),
+        startDate: z.string().trim().max(40).optional(),
+        endDate: z.string().trim().max(40).optional(),
+        userId: uuidSchema.optional(),
+    }),
+});

--- a/src/validators/schemas/conversations.schemas.ts
+++ b/src/validators/schemas/conversations.schemas.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+import { uuidSchema } from './common.schemas';
+
+export const createOrGetConversationSchema = z.object({
+    body: z
+        .object({
+            participantId: uuidSchema,
+        })
+        .strict(),
+});
+
+export const conversationIdParamSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+});
+
+export const getMessagesSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+    query: z.object({
+        limit: z.string().optional(),
+        cursor: z.string().trim().max(200).optional(),
+    }),
+});
+
+export const sendMessageSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+    body: z
+        .object({
+            body: z.string().trim().min(1, 'Message body is required').max(5000),
+        })
+        .strict(),
+});
+
+export const deleteMessageSchema = z.object({
+    params: z.object({ id: uuidSchema, msgId: uuidSchema }),
+});
+
+export const markReadSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+});
+
+export const uploadAttachmentSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+});

--- a/src/validators/schemas/disputes.schemas.ts
+++ b/src/validators/schemas/disputes.schemas.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+import { uuidSchema, longTextSchema, urlSchema } from './common.schemas';
+
+export const disputeIdParamSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+});
+
+export const openDisputeSchema = z.object({
+    body: z
+        .object({
+            session_id: uuidSchema,
+            type: z.string().trim().min(1).max(100),
+            reason: longTextSchema,
+        })
+        .strict(),
+});
+
+export const uploadEvidenceSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+    body: z
+        .object({
+            text_content: z.string().trim().max(5000).optional(),
+            file_url: urlSchema.optional(),
+        })
+        .strict(),
+});
+
+export const resolveDisputeSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+    body: z
+        .object({
+            mentor_pct: z
+                .number()
+                .min(0, 'mentor_pct must be at least 0')
+                .max(100, 'mentor_pct must not exceed 100'),
+            notes: longTextSchema.optional(),
+        })
+        .strict(),
+});
+
+export const mediateDisputeSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+    body: z
+        .object({
+            notes: longTextSchema.optional(),
+        })
+        .strict(),
+});

--- a/src/validators/schemas/feature-flag.schemas.ts
+++ b/src/validators/schemas/feature-flag.schemas.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+import { uuidSchema } from './common.schemas';
+
+const flagKeySchema = z
+    .string()
+    .trim()
+    .min(1, 'key is required')
+    .max(255)
+    .regex(/^[a-zA-Z0-9_.-]+$/, 'key must be alphanumeric with -, _, . allowed');
+
+const flagVariantSchema = z.object({
+    key: z.string().trim().min(1).max(100),
+    weight: z.number().min(0).max(100).optional(),
+    payload: z.unknown().optional(),
+}).passthrough();
+
+const flagTargetingSchema = z.record(z.string(), z.unknown());
+
+export const flagKeyParamSchema = z.object({
+    params: z.object({ key: flagKeySchema }),
+});
+
+export const flagIdParamSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+});
+
+export const evaluateFlagSchema = z.object({
+    params: z.object({ key: flagKeySchema }),
+    query: z.object({
+        userId: z.string().trim().max(200).optional(),
+        segment: z.string().trim().max(200).optional(),
+        tenantId: uuidSchema.optional(),
+    }),
+});
+
+export const trackConversionSchema = z.object({
+    params: z.object({ key: flagKeySchema }),
+    body: z
+        .object({
+            userId: z.string().trim().min(1).max(200),
+            variant: z.string().trim().max(100).optional(),
+            metadata: z.record(z.string(), z.unknown()).optional(),
+        })
+        .strict(),
+});
+
+export const createFeatureFlagSchema = z.object({
+    body: z
+        .object({
+            key: flagKeySchema,
+            name: z.string().trim().min(1).max(255),
+            description: z.string().trim().max(2000).optional(),
+            enabled: z.boolean().optional(),
+            rolloutPercentage: z.number().min(0).max(100).optional(),
+            targeting: flagTargetingSchema.optional(),
+            variants: z.array(flagVariantSchema).max(50).optional(),
+        })
+        .strict(),
+});
+
+export const updateFeatureFlagSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+    body: z
+        .object({
+            name: z.string().trim().min(1).max(255).optional(),
+            description: z.string().trim().max(2000).optional(),
+            enabled: z.boolean().optional(),
+            rolloutPercentage: z.number().min(0).max(100).optional(),
+            targeting: flagTargetingSchema.optional(),
+            variants: z.array(flagVariantSchema).max(50).optional(),
+        })
+        .strict(),
+});
+
+export const getMetricsSchema = z.object({
+    params: z.object({ key: flagKeySchema }),
+    query: z.object({
+        since: z.string().datetime().optional(),
+    }),
+});

--- a/src/validators/schemas/goal.schemas.ts
+++ b/src/validators/schemas/goal.schemas.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+import { uuidSchema, longTextSchema } from './common.schemas';
+
+export const createGoalSchema = z.object({
+    body: z
+        .object({
+            title: z.string().trim().min(1, 'title is required').max(500),
+            description: longTextSchema.optional(),
+            target_date: z.string().date().optional(),
+            progress: z.number().min(0).max(100).optional(),
+            status: z.enum(['active', 'completed', 'paused']).optional(),
+        })
+        .strict(),
+});
+
+export const goalIdParamSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+});
+
+export const updateGoalSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+    body: z
+        .object({
+            title: z.string().trim().min(1).max(500).optional(),
+            description: longTextSchema.optional(),
+            target_date: z.string().date().optional(),
+            progress: z.number().min(0).max(100).optional(),
+            status: z.enum(['active', 'completed', 'paused']).optional(),
+        })
+        .strict(),
+});
+
+export const updateGoalProgressSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+    body: z
+        .object({
+            progress: z.number().min(0).max(100),
+            notes: longTextSchema.optional(),
+        })
+        .strict(),
+});
+
+export const linkSessionSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+    body: z
+        .object({
+            booking_id: uuidSchema,
+        })
+        .strict(),
+});

--- a/src/validators/schemas/integrations.schemas.ts
+++ b/src/validators/schemas/integrations.schemas.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+
+const triggerEnum = z.enum([
+    'new_booking',
+    'session_completed',
+    'payment_received',
+    'new_review',
+]);
+
+const actionEnum = z.enum([
+    'send_message',
+    'create_note',
+    'update_goal_progress',
+]);
+
+export const zapierSubscribeSchema = z.object({
+    body: z
+        .object({
+            trigger: triggerEnum,
+            targetUrl: z.string().trim().url('targetUrl must be a valid URL').max(2048),
+            secret: z.string().trim().min(8).max(200).optional(),
+            metadata: z.record(z.string(), z.unknown()).optional(),
+        })
+        .strict(),
+});
+
+export const zapierUnsubscribeSchema = z.object({
+    body: z
+        .object({
+            subscriptionId: z.string().trim().min(1).max(200).optional(),
+            targetUrl: z.string().trim().url().max(2048).optional(),
+        })
+        .strict()
+        .refine((b) => b.subscriptionId !== undefined || b.targetUrl !== undefined, {
+            message: 'subscriptionId or targetUrl is required',
+        }),
+});
+
+export const zapierTriggerSampleParamSchema = z.object({
+    params: z.object({ trigger: triggerEnum }),
+});
+
+export const zapierActionSampleParamSchema = z.object({
+    params: z.object({ action: actionEnum }),
+});
+
+export const zapierExecuteActionSchema = z.object({
+    params: z.object({ action: actionEnum }),
+    body: z.record(z.string(), z.unknown()).optional(),
+});

--- a/src/validators/schemas/invoice.schemas.ts
+++ b/src/validators/schemas/invoice.schemas.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+import { uuidSchema } from './common.schemas';
+
+const lineItemSchema = z.object({
+    description: z.string().trim().min(1).max(500),
+    quantity: z.number().positive().max(1_000_000),
+    unitPrice: z.string().regex(/^\d+(\.\d{1,7})?$/, 'unitPrice must be a valid decimal'),
+    total: z.string().regex(/^\d+(\.\d{1,7})?$/, 'total must be a valid decimal'),
+    taxRate: z.number().min(0).max(1),
+});
+
+export const createInvoiceSchema = z.object({
+    body: z
+        .object({
+            type: z.enum(['session', 'subscription', 'refund']),
+            lineItems: z.array(lineItemSchema).min(1).max(200),
+            currency: z.string().trim().min(1).max(12).optional(),
+            dueDate: z.string().datetime().or(z.string().date()),
+        })
+        .strict(),
+});
+
+export const invoiceIdParamSchema = z.object({
+    params: z.object({ invoiceId: uuidSchema }),
+});
+
+export const listInvoicesSchema = z.object({
+    query: z.object({
+        status: z.enum(['draft', 'sent', 'paid', 'overdue', 'cancelled']).optional(),
+    }),
+});
+
+export const updateInvoiceStatusSchema = z.object({
+    params: z.object({ invoiceId: uuidSchema }),
+    body: z
+        .object({
+            status: z.enum(['draft', 'sent', 'paid', 'overdue', 'cancelled']),
+        })
+        .strict(),
+});
+
+export const bulkExportInvoicesSchema = z.object({
+    query: z.object({
+        from: z.string().trim().min(1).max(40),
+        to: z.string().trim().min(1).max(40),
+    }),
+});

--- a/src/validators/schemas/loyalty.schemas.ts
+++ b/src/validators/schemas/loyalty.schemas.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+// Earn rule actions are a fixed set defined in loyalty.service.ts EARN_RULES.
+const earnActionEnum = z.enum([
+    'complete_session',
+    'write_review',
+    'referral',
+    'daily_login',
+]);
+
+export const earnTokensSchema = z.object({
+    body: z
+        .object({
+            action: earnActionEnum,
+        })
+        .strict(),
+});
+
+export const redeemTokensSchema = z.object({
+    body: z
+        .object({
+            tokens: z.number().positive('tokens must be a positive number'),
+        })
+        .strict(),
+});

--- a/src/validators/schemas/mentor-onboarding-flow.schemas.ts
+++ b/src/validators/schemas/mentor-onboarding-flow.schemas.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+import { longTextSchema } from './common.schemas';
+
+const slugParam = z.string().trim().min(1).max(100).regex(/^[a-zA-Z0-9_-]+$/, 'Invalid identifier');
+
+export const completeOnboardingStepFlowSchema = z.object({
+    params: z.object({ stepId: slugParam }),
+});
+
+export const pauseOnboardingSchema = z.object({
+    body: z
+        .object({
+            reason: longTextSchema.optional(),
+        })
+        .strict()
+        .optional(),
+});
+
+export const completeChecklistItemSchema = z.object({
+    params: z.object({ itemKey: slugParam }),
+});

--- a/src/validators/schemas/moderation.schemas.ts
+++ b/src/validators/schemas/moderation.schemas.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+import { uuidSchema, longTextSchema } from './common.schemas';
+
+const paginationQuery = z.object({
+    limit: z
+        .string()
+        .optional()
+        .transform((v) => (v ? parseInt(v, 10) : 50))
+        .refine((v) => Number.isInteger(v) && v >= 1 && v <= 100, 'Limit must be between 1 and 100'),
+    offset: z
+        .string()
+        .optional()
+        .transform((v) => (v ? parseInt(v, 10) : 0))
+        .refine((v) => Number.isInteger(v) && v >= 0 && v <= 10_000_000, 'Invalid offset'),
+});
+
+export const moderationFlagIdParamSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+});
+
+export const getModerationQueueSchema = z.object({
+    query: paginationQuery,
+});
+
+export const getAIQueueSchema = z.object({
+    query: paginationQuery,
+});
+
+export const triggerAIScanSchema = z.object({
+    body: z
+        .object({
+            contentId: z.string().trim().min(1).max(200),
+            contentType: z.enum(['profile', 'review', 'message']),
+            text: z.string().trim().min(1).max(20000),
+        })
+        .strict(),
+});
+
+export const approveContentSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+});
+
+export const rejectContentSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+    body: z
+        .object({
+            notes: longTextSchema.optional(),
+            suspendHours: z
+                .number()
+                .int()
+                .min(1, 'suspendHours must be at least 1')
+                .max(8760, 'suspendHours must not exceed 8760 (1 year)')
+                .optional(),
+        })
+        .strict(),
+});
+
+export const escalateFlagSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+    body: z
+        .object({
+            notes: longTextSchema.optional(),
+        })
+        .strict(),
+});
+
+export const deleteFlagSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+});
+
+export const getAppealsSchema = z.object({
+    query: paginationQuery.extend({
+        status: z.string().trim().max(50).optional(),
+    }),
+});
+
+export const resolveAppealSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+    body: z
+        .object({
+            status: z.enum(['approved', 'rejected']),
+            notes: longTextSchema.optional(),
+        })
+        .strict(),
+});

--- a/src/validators/schemas/notifications.schemas.ts
+++ b/src/validators/schemas/notifications.schemas.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import { uuidSchema } from './common.schemas';
+
+export const listNotificationsSchema = z.object({
+    query: z.object({
+        page: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 1))
+            .refine((v) => Number.isInteger(v) && v >= 1 && v <= 1_000_000, 'Invalid page'),
+        limit: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 20))
+            .refine((v) => Number.isInteger(v) && v >= 1 && v <= 100, 'Limit must be between 1 and 100'),
+    }),
+});
+
+export const notificationIdParamSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+});
+
+export const updateNotificationPreferencesSchema = z.object({
+    body: z
+        .object({
+            preferences: z.record(z.string(), z.unknown()),
+        })
+        .strict(),
+});
+
+export const pushUnsubscribeSchema = z.object({
+    body: z
+        .object({
+            token: z.string().trim().min(1, 'token is required').max(4096),
+        })
+        .strict(),
+});

--- a/src/validators/schemas/offline.schemas.ts
+++ b/src/validators/schemas/offline.schemas.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod';
+import { uuidSchema } from './common.schemas';
+
+const domainEnum = z.enum(['bookings', 'notifications', 'profile', 'goals', 'messages']);
+
+const actionTypeEnum = z.enum([
+    'booking:create',
+    'booking:cancel',
+    'booking:reschedule',
+    'review:create',
+    'note:create',
+    'note:update',
+    'goal:update',
+    'profile:update',
+    'message:send',
+]);
+
+// clientKey is validated by the controller with /^[0-9a-f-]{36}$/i (UUID-shaped);
+// uuidSchema (UUID v4) is a safe, slightly stricter subset to enforce at the edge.
+const offlineActionSchema = z
+    .object({
+        clientKey: uuidSchema,
+        actionType: actionTypeEnum,
+        payload: z.record(z.string(), z.unknown()),
+        clientTimestamp: z.string().datetime(),
+    })
+    .strict();
+
+export const getSnapshotSchema = z.object({
+    query: z.object({
+        refresh: z.string().optional(),
+    }),
+});
+
+export const getDeltaSchema = z.object({
+    query: z.object({
+        domain: domainEnum,
+        since: z.string().datetime('since must be a valid ISO 8601 timestamp'),
+    }),
+});
+
+export const getQueueSchema = z.object({
+    query: z.object({
+        status: z.enum(['pending', 'processing', 'completed', 'failed', 'conflict']).optional(),
+        limit: z.string().optional(),
+        offset: z.string().optional(),
+    }),
+});
+
+export const enqueueActionSchema = z.object({
+    body: offlineActionSchema,
+});
+
+export const syncSchema = z.object({
+    body: z
+        .object({
+            syncState: z
+                .object({
+                    domains: z.record(z.string(), z.string()),
+                })
+                .strict(),
+            actions: z.array(offlineActionSchema).optional(),
+        })
+        .strict(),
+});
+
+export const resolveConflictSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+    body: z
+        .object({
+            strategy: z.enum(['client_wins', 'server_wins', 'merge']),
+            mergedPayload: z.record(z.string(), z.unknown()).optional(),
+        })
+        .strict(),
+});

--- a/src/validators/schemas/oracle.schemas.ts
+++ b/src/validators/schemas/oracle.schemas.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const getOraclePriceSchema = z.object({
+    params: z.object({
+        asset: z
+            .string()
+            .trim()
+            .min(1, 'Asset symbol is required')
+            .max(12, 'Asset symbol is too long')
+            .regex(/^[A-Za-z0-9]+$/, 'Asset symbol must be alphanumeric'),
+    }),
+});
+
+export type GetOraclePriceInput = z.infer<typeof getOraclePriceSchema>['params'];

--- a/src/validators/schemas/referral.schemas.ts
+++ b/src/validators/schemas/referral.schemas.ts
@@ -1,0 +1,104 @@
+import { z } from 'zod';
+import { uuidSchema, emailSchema } from './common.schemas';
+
+export const createReferralCodeSchema = z.object({
+    body: z
+        .object({
+            codeType: z.enum(['personal', 'campaign']).optional(),
+            customCode: z
+                .string()
+                .trim()
+                .min(3)
+                .max(30)
+                .regex(/^[A-Za-z0-9_-]+$/, 'customCode must be alphanumeric')
+                .optional(),
+            maxUses: z.number().int().min(1).max(1_000_000).optional(),
+            expiresAt: z.string().datetime().optional(),
+            metadata: z.record(z.string(), z.unknown()).optional(),
+        })
+        .strict(),
+});
+
+export const referralCodeParamSchema = z.object({
+    params: z.object({
+        code: z.string().trim().min(1).max(30),
+    }),
+});
+
+export const applyReferralCodeSchema = z.object({
+    body: z
+        .object({
+            referralCode: z.string().trim().min(1).max(30),
+            referredEmail: emailSchema.optional(),
+            metadata: z.record(z.string(), z.unknown()).optional(),
+        })
+        .strict(),
+});
+
+export const listUserReferralsSchema = z.object({
+    query: z.object({
+        status: z
+            .enum(['pending', 'registered', 'completed', 'rewarded', 'expired', 'cancelled'])
+            .optional(),
+    }),
+});
+
+export const referralStatsQuerySchema = z.object({
+    query: z.object({
+        global: z.enum(['true', 'false']).optional(),
+    }),
+});
+
+export const referralIdParamSchema = z.object({
+    params: z.object({ referralId: uuidSchema }),
+});
+
+export const updateReferralSchema = z.object({
+    params: z.object({ referralId: uuidSchema }),
+    body: z
+        .object({
+            status: z
+                .enum(['pending', 'registered', 'completed', 'rewarded', 'expired', 'cancelled'])
+                .optional(),
+            conversionType: z.string().trim().max(100).optional(),
+            referredUserId: uuidSchema.optional(),
+            metadata: z.record(z.string(), z.unknown()).optional(),
+        })
+        .strict(),
+});
+
+export const createAffiliateProfileSchema = z.object({
+    body: z
+        .object({
+            stellarAddress: z.string().trim().min(1).max(60).optional(),
+            paymentSchedule: z.string().trim().max(50).optional(),
+            minimumPayout: z.number().min(0).max(1_000_000).optional(),
+        })
+        .strict(),
+});
+
+export const affiliateUserIdParamSchema = z.object({
+    params: z.object({ userId: uuidSchema }),
+});
+
+export const updateAffiliateProfileSchema = z.object({
+    params: z.object({ userId: uuidSchema }),
+    body: z
+        .object({
+            stellarAddress: z.string().trim().min(1).max(60).optional(),
+            paymentSchedule: z.string().trim().max(50).optional(),
+            minimumPayout: z.number().min(0).max(1_000_000).optional(),
+        })
+        .strict(),
+});
+
+export const requestPayoutSchema = z.object({
+    params: z.object({ userId: uuidSchema }),
+    body: z
+        .object({
+            amount: z.number().positive().max(1_000_000),
+            payoutType: z.string().trim().max(50).optional(),
+            metadata: z.record(z.string(), z.unknown()).optional(),
+        })
+        .strict(),
+});

--- a/src/validators/schemas/session-feedback.schemas.ts
+++ b/src/validators/schemas/session-feedback.schemas.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import { uuidSchema } from './common.schemas';
+
+export const submitFeedbackSchema = z.object({
+    body: z
+        .object({
+            session_id: uuidSchema,
+            rating_content: z.number().int().min(1).max(5),
+            rating_communication: z.number().int().min(1).max(5),
+            rating_preparation: z.number().int().min(1).max(5),
+            rating_value: z.number().int().min(1).max(5),
+            comment: z.string().trim().max(2000).optional(),
+            improvements: z.array(z.string().trim().max(500)).optional(),
+            would_recommend: z.boolean().optional(),
+        })
+        .strict(),
+});
+
+export const sessionIdParamSchema = z.object({
+    params: z.object({ sessionId: uuidSchema }),
+});
+
+export const mentorFeedbackParamSchema = z.object({
+    params: z.object({ mentorId: uuidSchema }),
+    query: z.object({
+        page: z.string().optional(),
+        limit: z.string().optional(),
+    }),
+});
+
+export const mentorIdParamSchema = z.object({
+    params: z.object({ mentorId: uuidSchema }),
+});

--- a/src/validators/schemas/session-milestone.schemas.ts
+++ b/src/validators/schemas/session-milestone.schemas.ts
@@ -1,0 +1,88 @@
+import { z } from 'zod';
+import { uuidSchema, shortTextSchema } from './common.schemas';
+
+const sessionTypeEnum = z.enum(['milestone', 'support', 'assessment']);
+const completionStatusEnum = z.enum(['not_started', 'in_progress', 'completed', 'needs_review']);
+const followUpEnum = z.enum(['continue', 'assessment', 'support', 'complete']);
+
+export const bookingIdParamSchema = z.object({
+    params: z.object({ bookingId: uuidSchema }),
+});
+
+export const milestoneIdParamSchema = z.object({
+    params: z.object({ milestoneId: uuidSchema }),
+});
+
+export const mentorIdParamSchema = z.object({
+    params: z.object({ mentorId: uuidSchema }),
+});
+
+export const mentorStudentParamSchema = z.object({
+    params: z.object({ mentorId: uuidSchema, studentId: uuidSchema }),
+});
+
+export const linkSessionToMilestoneSchema = z.object({
+    params: z.object({ bookingId: uuidSchema }),
+    body: z
+        .object({
+            milestoneId: uuidSchema,
+            sessionType: sessionTypeEnum.default('milestone'),
+            contributesToCompletion: z.boolean().default(true),
+        })
+        .strict(),
+});
+
+export const updateSessionMappingSchema = z.object({
+    params: z.object({ bookingId: uuidSchema }),
+    body: z
+        .object({
+            sessionType: sessionTypeEnum.optional(),
+            contributesToCompletion: z.boolean().optional(),
+        })
+        .strict(),
+});
+
+export const createSessionOutcomeSchema = z.object({
+    params: z.object({ bookingId: uuidSchema }),
+    body: z
+        .object({
+            mentorFeedback: z.string().trim().max(5000).optional(),
+            studentFeedback: z.string().trim().max(5000).optional(),
+            objectivesAchieved: z.array(z.string().trim().max(500)).optional(),
+            skillsImproved: z.array(z.string().trim().max(500)).optional(),
+            nextSteps: z.array(z.string().trim().max(500)).optional(),
+            progressContribution: z.number().min(0).max(100).optional(),
+            completionStatus: completionStatusEnum.optional(),
+            sessionEffectiveness: z.number().min(1).max(5).optional(),
+            recommendedFollowUp: followUpEnum.optional(),
+        })
+        .strict(),
+});
+
+export const createContextualBookingSchema = z.object({
+    body: z
+        .object({
+            menteeId: uuidSchema,
+            mentorId: uuidSchema,
+            scheduledAt: z.string().datetime(),
+            durationMinutes: z.number().min(15).max(240),
+            topic: shortTextSchema,
+            notes: z.string().trim().max(5000).optional(),
+            milestoneId: uuidSchema.optional(),
+            sessionType: sessionTypeEnum.optional(),
+            contributesToCompletion: z.boolean().optional(),
+        })
+        .strict(),
+});
+
+export const updateHybridModeConfigSchema = z.object({
+    params: z.object({ mentorId: uuidSchema }),
+    body: z
+        .object({
+            learningPathsEnabled: z.boolean().optional(),
+            individualSessionsEnabled: z.boolean().optional(),
+            autoLinkSessions: z.boolean().optional(),
+            defaultSessionType: sessionTypeEnum.optional(),
+        })
+        .strict(),
+});

--- a/src/validators/schemas/session-quality.schemas.ts
+++ b/src/validators/schemas/session-quality.schemas.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import { uuidSchema } from './common.schemas';
+
+export const sessionIdParamSchema = z.object({
+    params: z.object({ sessionId: uuidSchema }),
+});
+
+export const mentorTrendSchema = z.object({
+    params: z.object({ mentorId: uuidSchema }),
+    query: z.object({
+        days: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 90))
+            .refine((v) => v >= 7 && v <= 365, 'days must be between 7 and 365'),
+    }),
+});
+
+export const mentorIdParamSchema = z.object({
+    params: z.object({ mentorId: uuidSchema }),
+});
+
+export const topSessionsSchema = z.object({
+    params: z.object({ mentorId: uuidSchema }),
+    query: z.object({
+        limit: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : 5))
+            .refine((v) => v >= 1 && v <= 20, 'limit must be between 1 and 20'),
+    }),
+});

--- a/src/validators/schemas/session-recording.schemas.ts
+++ b/src/validators/schemas/session-recording.schemas.ts
@@ -1,0 +1,113 @@
+import { z } from 'zod';
+import { uuidSchema, longTextSchema } from './common.schemas';
+
+export const startRecordingSchema = z.object({
+    params: z.object({ sessionId: uuidSchema }),
+    body: z
+        .object({
+            format: z.string().trim().max(20).optional(),
+        })
+        .strict()
+        .optional(),
+});
+
+export const recordingIdParamSchema = z.object({
+    params: z.object({ recordingId: uuidSchema }),
+});
+
+export const uploadRecordingSchema = z.object({
+    params: z.object({ recordingId: uuidSchema }),
+    body: z
+        .object({
+            fileSize: z
+                .number()
+                .int()
+                .min(0)
+                .max(50 * 1024 * 1024 * 1024, 'fileSize exceeds max allowed (50GB)')
+                .optional(),
+            durationSeconds: z
+                .number()
+                .int()
+                .min(0)
+                .max(86_400, 'durationSeconds exceeds max allowed (24h)')
+                .optional(),
+            metadata: z.record(z.string(), z.unknown()).optional(),
+        })
+        .strict(),
+});
+
+export const completeRecordingSchema = z.object({
+    params: z.object({ recordingId: uuidSchema }),
+});
+
+export const updateConsentSchema = z.object({
+    params: z.object({ recordingId: uuidSchema }),
+    body: z
+        .object({
+            consent: z.boolean(),
+        })
+        .strict(),
+});
+
+export const generatePlaybackUrlSchema = z.object({
+    params: z.object({ recordingId: uuidSchema }),
+    query: z.object({
+        expiresIn: z
+            .string()
+            .optional()
+            .transform((v) => (v ? parseInt(v, 10) : undefined))
+            .refine((v) => v === undefined || (Number.isInteger(v) && v > 0 && v <= 86_400), {
+                message: 'expiresIn must be between 1 and 86400 seconds',
+            }),
+    }),
+});
+
+export const startTranscriptionSchema = z.object({
+    params: z.object({ recordingId: uuidSchema }),
+    body: z
+        .object({
+            language: z.string().trim().max(10).optional(),
+        })
+        .strict()
+        .optional(),
+});
+
+export const searchTranscriptionsSchema = z.object({
+    query: z.object({
+        query: z.string().trim().min(1).max(500).optional(),
+    }),
+});
+
+export const createBookmarkSchema = z.object({
+    params: z.object({ recordingId: uuidSchema }),
+    body: z
+        .object({
+            type: z.string().trim().max(50).optional(),
+            timestampSeconds: z.number().min(0).max(86_400),
+            title: z.string().trim().max(200).optional(),
+            note: longTextSchema.optional(),
+            color: z.string().trim().max(20).optional(),
+            durationSeconds: z.number().min(0).max(86_400).optional(),
+            isPrivate: z.boolean().optional(),
+        })
+        .strict(),
+});
+
+export const bookmarkIdParamSchema = z.object({
+    params: z.object({ bookmarkId: uuidSchema }),
+});
+
+export const updateBookmarkSchema = z.object({
+    params: z.object({ bookmarkId: uuidSchema }),
+    body: z
+        .object({
+            type: z.string().trim().max(50).optional(),
+            timestampSeconds: z.number().min(0).max(86_400).optional(),
+            title: z.string().trim().max(200).optional(),
+            note: longTextSchema.optional(),
+            color: z.string().trim().max(20).optional(),
+            durationSeconds: z.number().min(0).max(86_400).optional(),
+            isPrivate: z.boolean().optional(),
+        })
+        .strict(),
+});

--- a/src/validators/schemas/session-summary.schemas.ts
+++ b/src/validators/schemas/session-summary.schemas.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import { uuidSchema, longTextSchema } from './common.schemas';
+
+export const bookingIdParamSchema = z.object({
+    params: z.object({ bookingId: uuidSchema }),
+});
+
+export const generateSummarySchema = z.object({
+    params: z.object({ bookingId: uuidSchema }),
+    body: z
+        .object({
+            transcriptId: uuidSchema.optional(),
+            transcriptText: z.string().trim().max(200_000).optional(),
+            sessionNotes: longTextSchema.optional(),
+            sessionTitle: z.string().trim().max(500).optional(),
+            sessionId: uuidSchema.optional(),
+        })
+        .strict(),
+});
+
+export const sessionIdParamSchema = z.object({
+    params: z.object({ sessionId: uuidSchema }),
+});
+
+export const summaryIdParamSchema = z.object({
+    params: z.object({ id: uuidSchema }),
+});

--- a/src/validators/schemas/session-transcription.schemas.ts
+++ b/src/validators/schemas/session-transcription.schemas.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod';
+import { uuidSchema } from './common.schemas';
+
+const languageParam = z
+    .string()
+    .trim()
+    .min(2)
+    .max(10)
+    .regex(/^[a-zA-Z-]+$/, 'language must be a valid language code');
+
+const segmentSchema = z.object({
+    speakerId: z.string().trim().min(1).max(100),
+    text: z.string().trim().max(10000),
+    startTime: z.number().min(0).max(86_400),
+    endTime: z.number().min(0).max(86_400),
+    confidence: z.number().min(0).max(1),
+});
+
+const speakerSchema = z.object({
+    id: z.string().trim().min(1).max(100),
+    label: z.string().trim().max(200),
+    totalSpeakingTime: z.number().min(0).max(86_400),
+});
+
+export const sessionIdParamSchema = z.object({
+    params: z.object({ sessionId: uuidSchema }),
+});
+
+export const saveTranscriptSchema = z.object({
+    params: z.object({ sessionId: uuidSchema }),
+    body: z
+        .object({
+            language: languageParam,
+            segments: z.array(segmentSchema).max(10_000),
+            speakers: z.array(speakerSchema).max(100),
+            keywords: z.array(z.string().trim().max(200)).max(500),
+            summary: z.string().trim().max(20000),
+        })
+        .strict(),
+});
+
+export const updateTranscriptSchema = z.object({
+    params: z.object({ sessionId: uuidSchema }),
+    body: z
+        .object({
+            language: languageParam.optional(),
+            segments: z.array(segmentSchema).max(10_000).optional(),
+            speakers: z.array(speakerSchema).max(100).optional(),
+            keywords: z.array(z.string().trim().max(200)).max(500).optional(),
+            summary: z.string().trim().max(20000).optional(),
+        })
+        .strict(),
+});
+
+export const searchTranscriptsSchema = z.object({
+    query: z.object({
+        q: z.string().trim().min(1).max(500),
+    }),
+});
+
+export const translationParamSchema = z.object({
+    params: z.object({
+        sessionId: uuidSchema,
+        language: languageParam,
+    }),
+});
+
+export const saveTranslationSchema = z.object({
+    params: z.object({
+        sessionId: uuidSchema,
+        language: languageParam,
+    }),
+    body: z
+        .object({
+            segments: z.array(segmentSchema).max(10_000),
+            summary: z.string().trim().max(20000),
+        })
+        .strict(),
+});

--- a/src/validators/schemas/tax.schemas.ts
+++ b/src/validators/schemas/tax.schemas.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const taxYearParamSchema = z.object({
+    params: z.object({
+        year: z
+            .string()
+            .regex(/^\d{4}$/, 'year must be a 4-digit year')
+            .refine((v) => {
+                const y = parseInt(v, 10);
+                return y >= 2000 && y <= 2100;
+            }, 'year must be between 2000 and 2100'),
+    }),
+});

--- a/src/validators/schemas/trace.schemas.ts
+++ b/src/validators/schemas/trace.schemas.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const getTraceSchema = z.object({
+    params: z.object({
+        traceId: z
+            .string()
+            .trim()
+            .regex(/^[0-9a-f]{32}$/i, 'traceId must be a 32-character hex string'),
+    }),
+});
+
+export type GetTraceInput = z.infer<typeof getTraceSchema>['params'];

--- a/src/worker-bootstrap.ts
+++ b/src/worker-bootstrap.ts
@@ -13,6 +13,11 @@ async function startWorkers() {
   // Load secrets (AWS / Vault / env) before any queue/worker modules are imported
   await loadSecrets();
 
+  // Initialise OTel before queue/worker modules are imported so auto-
+  // instrumentations (pg, ioredis, http) patch modules at load time.
+  const { initTracing } = await import("./config/tracing");
+  initTracing();
+
   // Dynamic import ensures config/env.ts is validated AFTER secrets are merged
   const { logger } = await import("./utils/logger.utils");
 

--- a/src/workers/scheduler.ts
+++ b/src/workers/scheduler.ts
@@ -162,4 +162,17 @@ export async function runMaintenanceTasks(): Promise<void> {
   } catch (error) {
     logger.error("Maintenance: error cleaning up offline queue", { error });
   }
+
+  // GDPR retention: delete data exports (S3 + DB) older than 30 days
+  try {
+    const { ExportService } = await import("../services/export.service");
+    const cleaned = await ExportService.cleanupExpiredExports(30);
+    if (cleaned > 0) {
+      logger.info("Maintenance: expired data exports cleaned up", {
+        count: cleaned,
+      });
+    }
+  } catch (error) {
+    logger.error("Maintenance: error cleaning up expired exports", { error });
+  }
 }


### PR DESCRIPTION
# Oracle pricing, GDPR export fix, trace correlation, and Zod validation

## Summary

- **Oracle integration**: `OracleService` queries the Soroban price oracle (60s Redis cache), exposes `GET /api/v1/oracle/price/:asset`, enriches booking responses with `usd_equivalent`, and `AssetExchangeService` prefers the oracle over SDEX with a stale-price circuit breaker.
- **GDPR export fix**: Replaced the `Math.random()` placeholder download URL with a real S3 upload + presigned URL (AES256 SSE), added `downloaded_at` tracking, and a daily cleanup task deleting exports (S3 + DB) older than 30 days.
- **Trace correlation**: Wired up OpenTelemetry (was defined but never initialized), injected `traceId`/`spanId` into every log line, propagated trace context into BullMQ jobs and back out in workers, and added `GET /api/v1/admin/trace/:traceId` to query Jaeger.
- **Input validation**: Added Zod validation (body/query/params, HTTP 422 on failure, UUID enforcement on `:id` params, bounded string lengths) across 30 previously-unvalidated v1 route files.

## Testing

- `npm run build:check` — clean (2 pre-existing, unrelated errors in `src/config/passport.ts`, not touched by this PR)
- `npm run lint` — 0 errors (pre-existing warnings only, none introduced)
- `npm run test:validators` — 33/33 passing (new lightweight harness, repo has no test runner installed)

## Notes

- 7 route files with pre-existing `express-validator` usage (`advanced-analytics`, `learning-path`, `progress`) were left as-is; migrating those to Zod is follow-up work.
- Details on the validation pattern: `api-validation.md`.

Closes #667
Closes #681
Closes #659
Closes #679
