### PR TITLE
Implement platform integration wave issues

### DIFF
--- a/database/migrations/102_create_forecasting_views.sql
+++ b/database/migrations/102_create_forecasting_views.sql
@@ -1,0 +1,35 @@
+-- Migration: create forecasting materialized views
+-- Issue #763: PredictiveEngineService depends on these relations.
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_revenue_time_series AS
+SELECT
+  DATE(created_at) AS date,
+  COALESCE(currency, 'XLM') AS currency,
+  COALESCE(SUM(amount), 0)::DECIMAL(20, 7) AS total_amount,
+  COUNT(*)::INTEGER AS transaction_count
+FROM transactions
+WHERE status = 'completed'
+  AND type IN ('payment', 'deposit', 'escrow_release')
+GROUP BY DATE(created_at), COALESCE(currency, 'XLM');
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mv_revenue_time_series_unique
+  ON mv_revenue_time_series(date, currency);
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_hourly_session_demand AS
+SELECT
+  DATE_TRUNC('hour', scheduled_start) AS hour,
+  EXTRACT(DOW FROM scheduled_start)::INTEGER AS day_of_week,
+  EXTRACT(HOUR FROM scheduled_start)::INTEGER AS hour_of_day,
+  COUNT(*)::INTEGER AS booking_count,
+  COUNT(DISTINCT mentor_id)::INTEGER AS active_mentors
+FROM bookings
+WHERE scheduled_start IS NOT NULL
+  AND status NOT IN ('cancelled', 'no_show')
+GROUP BY
+  DATE_TRUNC('hour', scheduled_start),
+  EXTRACT(DOW FROM scheduled_start),
+  EXTRACT(HOUR FROM scheduled_start);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mv_hourly_session_demand_unique
+  ON mv_hourly_session_demand(hour);
+

--- a/database/migrations/103_create_analytics_predictions.sql
+++ b/database/migrations/103_create_analytics_predictions.sql
@@ -1,0 +1,19 @@
+-- Migration: create analytics predictions storage
+-- Issue #763: PredictiveEngineService.storePredictions inserts here.
+
+CREATE TABLE IF NOT EXISTS analytics_predictions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  prediction_type VARCHAR(100) NOT NULL,
+  target_date DATE NOT NULL,
+  predicted_value DECIMAL(20, 7) NOT NULL,
+  confidence_interval_lower DECIMAL(20, 7),
+  confidence_interval_upper DECIMAL(20, 7),
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(prediction_type, target_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_analytics_predictions_type_date
+  ON analytics_predictions(prediction_type, target_date);
+

--- a/database/migrations/104_learning_path_payment_gate.sql
+++ b/database/migrations/104_learning_path_payment_gate.sql
@@ -1,0 +1,48 @@
+-- Migration: add learning path purchase gate columns and purchase records
+-- Issue #764.
+
+ALTER TABLE learning_paths
+  ADD COLUMN IF NOT EXISTS price NUMERIC(15, 2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS is_free BOOLEAN NOT NULL DEFAULT true;
+
+UPDATE learning_paths
+SET
+  price = COALESCE(total_price, 0),
+  is_free = COALESCE(total_price, 0) <= 0
+WHERE price = 0
+  AND COALESCE(total_price, 0) > 0;
+
+ALTER TABLE path_enrollments
+  ADD COLUMN IF NOT EXISTS is_trial BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS trial_ends_at TIMESTAMP WITH TIME ZONE,
+  ADD COLUMN IF NOT EXISTS requires_payment_after TIMESTAMP WITH TIME ZONE;
+
+CREATE TABLE IF NOT EXISTS learning_path_purchases (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  learning_path_id UUID NOT NULL REFERENCES learning_paths(id) ON DELETE CASCADE,
+  enrollment_id UUID NOT NULL REFERENCES path_enrollments(id) ON DELETE CASCADE,
+  student_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  transaction_id UUID NOT NULL REFERENCES transactions(id) ON DELETE RESTRICT,
+  amount NUMERIC(15, 2) NOT NULL,
+  currency VARCHAR(10) NOT NULL DEFAULT 'XLM',
+  provider VARCHAR(50) NOT NULL,
+  payment_reference VARCHAR(255) NOT NULL,
+  status VARCHAR(20) NOT NULL DEFAULT 'completed' CHECK (status IN ('pending', 'completed', 'failed', 'refunded')),
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(enrollment_id),
+  UNIQUE(transaction_id),
+  UNIQUE(provider, payment_reference)
+);
+
+CREATE INDEX IF NOT EXISTS idx_learning_path_purchases_path
+  ON learning_path_purchases(learning_path_id);
+
+CREATE INDEX IF NOT EXISTS idx_learning_path_purchases_student
+  ON learning_path_purchases(student_id);
+
+CREATE INDEX IF NOT EXISTS idx_path_enrollments_trials
+  ON path_enrollments(trial_ends_at)
+  WHERE is_trial = true AND payment_status <> 'paid';
+

--- a/database/migrations/105_create_chatbot_messages.sql
+++ b/database/migrations/105_create_chatbot_messages.sql
@@ -1,0 +1,24 @@
+-- Migration: persist chatbot messages for analytics and history
+-- Issue #760.
+
+CREATE TABLE IF NOT EXISTS chatbot_messages (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  message TEXT NOT NULL,
+  response TEXT NOT NULL,
+  intent VARCHAR(100) NOT NULL,
+  confidence NUMERIC(5, 4) NOT NULL DEFAULT 0,
+  escalated BOOLEAN NOT NULL DEFAULT false,
+  cleared_at TIMESTAMP WITH TIME ZONE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_chatbot_messages_user_created
+  ON chatbot_messages(user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_chatbot_messages_intent
+  ON chatbot_messages(intent);
+
+CREATE INDEX IF NOT EXISTS idx_chatbot_messages_escalated
+  ON chatbot_messages(escalated);
+

--- a/docs/background-check-provider.md
+++ b/docs/background-check-provider.md
@@ -1,0 +1,23 @@
+# Background Check Provider
+
+Background checks use a provider adapter selected by `BACKGROUND_CHECK_PROVIDER`.
+
+## Providers
+
+- `BACKGROUND_CHECK_PROVIDER=checkr` uses Checkr REST APIs and requires `CHECKR_API_KEY`.
+- `BACKGROUND_CHECK_PROVIDER=mock` uses deterministic local/test results from `BACKGROUND_CHECK_MOCK_RESULT`.
+
+Production defaults to Checkr when no provider is configured. Non-production defaults to the mock adapter.
+
+## Webhooks and polling
+
+Checkr completion callbacks are accepted at:
+
+```text
+POST /api/v1/admin/background-checks/webhook
+```
+
+The scheduler also polls pending provider checks every 6 hours for providers or events that do not complete via webhook.
+
+Every transition is written to `audit_logs` with action `background_check.transition`.
+

--- a/docs/forecasting-views.md
+++ b/docs/forecasting-views.md
@@ -1,0 +1,18 @@
+# Forecasting Views
+
+Migration `102_create_forecasting_views.sql` creates the materialized views used by `PredictiveEngineService`:
+
+- `mv_revenue_time_series`
+- `mv_hourly_session_demand`
+
+Both views have unique indexes and can be refreshed concurrently:
+
+```sql
+REFRESH MATERIALIZED VIEW CONCURRENTLY mv_revenue_time_series;
+REFRESH MATERIALIZED VIEW CONCURRENTLY mv_hourly_session_demand;
+```
+
+If these views are missing, forecasting methods return empty arrays and log a warning that points to migration `102_create_forecasting_views.sql`. Health checks report the missing views as degraded.
+
+Migration `103_create_analytics_predictions.sql` creates `analytics_predictions`, which stores generated forecasts.
+

--- a/docs/learning-path-payments.md
+++ b/docs/learning-path-payments.md
@@ -1,0 +1,21 @@
+# Learning Path Payments
+
+Paid learning paths are gated in `EnrollmentService.enrollStudent`.
+
+## Pricing columns
+
+`learning_paths.price`, `learning_paths.currency`, and `learning_paths.is_free` define the enrollment gate. Migration `104_learning_path_payment_gate.sql` backfills `price` from the existing `total_price` column.
+
+## Purchase flow
+
+1. Call `GET /api/v1/learning-paths/:id/purchase` to read price, currency, purchase status, and supported payment methods.
+2. For Stripe, submit `paymentData.paymentIntentId` to `POST /api/v1/learning-paths/:id/enroll`.
+3. For Stellar, submit `paymentData.stellarTxHash` and either an existing `paymentId`/`transactionId` or a completed transaction hash already recorded in `transactions`.
+4. Successful paid enrollments create `learning_path_purchases` rows linked to the enrollment and transaction.
+
+Paid paths without a valid payment return HTTP 402. Free paths enroll without payment verification.
+
+## Trials
+
+`POST /api/v1/learning-paths/:id/trial` creates a 7-day trial enrollment. Daily maintenance pauses expired unpaid trials and leaves `payment_status = pending`, requiring a completed purchase before continued paid access.
+

--- a/src/config/metrics.ts
+++ b/src/config/metrics.ts
@@ -133,6 +133,15 @@ export const redisCallDurationSeconds = new Histogram<string>({
   registers: [metricsRegistry],
 });
 
+// ─── Chatbot ─────────────────────────────────────────────────────────────────
+
+export const chatbotMessagesTotal = new Counter<string>({
+  name: "chatbot_messages_total",
+  help: "Total chatbot messages, partitioned by intent and escalation status",
+  labelNames: ["intent", "escalated"],
+  registers: [metricsRegistry],
+});
+
 // ─── Queue / BullMQ ──────────────────────────────────────────────────────────
 
 export const queueJobDurationSeconds = new Histogram<string>({

--- a/src/controllers/background-check.controller.ts
+++ b/src/controllers/background-check.controller.ts
@@ -1,0 +1,13 @@
+import { Request, Response } from "express";
+import { BackgroundCheckService } from "../services/background-check.service";
+
+export const BackgroundCheckController = {
+  async handleWebhook(req: Request, res: Response): Promise<void> {
+    const backgroundCheck = await BackgroundCheckService.handleProviderWebhook(req.body);
+    res.json({
+      success: true,
+      data: backgroundCheck,
+    });
+  },
+};
+

--- a/src/controllers/chatbot.controller.ts
+++ b/src/controllers/chatbot.controller.ts
@@ -1,0 +1,75 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+import { chatbotService, UserProfile } from "../services/chatbot.service";
+import { createError } from "../middleware/errorHandler";
+
+const ChatRequestSchema = z.object({
+  message: z.string().min(1),
+  userProfile: z
+    .object({
+      name: z.string().default("User"),
+      role: z.enum(["mentor", "mentee"]).default("mentee"),
+      language: z.string().optional(),
+    })
+    .partial()
+    .optional(),
+});
+
+export const ChatbotController = {
+  async chat(req: Request, res: Response): Promise<void> {
+    const userId = req.user?.id;
+    if (!userId) {
+      throw createError("Authentication required", 401);
+    }
+
+    const body = ChatRequestSchema.parse(req.body);
+    const userProfile: UserProfile = {
+      id: userId,
+      name: body.userProfile?.name || req.user?.email || "User",
+      role: body.userProfile?.role || (req.user?.role === "mentor" ? "mentor" : "mentee"),
+      language: body.userProfile?.language,
+    };
+
+    const message = await chatbotService.chat(userId, body.message, userProfile);
+    res.status(201).json({
+      success: true,
+      data: message,
+    });
+  },
+
+  async history(req: Request, res: Response): Promise<void> {
+    const userId = req.user?.id;
+    if (!userId) {
+      throw createError("Authentication required", 401);
+    }
+
+    const limit = Math.min(Number(req.query.limit || 100), 100);
+    const history = await chatbotService.getHistory(userId, limit);
+    res.json({
+      success: true,
+      data: history,
+    });
+  },
+
+  async clearHistory(req: Request, res: Response): Promise<void> {
+    const userId = req.user?.id;
+    if (!userId) {
+      throw createError("Authentication required", 401);
+    }
+
+    await chatbotService.clearHistory(userId);
+    res.json({
+      success: true,
+      message: "Chatbot history cleared",
+    });
+  },
+
+  async analytics(_req: Request, res: Response): Promise<void> {
+    const analytics = await chatbotService.getAnalytics();
+    res.json({
+      success: true,
+      data: analytics,
+    });
+  },
+};
+

--- a/src/controllers/learning-path-purchase.controller.ts
+++ b/src/controllers/learning-path-purchase.controller.ts
@@ -1,0 +1,49 @@
+import { Request, Response } from "express";
+import { EnrollmentService } from "../services/enrollment.service";
+import { createError } from "../middleware/errorHandler";
+import { logger } from "../utils/logger.utils";
+
+export const LearningPathPurchaseController = {
+  async getPurchaseInfo(req: Request, res: Response): Promise<void> {
+    const { pathId } = req.params as Record<string, string>;
+    const userId = req.user?.id;
+
+    if (!pathId) {
+      throw createError("Path ID is required", 400);
+    }
+
+    const purchaseInfo = await EnrollmentService.getPurchaseInfo(pathId, userId);
+    res.json({
+      success: true,
+      data: purchaseInfo,
+    });
+  },
+
+  async startTrial(req: Request, res: Response): Promise<void> {
+    const { pathId } = req.params as Record<string, string>;
+    const userId = req.user?.id;
+
+    if (!userId) {
+      throw createError("Authentication required", 401);
+    }
+
+    if (!pathId) {
+      throw createError("Path ID is required", 400);
+    }
+
+    const enrollment = await EnrollmentService.startTrial(pathId, userId);
+
+    logger.info("Learning path trial started", {
+      pathId,
+      studentId: userId,
+      enrollmentId: enrollment.id,
+    });
+
+    res.status(201).json({
+      success: true,
+      data: enrollment,
+      message: "Trial enrollment started",
+    });
+  },
+};
+

--- a/src/models/learning-path.model.ts
+++ b/src/models/learning-path.model.ts
@@ -49,8 +49,10 @@ export interface LearningPath {
   estimatedDurationHours: number;
   difficultyLevel: z.infer<typeof DifficultyLevelSchema>;
   totalPrice?: number;
+  price?: number;
   pricingModel: z.infer<typeof PricingModelSchema>;
   currency: string;
+  isFree?: boolean;
   isPublished: boolean;
   isTemplate: boolean;
   templateId?: string;
@@ -256,8 +258,10 @@ export interface LearningPathRecord {
   estimated_duration_hours: number;
   difficulty_level: string;
   total_price?: number;
+  price?: number;
   pricing_model: string;
   currency: string;
+  is_free?: boolean;
   is_published: boolean;
   is_template: boolean;
   template_id?: string;
@@ -382,6 +386,15 @@ export const UpdateLearningPathSchema = CreateLearningPathSchema.partial();
 export const CreateEnrollmentSchema = z.object({
   paymentMethod: z.string().optional(),
   promoCode: z.string().optional(),
+  paymentData: z
+    .object({
+      paymentIntentId: z.string().optional(),
+      stellarTxHash: z.string().optional(),
+      paymentId: z.string().uuid().optional(),
+      transactionId: z.string().uuid().optional(),
+    })
+    .passthrough()
+    .optional(),
 });
 
 export const UpdateEnrollmentStatusSchema = z.object({

--- a/src/routes/admin.routes.ts
+++ b/src/routes/admin.routes.ts
@@ -20,6 +20,7 @@ import {
 import { ConsentController } from "../controllers/consent.controller";
 import { TraceController } from "../controllers/trace.controller";
 import { EscrowController } from "../controllers/escrow.controller";
+import { BackgroundCheckController } from "../controllers/background-check.controller";
 import { getTraceSchema } from "../validators/schemas/trace.schemas";
 import {
   listAdminUsersSchema,
@@ -55,6 +56,11 @@ const router = Router();
 router.use(authenticate);
 router.use(requireAdmin);
 // adminAllowlistMiddleware is now applied globally in v1/index.ts for /admin/*
+
+router.post(
+  "/background-checks/webhook",
+  asyncHandler(BackgroundCheckController.handleWebhook),
+);
 
 /**
  * @swagger

--- a/src/routes/chatbot.routes.ts
+++ b/src/routes/chatbot.routes.ts
@@ -1,0 +1,16 @@
+import { Router } from "express";
+import { ChatbotController } from "../controllers/chatbot.controller";
+import { authenticate } from "../middleware/auth.middleware";
+import { asyncHandler } from "../utils/asyncHandler.utils";
+
+const router = Router();
+
+router.use(authenticate);
+
+router.post("/", asyncHandler(ChatbotController.chat));
+router.get("/history", asyncHandler(ChatbotController.history));
+router.delete("/history", asyncHandler(ChatbotController.clearHistory));
+router.get("/analytics", asyncHandler(ChatbotController.analytics));
+
+export default router;
+

--- a/src/routes/learning-path.routes.ts
+++ b/src/routes/learning-path.routes.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { LearningPathController } from "../controllers/learning-path.controller";
+import { LearningPathPurchaseController } from "../controllers/learning-path-purchase.controller";
 import { authenticate as authenticateToken } from "../middleware/auth.middleware";
 import { validationMiddleware as validateRequest } from "../middleware/validation.middleware";
 import { body, param } from "express-validator";
@@ -142,6 +143,20 @@ router.post(
  *         description: Learning paths retrieved successfully
  */
 router.get("/", LearningPathController.getPaths);
+
+router.get(
+  "/:pathId/purchase",
+  validatePathId,
+  validateRequest,
+  LearningPathPurchaseController.getPurchaseInfo,
+);
+
+router.post(
+  "/:pathId/trial",
+  validatePathId,
+  validateRequest,
+  LearningPathPurchaseController.startTrial,
+);
 
 /**
  * @swagger

--- a/src/routes/v1/index.ts
+++ b/src/routes/v1/index.ts
@@ -45,6 +45,7 @@ import apiDocsPortalRoutes from "../api-docs-portal.routes";
 import tenantRoutes from "../tenant.routes";
 import dynamicPricingRoutes from "../dynamic-pricing.routes";
 import mentorOnboardingRoutes from "../mentor-onboarding.routes";
+import chatbotRoutes from "../chatbot.routes";
 
 import { BookingsService } from "../../services/bookings.service";
 import { logger } from "../../utils/logger";
@@ -117,5 +118,6 @@ router.use("/pricing", dynamicPricingRoutes);
 
 // Mentor Onboarding Automation (issue #562)
 router.use("/onboarding", mentorOnboardingRoutes);
+router.use("/chatbot", chatbotRoutes);
 
 export default router;

--- a/src/services/background-check.service.ts
+++ b/src/services/background-check.service.ts
@@ -6,6 +6,10 @@ import {
   InitiateBackgroundCheckData
 } from "../models/certification.model";
 import { CertificationService } from "./certification.service";
+import { AuditLogModel } from "../models/audit-log.model";
+import { BackgroundCheckAdapter } from "./background-checks/background-check.adapter";
+import { CheckrBackgroundCheckAdapter } from "./background-checks/checkr.adapter";
+import { MockBackgroundCheckAdapter } from "./background-checks/mock.adapter";
 
 /**
  * Background Check Service
@@ -39,13 +43,15 @@ export const BackgroundCheckService = {
         throw createError("Background check already in progress", 409);
       }
 
+      const provider = data.provider || this.getProviderName();
+
       // Create background check record
       const { rows } = await pool.query(
         `INSERT INTO background_checks 
          (mentor_id, certification_id, provider, check_type, status)
          VALUES ($1, $2, $3, $4, 'pending')
          RETURNING *`,
-        [data.mentorId, data.certificationId || null, data.provider, data.checkType]
+        [data.mentorId, data.certificationId || null, provider, data.checkType]
       );
 
       const check = this.transformBackgroundCheck(rows[0]);
@@ -54,13 +60,11 @@ export const BackgroundCheckService = {
         checkId: check.id,
         mentorId: data.mentorId,
         checkType: data.checkType,
-        provider: data.provider
+        provider
       });
 
-      // In production, this would integrate with actual background check providers
-      // For now, we'll simulate the process
-      this.simulateBackgroundCheck(check.id).catch(err => {
-        logger.error("Background check simulation failed", { error: err });
+      this.initiateProviderCheck(check.id).catch(err => {
+        logger.error("Background check provider initiation failed", { error: err });
       });
 
       return check;
@@ -181,6 +185,8 @@ export const BackgroundCheckService = {
         result
       });
 
+      await this.auditTransition(check, status, result, resultData);
+
       return this.transformBackgroundCheck(rows[0]);
     } catch (error) {
       logger.error("Failed to update background check", {
@@ -197,6 +203,10 @@ export const BackgroundCheckService = {
    * In production, this would integrate with actual providers
    */
   async simulateBackgroundCheck(checkId: string): Promise<void> {
+    if (process.env.NODE_ENV === "production") {
+      throw createError("Simulated background checks are disabled in production", 500);
+    }
+
     try {
       // Simulate processing time
       await new Promise(resolve => setTimeout(resolve, 5000));
@@ -227,6 +237,156 @@ export const BackgroundCheckService = {
         error: error instanceof Error ? error.message : error
       });
     }
+  },
+
+  getProviderName(): string {
+    const configured = (process.env.BACKGROUND_CHECK_PROVIDER || "").toLowerCase();
+    if (configured) return configured;
+    return process.env.NODE_ENV === "production" ? "checkr" : "mock";
+  },
+
+  getAdapter(provider = this.getProviderName()): BackgroundCheckAdapter {
+    if (provider.toLowerCase() === "checkr") {
+      return new CheckrBackgroundCheckAdapter();
+    }
+    return new MockBackgroundCheckAdapter();
+  },
+
+  async initiateProviderCheck(checkId: string): Promise<BackgroundCheck> {
+    const check = await this.getBackgroundCheck(checkId);
+    if (!check) {
+      throw createError("Background check not found", 404);
+    }
+
+    const adapter = this.getAdapter(check.provider);
+    const initiated = await adapter.initiateCheck(check.mentorId, check.checkType);
+
+    const { rows } = await pool.query(
+      `UPDATE background_checks
+       SET status = 'in_progress',
+           external_reference_id = $2,
+           result_data = COALESCE(result_data, '{}'::jsonb) || $3::jsonb
+       WHERE id = $1
+       RETURNING *`,
+      [
+        checkId,
+        initiated.externalReferenceId,
+        JSON.stringify({
+          initiatedAt: new Date().toISOString(),
+          provider: check.provider,
+          providerResponse: initiated.raw || {},
+        }),
+      ],
+    );
+
+    const updated = this.transformBackgroundCheck(rows[0]);
+    await this.auditTransition(check, "in_progress", undefined, initiated.raw);
+    return updated;
+  },
+
+  async handleProviderWebhook(payload: any): Promise<BackgroundCheck | null> {
+    const externalReferenceId =
+      payload?.invitation?.id ||
+      payload?.report?.id ||
+      payload?.id ||
+      payload?.data?.object?.id ||
+      payload?.object?.id;
+
+    if (!externalReferenceId) {
+      throw createError("Webhook payload missing provider reference", 400);
+    }
+
+    const { rows } = await pool.query(
+      `SELECT *
+       FROM background_checks
+       WHERE external_reference_id = $1
+       LIMIT 1`,
+      [externalReferenceId],
+    );
+
+    if (!rows[0]) {
+      logger.warn("Background check webhook reference not found", { externalReferenceId });
+      return null;
+    }
+
+    const check = this.transformBackgroundCheck(rows[0]);
+    const adapter = this.getAdapter(check.provider);
+    const mapped = {
+      status: adapter instanceof CheckrBackgroundCheckAdapter
+        ? adapter.mapStatus(payload?.report?.status || payload?.status || payload?.data?.object?.status)
+        : "completed",
+      result: adapter instanceof CheckrBackgroundCheckAdapter
+        ? adapter.mapResult(payload?.report?.result || payload?.result || payload?.data?.object?.result)
+        : (process.env.BACKGROUND_CHECK_MOCK_RESULT || "clear"),
+    } as any;
+
+    return this.updateBackgroundCheckStatus(
+      check.id,
+      mapped.status,
+      mapped.result,
+      { webhookPayload: payload },
+    );
+  },
+
+  async pollPendingChecks(): Promise<number> {
+    const { rows } = await pool.query(
+      `SELECT *
+       FROM background_checks
+       WHERE status IN ('pending', 'in_progress')
+         AND external_reference_id IS NOT NULL
+       ORDER BY requested_at ASC
+       LIMIT 100`,
+    );
+
+    let updatedCount = 0;
+    for (const row of rows) {
+      const check = this.transformBackgroundCheck(row);
+      try {
+        const result = await this.getAdapter(check.provider).getCheckResult(check.externalReferenceId!);
+        if (result.status !== check.status || result.result) {
+          await this.updateBackgroundCheckStatus(
+            check.id,
+            result.status as BackgroundCheck["status"],
+            result.result,
+            result.raw,
+          );
+          updatedCount++;
+        }
+      } catch (error) {
+        logger.error("Failed to poll background check provider", {
+          checkId: check.id,
+          provider: check.provider,
+          error: error instanceof Error ? error.message : error,
+        });
+      }
+    }
+
+    return updatedCount;
+  },
+
+  async auditTransition(
+    previous: BackgroundCheck,
+    status: BackgroundCheck["status"],
+    result?: BackgroundCheck["result"],
+    resultData?: Record<string, any>,
+  ): Promise<void> {
+    await AuditLogModel.create({
+      level: "info",
+      action: "background_check.transition",
+      message: "Background check status transitioned",
+      user_id: previous.mentorId,
+      entity_type: "background_check",
+      entity_id: previous.id,
+      metadata: {
+        previousStatus: previous.status,
+        status,
+        previousResult: previous.result,
+        result,
+        resultData,
+      },
+      ip_address: null,
+      user_agent: null,
+    });
   },
 
   transformBackgroundCheck(row: any): BackgroundCheck {

--- a/src/services/background-checks/background-check.adapter.ts
+++ b/src/services/background-checks/background-check.adapter.ts
@@ -1,0 +1,25 @@
+import { BackgroundCheck } from "../../models/certification.model";
+
+export type BackgroundCheckStatus = "pending" | "in_progress" | "completed" | "failed";
+export type BackgroundCheckResult = "clear" | "consider" | "suspended";
+
+export interface BackgroundCheckAdapterResult {
+  status: BackgroundCheckStatus;
+  result?: BackgroundCheckResult;
+  raw?: Record<string, unknown>;
+}
+
+export interface InitiatedBackgroundCheck {
+  externalReferenceId: string;
+  raw?: Record<string, unknown>;
+}
+
+export interface BackgroundCheckAdapter {
+  initiateCheck(
+    mentorId: string,
+    checkType: BackgroundCheck["checkType"],
+  ): Promise<InitiatedBackgroundCheck>;
+
+  getCheckResult(externalReferenceId: string): Promise<BackgroundCheckAdapterResult>;
+}
+

--- a/src/services/background-checks/checkr.adapter.ts
+++ b/src/services/background-checks/checkr.adapter.ts
@@ -1,0 +1,86 @@
+import axios, { AxiosInstance } from "axios";
+import {
+  BackgroundCheckAdapter,
+  BackgroundCheckAdapterResult,
+  InitiatedBackgroundCheck,
+} from "./background-check.adapter";
+import { BackgroundCheck } from "../../models/certification.model";
+
+export class CheckrBackgroundCheckAdapter implements BackgroundCheckAdapter {
+  private readonly client: AxiosInstance;
+  private readonly packageSlug = process.env.CHECKR_PACKAGE || "basic_plus";
+
+  constructor() {
+    if (!process.env.CHECKR_API_KEY) {
+      throw new Error("CHECKR_API_KEY is required when BACKGROUND_CHECK_PROVIDER=checkr");
+    }
+
+    this.client = axios.create({
+      baseURL: process.env.CHECKR_BASE_URL || "https://api.checkr.com/v1",
+      auth: {
+        username: process.env.CHECKR_API_KEY,
+        password: "",
+      },
+      timeout: Number(process.env.CHECKR_TIMEOUT_MS || 10000),
+    });
+  }
+
+  async initiateCheck(
+    mentorId: string,
+    checkType: BackgroundCheck["checkType"],
+  ): Promise<InitiatedBackgroundCheck> {
+    const response = await this.withRetry(() =>
+      this.client.post("/invitations", {
+        package: this.packageSlug,
+        work_locations: [{ country: "US" }],
+        metadata: {
+          mentorId,
+          checkType,
+        },
+      }),
+    );
+
+    return {
+      externalReferenceId: response.data?.id,
+      raw: response.data,
+    };
+  }
+
+  async getCheckResult(externalReferenceId: string): Promise<BackgroundCheckAdapterResult> {
+    const response = await this.withRetry(() => this.client.get(`/invitations/${externalReferenceId}`));
+    return {
+      status: this.mapStatus(response.data?.status),
+      result: this.mapResult(response.data?.result),
+      raw: response.data,
+    };
+  }
+
+  mapStatus(status?: string): BackgroundCheckAdapterResult["status"] {
+    if (status === "complete" || status === "completed") return "completed";
+    if (status === "pending") return "pending";
+    if (status === "suspended" || status === "canceled" || status === "cancelled") return "failed";
+    return "in_progress";
+  }
+
+  mapResult(result?: string): BackgroundCheckAdapterResult["result"] | undefined {
+    if (result === "clear") return "clear";
+    if (result === "consider") return "consider";
+    if (result === "suspended") return "suspended";
+    return undefined;
+  }
+
+  private async withRetry<T>(fn: () => Promise<T>, attempts = 3): Promise<T> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      try {
+        return await fn();
+      } catch (error) {
+        lastError = error;
+        if (attempt < attempts - 1) {
+          await new Promise((resolve) => setTimeout(resolve, 250 * Math.pow(2, attempt)));
+        }
+      }
+    }
+    throw lastError;
+  }
+}

--- a/src/services/background-checks/mock.adapter.ts
+++ b/src/services/background-checks/mock.adapter.ts
@@ -1,0 +1,29 @@
+import {
+  BackgroundCheckAdapter,
+  BackgroundCheckAdapterResult,
+  InitiatedBackgroundCheck,
+} from "./background-check.adapter";
+import { BackgroundCheck } from "../../models/certification.model";
+
+export class MockBackgroundCheckAdapter implements BackgroundCheckAdapter {
+  async initiateCheck(
+    mentorId: string,
+    checkType: BackgroundCheck["checkType"],
+  ): Promise<InitiatedBackgroundCheck> {
+    return {
+      externalReferenceId: `mock-${mentorId}-${checkType}-${Date.now()}`,
+      raw: { provider: "mock", checkType },
+    };
+  }
+
+  async getCheckResult(externalReferenceId: string): Promise<BackgroundCheckAdapterResult> {
+    const configured = (process.env.BACKGROUND_CHECK_MOCK_RESULT || "clear").toLowerCase();
+    const result = configured === "consider" || configured === "suspended" ? configured : "clear";
+    return {
+      status: "completed",
+      result,
+      raw: { provider: "mock", externalReferenceId },
+    };
+  }
+}
+

--- a/src/services/cache.service.ts
+++ b/src/services/cache.service.ts
@@ -164,6 +164,51 @@ export class CacheService {
     }
   }
 
+  /** Push a JSON value onto a capped Redis list, with in-memory fallback. */
+  static async lpushTrim<T>(
+    key: string,
+    value: T,
+    maxLength: number,
+    ttlSeconds = redisConfig.defaultTtl,
+  ): Promise<void> {
+    try {
+      const serialized = JSON.stringify(value);
+      const client = await getClient();
+      if (client) {
+        await client.lpush(key, serialized);
+        await client.ltrim(key, 0, maxLength - 1);
+        await client.expire(key, ttlSeconds);
+      } else {
+        const current = JSON.parse(memGet(key) || '[]') as T[];
+        current.unshift(value);
+        memSet(key, JSON.stringify(current.slice(0, maxLength)), ttlSeconds);
+      }
+      track('sets', key);
+    } catch (err: any) {
+      track('errors', key);
+      logger.warn('Cache list push error', { key, error: err.message });
+    }
+  }
+
+  /** Read a JSON Redis list range, newest first for lists written by lpushTrim. */
+  static async lrange<T>(key: string, start = 0, stop = -1): Promise<T[]> {
+    try {
+      const client = await getClient();
+      const rawItems: string[] = client
+        ? await client.lrange(key, start, stop)
+        : (JSON.parse(memGet(key) || '[]') as T[])
+            .slice(start, stop === -1 ? undefined : stop + 1)
+            .map((item) => JSON.stringify(item));
+
+      track(rawItems.length > 0 ? 'hits' : 'misses', key);
+      return rawItems.map((raw) => JSON.parse(raw) as T);
+    } catch (err: any) {
+      track('errors', key);
+      logger.warn('Cache list range error', { key, error: err.message });
+      return [];
+    }
+  }
+
   /** Delete all keys matching a glob pattern (e.g. `mm:mentors:*`) */
   static async invalidatePattern(pattern: string): Promise<void> {
     try {

--- a/src/services/chatbot.service.ts
+++ b/src/services/chatbot.service.ts
@@ -1,5 +1,9 @@
 import axios from "axios";
+import { randomUUID } from "crypto";
+import pool from "../config/database";
+import { chatbotMessagesTotal } from "../config/metrics";
 import { logger } from "../utils/logger.utils";
+import { CacheService } from "./cache.service";
 
 export interface Message {
   role: "user" | "assistant" | "system";
@@ -50,15 +54,15 @@ const INTENT_PATTERNS: Record<string, RegExp[]> = {
 
 export class ChatbotService {
   private readonly openaiApiKey = process.env.OPENAI_API_KEY;
-  private readonly contexts = new Map<string, ChatbotContext>();
-  private readonly messageLog: ChatbotMessage[] = [];
+  private readonly contextTtlSeconds = 30 * 60;
+  private readonly historyLimit = 100;
 
   async chat(
     userId: string,
     message: string,
     userProfile: UserProfile,
   ): Promise<ChatbotMessage> {
-    const context = this.getOrCreateContext(userId, userProfile);
+    const context = await this.getOrCreateContext(userId, userProfile);
     const { intent, confidence } = this.classifyIntent(message);
 
     context.currentIntent = intent;
@@ -80,7 +84,7 @@ export class ChatbotService {
     });
 
     const record: ChatbotMessage = {
-      id: `msg-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      id: randomUUID(),
       userId,
       message,
       response,
@@ -90,7 +94,13 @@ export class ChatbotService {
       timestamp: new Date(),
     };
 
-    this.messageLog.push(record);
+    await this.saveContext(context);
+    await this.storeMessage(record);
+    chatbotMessagesTotal.inc({
+      intent,
+      escalated: String(escalated),
+    });
+
     logger.info(
       `Chatbot: user=${userId} intent=${intent} confidence=${confidence} escalated=${escalated}`,
     );
@@ -174,49 +184,134 @@ Be concise and helpful.`,
     return responses[intent] ?? responses.general;
   }
 
-  private getOrCreateContext(
+  private contextKey(userId: string): string {
+    return `chatbot:context:${userId}`;
+  }
+
+  private historyKey(userId: string): string {
+    return `chatbot:history:${userId}`;
+  }
+
+  private async getOrCreateContext(
     userId: string,
     userProfile: UserProfile,
-  ): ChatbotContext {
-    if (!this.contexts.has(userId)) {
-      this.contexts.set(userId, {
-        userId,
-        conversationHistory: [],
+  ): Promise<ChatbotContext> {
+    const cached = await CacheService.get<ChatbotContext>(this.contextKey(userId));
+    if (cached) {
+      return {
+        ...cached,
         userProfile,
-        currentIntent: "general",
-        entities: {},
-      });
+        conversationHistory: cached.conversationHistory.map((message) => ({
+          ...message,
+          timestamp: new Date(message.timestamp),
+        })),
+      };
     }
-    return this.contexts.get(userId)!;
-  }
-
-  clearHistory(userId: string): void {
-    const context = this.contexts.get(userId);
-    if (context) {
-      context.conversationHistory = [];
-      context.currentIntent = "general";
-    }
-  }
-
-  getAnalytics(): ChatbotAnalytics {
-    const topIntents: Record<string, number> = {};
-    let totalConfidence = 0;
-    let escalatedCount = 0;
-
-    this.messageLog.forEach((m) => {
-      topIntents[m.intent] = (topIntents[m.intent] ?? 0) + 1;
-      totalConfidence += m.confidence;
-      if (m.escalated) escalatedCount++;
-    });
 
     return {
-      totalMessages: this.messageLog.length,
-      escalatedCount,
+      userId,
+      conversationHistory: [],
+      userProfile,
+      currentIntent: "general",
+      entities: {},
+    };
+  }
+
+  private async saveContext(context: ChatbotContext): Promise<void> {
+    await CacheService.set(this.contextKey(context.userId), context, this.contextTtlSeconds);
+  }
+
+  private async storeMessage(record: ChatbotMessage): Promise<void> {
+    await CacheService.lpushTrim(this.historyKey(record.userId), record, this.historyLimit, this.contextTtlSeconds);
+    await pool.query(
+      `INSERT INTO chatbot_messages (
+         id, user_id, message, response, intent, confidence, escalated, created_at
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [
+        record.id,
+        record.userId,
+        record.message,
+        record.response,
+        record.intent,
+        record.confidence,
+        record.escalated,
+        record.timestamp,
+      ],
+    );
+  }
+
+  async clearHistory(userId: string): Promise<void> {
+    await CacheService.del(this.contextKey(userId));
+    await CacheService.del(this.historyKey(userId));
+    await pool.query(
+      `UPDATE chatbot_messages
+       SET cleared_at = CURRENT_TIMESTAMP
+       WHERE user_id = $1
+         AND cleared_at IS NULL`,
+      [userId],
+    );
+  }
+
+  async getHistory(userId: string, limit = this.historyLimit): Promise<ChatbotMessage[]> {
+    const cached = await CacheService.lrange<ChatbotMessage>(this.historyKey(userId), 0, limit - 1);
+    if (cached.length > 0) {
+      return cached.map((message) => ({
+        ...message,
+        timestamp: new Date(message.timestamp),
+      }));
+    }
+
+    const { rows } = await pool.query(
+      `SELECT id, user_id, message, response, intent, confidence, escalated, created_at
+       FROM chatbot_messages
+       WHERE user_id = $1
+         AND cleared_at IS NULL
+       ORDER BY created_at DESC
+       LIMIT $2`,
+      [userId, limit],
+    );
+
+    return rows.map((row) => ({
+      id: row.id,
+      userId: row.user_id,
+      message: row.message,
+      response: row.response,
+      intent: row.intent,
+      confidence: Number(row.confidence),
+      escalated: row.escalated,
+      timestamp: row.created_at,
+    }));
+  }
+
+  async getAnalytics(): Promise<ChatbotAnalytics> {
+    const { rows } = await pool.query(
+      `SELECT
+         COUNT(*)::INTEGER AS total_messages,
+         COUNT(*) FILTER (WHERE escalated = true)::INTEGER AS escalated_count,
+         COALESCE(AVG(confidence), 0)::FLOAT AS avg_confidence
+       FROM chatbot_messages
+       WHERE cleared_at IS NULL`,
+    );
+
+    const intents = await pool.query(
+      `SELECT intent, COUNT(*)::INTEGER AS count
+       FROM chatbot_messages
+       WHERE cleared_at IS NULL
+       GROUP BY intent
+       ORDER BY count DESC`,
+    );
+
+    const topIntents = intents.rows.reduce<Record<string, number>>((acc, row) => {
+      acc[row.intent] = Number(row.count);
+      return acc;
+    }, {});
+
+    return {
+      totalMessages: Number(rows[0]?.total_messages ?? 0),
+      escalatedCount: Number(rows[0]?.escalated_count ?? 0),
       topIntents,
-      avgConfidence:
-        this.messageLog.length > 0
-          ? totalConfidence / this.messageLog.length
-          : 0,
+      avgConfidence: Number(rows[0]?.avg_confidence ?? 0),
     };
   }
 }

--- a/src/services/enrollment.service.ts
+++ b/src/services/enrollment.service.ts
@@ -5,6 +5,8 @@ import { CacheService } from "./cache.service";
 import { CacheKeys, CacheTTL } from "../utils/cache-key.utils";
 import { logger } from "../utils/logger.utils";
 import { createError } from "../middleware/errorHandler";
+import { PaymentsService } from "./payments.service";
+import { StripeService } from "./stripe.service";
 import { 
   PathEnrollment, 
   CreateEnrollmentData, 
@@ -28,6 +30,15 @@ export interface BulkEnrollmentData {
   studentIds: string[];
   paymentData?: any;
   organizationId?: string;
+}
+
+interface VerifiedLearningPathPayment {
+  transactionId: string;
+  amount: number;
+  currency: string;
+  provider: "stripe" | "stellar";
+  paymentReference: string;
+  metadata: Record<string, unknown>;
 }
 
 export const EnrollmentService = {
@@ -65,16 +76,72 @@ export const EnrollmentService = {
         throw createError("Student account is not active", 403);
       }
 
+      const price = this.getLearningPathPrice(learningPath);
+      const currency = learningPath.currency || "XLM";
+      const isFree = learningPath.is_free === true || price <= 0;
+      let verifiedPayment: VerifiedLearningPathPayment | null = null;
+
       // Check if already enrolled
       const existingEnrollment = await EnrollmentModel.findByStudentAndPath(studentId, learningPathId);
       if (existingEnrollment) {
+        const paymentReference = this.getPaymentReference(enrollmentData.paymentData);
+        if (paymentReference) {
+          const existingPurchase = await this.findPurchaseByReference(paymentReference);
+          if (
+            existingPurchase &&
+            existingPurchase.enrollment_id === existingEnrollment.id &&
+            existingEnrollment.status !== "cancelled"
+          ) {
+            return EnrollmentModel.transformToEnrollment(existingEnrollment);
+          }
+          if (
+            existingPurchase &&
+            existingPurchase.enrollment_id === existingEnrollment.id &&
+            existingEnrollment.status === "cancelled"
+          ) {
+            verifiedPayment = {
+              transactionId: existingPurchase.transaction_id,
+              amount: Number(existingPurchase.amount),
+              currency: existingPurchase.currency,
+              provider: existingPurchase.provider as "stripe" | "stellar",
+              paymentReference: existingPurchase.payment_reference,
+              metadata: { idempotent: true },
+            };
+          }
+          if (
+            existingPurchase &&
+            existingPurchase.enrollment_id !== existingEnrollment.id
+          ) {
+            throw createError("Payment reference has already been used", 409);
+          }
+        }
+
         if (existingEnrollment.status === 'cancelled') {
+          if (!isFree && !verifiedPayment) {
+            verifiedPayment = await this.verifyEnrollmentPayment(
+              studentId,
+              price,
+              currency,
+              enrollmentData.paymentData,
+            );
+          }
+
           // Allow re-enrollment if previously cancelled
           const reactivated = await EnrollmentModel.updateStatus(existingEnrollment.id, {
             status: 'active'
           });
           
           if (reactivated) {
+            if (verifiedPayment) {
+              await this.recordLearningPathPurchase(
+                learningPathId,
+                reactivated.id,
+                studentId,
+                verifiedPayment,
+              );
+              await EnrollmentModel.updatePaymentStatus(reactivated.id, "paid", verifiedPayment.amount);
+            }
+
             await this.invalidateEnrollmentCaches(studentId, learningPathId);
             
             logger.info("Student re-enrolled in learning path", {
@@ -90,8 +157,34 @@ export const EnrollmentService = {
         }
       }
 
+      if (!isFree) {
+        verifiedPayment = await this.verifyEnrollmentPayment(
+          studentId,
+          price,
+          currency,
+          enrollmentData.paymentData,
+        );
+      }
+
       // Create new enrollment
       const enrollmentRecord = await EnrollmentModel.create(learningPathId, studentId, enrollmentData);
+      let enrollmentForResponse: PathEnrollmentRecord = enrollmentRecord;
+      if (verifiedPayment) {
+        await this.recordLearningPathPurchase(
+          learningPathId,
+          enrollmentRecord.id,
+          studentId,
+          verifiedPayment,
+        );
+        const paidEnrollment = await EnrollmentModel.updatePaymentStatus(
+          enrollmentRecord.id,
+          "paid",
+          verifiedPayment.amount,
+        );
+        if (paidEnrollment) {
+          enrollmentForResponse = paidEnrollment;
+        }
+      }
       
       // Initialize milestone progress records for all milestones
       const milestones = await MilestoneModel.findByLearningPathId(learningPathId);
@@ -104,7 +197,7 @@ export const EnrollmentService = {
       // Invalidate relevant caches
       await this.invalidateEnrollmentCaches(studentId, learningPathId);
 
-      const enrollment = EnrollmentModel.transformToEnrollment(enrollmentRecord);
+      const enrollment = EnrollmentModel.transformToEnrollment(enrollmentForResponse);
 
       logger.info("Student enrolled in learning path", {
         pathId: learningPathId,
@@ -122,6 +215,290 @@ export const EnrollmentService = {
       });
       throw error;
     }
+  },
+
+  async getPurchaseInfo(learningPathId: string, studentId?: string): Promise<Record<string, unknown>> {
+    const learningPath = await LearningPathModel.findById(learningPathId);
+    if (!learningPath) {
+      throw createError("Learning path not found", 404);
+    }
+
+    const price = this.getLearningPathPrice(learningPath);
+    const currency = learningPath.currency || "XLM";
+    let purchased = false;
+
+    if (studentId) {
+      const { rows } = await pool.query(
+        `SELECT 1
+         FROM learning_path_purchases
+         WHERE learning_path_id = $1
+           AND student_id = $2
+           AND status = 'completed'
+         LIMIT 1`,
+        [learningPathId, studentId],
+      );
+      purchased = rows.length > 0;
+    }
+
+    return {
+      learningPathId,
+      price,
+      currency,
+      isFree: learningPath.is_free === true || price <= 0,
+      purchased,
+      availablePaymentMethods: ["stripe", "stellar"],
+    };
+  },
+
+  async startTrial(learningPathId: string, studentId: string): Promise<PathEnrollment> {
+    const learningPath = await LearningPathModel.findById(learningPathId);
+    if (!learningPath) {
+      throw createError("Learning path not found", 404);
+    }
+
+    if (!learningPath.is_published) {
+      throw createError("Learning path is not published", 400);
+    }
+
+    const existingEnrollment = await EnrollmentModel.findByStudentAndPath(studentId, learningPathId);
+    if (existingEnrollment) {
+      throw createError("Student is already enrolled in this learning path", 409);
+    }
+
+    const trialEndsAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    const enrollmentRecord = await EnrollmentModel.create(learningPathId, studentId, {
+      paymentMethod: "trial",
+      paymentData: { trialEndsAt: trialEndsAt.toISOString() },
+    });
+
+    const { rows } = await pool.query<PathEnrollmentRecord>(
+      `UPDATE path_enrollments
+       SET is_trial = true,
+           trial_ends_at = $2,
+           requires_payment_after = $2,
+           metadata = COALESCE(metadata, '{}'::jsonb) || $3::jsonb
+       WHERE id = $1
+       RETURNING *`,
+      [
+        enrollmentRecord.id,
+        trialEndsAt,
+        JSON.stringify({ trial: true, trialEndsAt: trialEndsAt.toISOString() }),
+      ],
+    );
+
+    const milestones = await MilestoneModel.findByLearningPathId(learningPathId);
+    for (const milestone of milestones) {
+      await MilestoneProgressModel.create(enrollmentRecord.id, milestone.id);
+    }
+
+    await this.invalidateEnrollmentCaches(studentId, learningPathId);
+    return EnrollmentModel.transformToEnrollment(rows[0]);
+  },
+
+  async expireTrials(): Promise<number> {
+    const { rowCount } = await pool.query(
+      `UPDATE path_enrollments
+       SET status = 'paused',
+           payment_status = 'pending',
+           paused_at = COALESCE(paused_at, CURRENT_TIMESTAMP),
+           metadata = COALESCE(metadata, '{}'::jsonb) || '{"trialExpired": true}'::jsonb
+       WHERE is_trial = true
+         AND trial_ends_at <= CURRENT_TIMESTAMP
+         AND payment_status <> 'paid'
+         AND status = 'active'`,
+    );
+
+    return rowCount ?? 0;
+  },
+
+  getLearningPathPrice(learningPath: any): number {
+    return Number(learningPath.price ?? learningPath.total_price ?? 0);
+  },
+
+  getPaymentReference(paymentData: any): string | null {
+    if (!paymentData) return null;
+    if (paymentData.paymentIntentId) return `stripe:${paymentData.paymentIntentId}`;
+    if (paymentData.stellarTxHash) return `stellar:${paymentData.stellarTxHash}`;
+    return null;
+  },
+
+  async findPurchaseByReference(reference: string): Promise<any | null> {
+    const [provider, paymentReference] = reference.split(":", 2);
+    const { rows } = await pool.query(
+      `SELECT *
+       FROM learning_path_purchases
+       WHERE provider = $1
+         AND payment_reference = $2
+         AND status = 'completed'
+       LIMIT 1`,
+      [provider, paymentReference],
+    );
+    return rows[0] || null;
+  },
+
+  async verifyEnrollmentPayment(
+    studentId: string,
+    amount: number,
+    currency: string,
+    paymentData: any,
+  ): Promise<VerifiedLearningPathPayment> {
+    if (!paymentData?.paymentIntentId && !paymentData?.stellarTxHash) {
+      throw createError("Payment required for this learning path", 402);
+    }
+
+    if (paymentData.paymentIntentId) {
+      const existingPurchase = await this.findPurchaseByReference(`stripe:${paymentData.paymentIntentId}`);
+      if (existingPurchase) {
+        throw createError("Payment reference has already been used", 409);
+      }
+
+      const stripe = StripeService.ensureClient();
+      const paymentIntent = await stripe.paymentIntents.retrieve(paymentData.paymentIntentId);
+      if (paymentIntent.status !== "succeeded") {
+        throw createError("Payment has not succeeded", 402);
+      }
+
+      const paidAmount = Number(paymentIntent.amount_received ?? paymentIntent.amount ?? 0) / 100;
+      if (paidAmount < amount) {
+        throw createError("Payment amount is less than learning path price", 402);
+      }
+
+      if ((paymentIntent.currency || "").toUpperCase() !== currency.toUpperCase()) {
+        throw createError("Payment currency does not match learning path currency", 402);
+      }
+
+      const transactionId = await this.upsertStripeTransaction(
+        studentId,
+        paymentData.paymentIntentId,
+        paidAmount,
+        currency,
+        paymentIntent,
+      );
+
+      return {
+        transactionId,
+        amount: paidAmount,
+        currency,
+        provider: "stripe",
+        paymentReference: paymentData.paymentIntentId,
+        metadata: { stripePaymentIntentId: paymentData.paymentIntentId },
+      };
+    }
+
+    const paymentId = paymentData.paymentId || paymentData.transactionId;
+    const existingPurchase = await this.findPurchaseByReference(`stellar:${paymentData.stellarTxHash}`);
+    if (existingPurchase) {
+      throw createError("Payment reference has already been used", 409);
+    }
+
+    if (paymentId) {
+      const confirmed = await PaymentsService.confirmPayment(paymentId, studentId, paymentData.stellarTxHash);
+      return {
+        transactionId: confirmed.id,
+        amount: Number(confirmed.amount),
+        currency: confirmed.currency,
+        provider: "stellar",
+        paymentReference: paymentData.stellarTxHash,
+        metadata: { stellarTxHash: paymentData.stellarTxHash },
+      };
+    }
+
+    const { rows } = await pool.query(
+      `SELECT id, amount, currency
+       FROM transactions
+       WHERE user_id = $1
+         AND stellar_tx_hash = $2
+         AND status = 'completed'
+         AND type = 'payment'
+       LIMIT 1`,
+      [studentId, paymentData.stellarTxHash],
+    );
+
+    if (!rows[0]) {
+      throw createError("Valid Stellar payment transaction not found", 402);
+    }
+
+    if (Number(rows[0].amount) < amount || rows[0].currency !== currency) {
+      throw createError("Stellar payment does not satisfy the learning path price", 402);
+    }
+
+    return {
+      transactionId: rows[0].id,
+      amount: Number(rows[0].amount),
+      currency: rows[0].currency,
+      provider: "stellar",
+      paymentReference: paymentData.stellarTxHash,
+      metadata: { stellarTxHash: paymentData.stellarTxHash },
+    };
+  },
+
+  async upsertStripeTransaction(
+    studentId: string,
+    paymentIntentId: string,
+    amount: number,
+    currency: string,
+    paymentIntent: unknown,
+  ): Promise<string> {
+    const existing = await pool.query(
+      `SELECT id
+       FROM transactions
+       WHERE user_id = $1
+         AND metadata->>'paymentIntentId' = $2
+       LIMIT 1`,
+      [studentId, paymentIntentId],
+    );
+    if (existing.rows[0]) {
+      return existing.rows[0].id;
+    }
+
+    const { rows } = await pool.query(
+      `INSERT INTO transactions (
+         user_id, type, status, amount, currency, description, metadata,
+         created_at, updated_at, completed_at
+       )
+       VALUES ($1, 'payment', 'completed', $2, $3, $4, $5::jsonb, NOW(), NOW(), NOW())
+       RETURNING id`,
+      [
+        studentId,
+        amount,
+        currency,
+        `stripe_payment_intent:${paymentIntentId}`,
+        JSON.stringify({ paymentIntentId, paymentIntent }),
+      ],
+    );
+
+    return rows[0].id;
+  },
+
+  async recordLearningPathPurchase(
+    learningPathId: string,
+    enrollmentId: string,
+    studentId: string,
+    payment: VerifiedLearningPathPayment,
+  ): Promise<void> {
+    await pool.query(
+      `INSERT INTO learning_path_purchases (
+         learning_path_id, enrollment_id, student_id, transaction_id,
+         amount, currency, provider, payment_reference, status, metadata
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'completed', $9::jsonb)
+       ON CONFLICT (provider, payment_reference)
+       DO UPDATE SET
+         enrollment_id = EXCLUDED.enrollment_id,
+         updated_at = CURRENT_TIMESTAMP
+       WHERE learning_path_purchases.enrollment_id = EXCLUDED.enrollment_id`,
+      [
+        learningPathId,
+        enrollmentId,
+        studentId,
+        payment.transactionId,
+        payment.amount,
+        payment.currency,
+        payment.provider,
+        payment.paymentReference,
+        JSON.stringify(payment.metadata),
+      ],
+    );
   },
 
   /**

--- a/src/services/health.service.ts
+++ b/src/services/health.service.ts
@@ -253,6 +253,8 @@ export class HealthService {
         "mv_session_stats",
         "mv_top_mentors",
         "mv_asset_distribution",
+        "mv_revenue_time_series",
+        "mv_hourly_session_demand",
       ];
 
       const query = `
@@ -284,7 +286,7 @@ export class HealthService {
         details: {
           missingViews: missing,
           totalViews: requiredViews.length,
-          message: "Run migration 015_analytics_views.sql to create views",
+          message: "Run migrations 015_analytics_views.sql and 102_create_forecasting_views.sql to create analytics views",
         },
       };
     } catch (err: any) {

--- a/src/services/predictive-engine.service.ts
+++ b/src/services/predictive-engine.service.ts
@@ -110,6 +110,14 @@ export const PredictiveEngineService = {
       try {
         logger.info('Generating revenue forecast', { months, currency });
 
+        if (!await this.relationExists('mv_revenue_time_series')) {
+          logger.warn('Revenue forecasting view missing; returning empty forecast', {
+            view: 'mv_revenue_time_series',
+            migration: '102_create_forecasting_views.sql'
+          });
+          return [];
+        }
+
         // Get historical revenue data
         const query = `
           SELECT 
@@ -126,7 +134,11 @@ export const PredictiveEngineService = {
         const { rows } = await pool.query(query, params);
 
         if (rows.length < 30) { // Need at least 30 days of data
-          throw new Error('Insufficient historical data for revenue forecasting');
+          logger.warn('Insufficient historical data for revenue forecasting', {
+            rows: rows.length,
+            minimumRows: 30
+          });
+          return [];
         }
 
         // Group by currency if not specified
@@ -179,6 +191,14 @@ export const PredictiveEngineService = {
       try {
         logger.info('Generating demand forecast', { days });
 
+        if (!await this.relationExists('mv_hourly_session_demand')) {
+          logger.warn('Demand forecasting view missing; returning empty forecast', {
+            view: 'mv_hourly_session_demand',
+            migration: '102_create_forecasting_views.sql'
+          });
+          return [];
+        }
+
         // Get historical hourly demand data
         const query = `
           SELECT 
@@ -195,7 +215,11 @@ export const PredictiveEngineService = {
         const { rows } = await pool.query(query);
 
         if (rows.length < 168) { // Need at least 1 week of hourly data
-          throw new Error('Insufficient historical data for demand forecasting');
+          logger.warn('Insufficient historical data for demand forecasting', {
+            rows: rows.length,
+            minimumRows: 168
+          });
+          return [];
         }
 
         // Group by day of week and hour
@@ -245,6 +269,21 @@ export const PredictiveEngineService = {
       }
     });
   },
+
+  async relationExists(relationName: string): Promise<boolean> {
+    const { rows } = await pool.query(
+      `SELECT EXISTS (
+         SELECT 1
+         FROM information_schema.tables
+         WHERE table_schema = 'public'
+           AND table_name = $1
+           AND table_type IN ('BASE TABLE', 'MATERIALIZED VIEW')
+       ) AS exists`,
+      [relationName],
+    );
+    return rows[0]?.exists === true;
+  },
+
   /**
    * Calculate forecast accuracy
    */

--- a/src/utils/table-validator.utils.ts
+++ b/src/utils/table-validator.utils.ts
@@ -50,6 +50,7 @@ const REQUIRED_TABLES = [
   'conversations',
   'messages',
   'message_attachments',
+  'chatbot_messages',
   'notification_templates',
   'notification_delivery_tracking',
   'notification_analytics',
@@ -81,6 +82,10 @@ const REQUIRED_TABLES = [
   'conversations',
   'messages',
   'message_attachments',
+  'learning_path_purchases',
+  'analytics_predictions',
+  'mv_revenue_time_series',
+  'mv_hourly_session_demand',
 ];
 
 /**
@@ -98,7 +103,7 @@ export async function validateRequiredTables(): Promise<ValidationSummary> {
       SELECT table_name
       FROM information_schema.tables
       WHERE table_schema = 'public'
-        AND table_type = 'BASE TABLE'
+        AND table_type IN ('BASE TABLE', 'MATERIALIZED VIEW')
         AND table_name = ANY($1)
     `;
     

--- a/src/workers/scheduler.ts
+++ b/src/workers/scheduler.ts
@@ -4,6 +4,8 @@ import { escrowCheckQueue } from "../queues/escrow-check.queue";
 import { notificationCleanupQueue } from "../queues/notificationCleanup.queue";
 import { maintenanceQueue } from "../queues/maintenance.queue";
 import { VerificationService } from "../services/verification.service";
+import { BackgroundCheckService } from "../services/background-check.service";
+import { EnrollmentService } from "../services/enrollment.service";
 import { accountDeletionJob } from "../jobs/accountDeletion.job";
 import { logger } from "../utils/logger.utils";
 import config from "../config";
@@ -11,6 +13,8 @@ import { AuditLogModel } from "../models/audit-log.model";
 import { PaymentModel } from "../models/payment.model";
 import SessionModel from "../models/session.model";
 import { Queue, JobsOptions } from "bullmq";
+
+let backgroundCheckPollingTimer: NodeJS.Timeout | null = null;
 
 /**
  * Add a repeatable job only if it doesn't already exist.
@@ -120,9 +124,22 @@ export async function startScheduler(): Promise<void> {
   logger.info(
     "Job scheduler started — weekly earnings, session reminders, escrow check, notification cleanup, and daily maintenance registered",
   );
+
+  if (!backgroundCheckPollingTimer) {
+    backgroundCheckPollingTimer = setInterval(() => {
+      BackgroundCheckService.pollPendingChecks().catch((error) => {
+        logger.error("Background check polling failed", { error });
+      });
+    }, 6 * 60 * 60 * 1000);
+    backgroundCheckPollingTimer.unref?.();
+  }
 }
 
 export async function stopScheduler(): Promise<void> {
+  if (backgroundCheckPollingTimer) {
+    clearInterval(backgroundCheckPollingTimer);
+    backgroundCheckPollingTimer = null;
+  }
   logger.info("Job scheduler stopped");
 }
 
@@ -134,6 +151,13 @@ export async function runMaintenanceTasks(): Promise<void> {
   if (expired > 0) {
     logger.info("Maintenance: expired verifications flagged", {
       count: expired,
+    });
+  }
+
+  const expiredTrials = await EnrollmentService.expireTrials();
+  if (expiredTrials > 0) {
+    logger.info("Maintenance: expired learning path trials paused", {
+      count: expiredTrials,
     });
   }
 


### PR DESCRIPTION
## Summary
- Add learning path payment gating, purchase records, purchase info endpoint, and 7-day trial enrollment handling.
- Add forecasting materialized views, analytics prediction storage, health checks, validator coverage, and graceful predictive engine degradation.
- Replace production background-check simulation with Checkr/mock provider adapters, webhook handling, audit logging, and scheduled polling.
- Move chatbot context/history from in-memory state to Redis/Postgres, add history APIs, and register Prometheus metrics.

<!-- migration: Adds /api/v1/learning-paths/:id/purchase, /api/v1/learning-paths/:id/trial, /api/v1/chatbot routes, and /api/v1/admin/background-checks/webhook. -->

## Test evidence
- Passed: npx eslint src/services/enrollment.service.ts src/services/chatbot.service.ts src/services/background-check.service.ts src/services/background-checks/background-check.adapter.ts src/services/background-checks/checkr.adapter.ts src/services/background-checks/mock.adapter.ts src/services/predictive-engine.service.ts src/services/cache.service.ts src/controllers/chatbot.controller.ts src/controllers/background-check.controller.ts src/controllers/learning-path-purchase.controller.ts src/routes/chatbot.routes.ts src/routes/learning-path.routes.ts src/routes/admin.routes.ts src/workers/scheduler.ts --quiet
- Blocked: npm run build:check fails before these changes on existing syntax errors in src/controllers/conversations.controller.ts and src/services/messaging.service.ts.
- Blocked: npm run migrate:validate fails on existing duplicate migration prefixes across the repo; the new 102/103 migrations are not reported as duplicates.

Closes #764
Closes #763
Closes #761
Closes #760