### PR TITLE
feat(wallets): add defi sync and onboarding guards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,15 @@ REDIS_CLUSTER_ENABLED=false
 REDIS_CLUSTER_NODES=localhost:7000,localhost:7001,localhost:7002
 REDIS_TLS_ENABLED=false
 
+# -----------------------------------------------------------------------------
+# DeFi wallet aggregation
+# -----------------------------------------------------------------------------
+DEFI_WALLET_USE_MOCKS=false
+DEFI_ETHEREUM_AAVE_SUBGRAPH_URL=
+DEFI_ETHEREUM_COMPOUND_SUBGRAPH_URL=
+DEFI_POLYGON_AAVE_SUBGRAPH_URL=
+DEFI_POLYGON_COMPOUND_SUBGRAPH_URL=
+
 # Microservices URLs
 AUTH_SERVICE_URL=http://localhost:5001
 USER_SERVICE_URL=http://localhost:5002

--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ GET /api/v1/timezones/:identifier - Get timezone details
 - `POST /api/v1/payments` - Process payment
 - `GET /api/v1/wallets/:id` - Get wallet info
 
+### New Wallet And Onboarding Endpoints
+```
+POST /api/v1/wallets/defi/sync
+GET /api/v1/wallets/defi/positions
+POST /api/v1/onboarding/steps/:stepId/complete
+```
+
 ## 🔐 Environment Variables
 
 | Variable | Description | Default |
@@ -148,6 +155,12 @@ GET /api/v1/timezones/:identifier - Get timezone details
 | `PORT` | Server port | 5000 |
 | `DATABASE_URL` | PostgreSQL connection string | - |
 | `JWT_SECRET` | JWT signing secret | - |
+| `REDIS_URL` | Redis connection string for cache-backed DeFi syncs | - |
+| `DEFI_WALLET_USE_MOCKS` | Force sandbox mock positions instead of live protocol queries | false |
+| `DEFI_ETHEREUM_AAVE_SUBGRAPH_URL` | Aave Ethereum subgraph endpoint | - |
+| `DEFI_ETHEREUM_COMPOUND_SUBGRAPH_URL` | Compound Ethereum subgraph endpoint | - |
+| `DEFI_POLYGON_AAVE_SUBGRAPH_URL` | Aave Polygon subgraph endpoint | - |
+| `DEFI_POLYGON_COMPOUND_SUBGRAPH_URL` | Compound Polygon subgraph endpoint | - |
 | `STELLAR_NETWORK` | Stellar network (testnet/mainnet) | testnet |
 | `STELLAR_HORIZON_URL` | Horizon server URL | testnet URL |
 | `CORS_ORIGIN` | Allowed CORS origins | * |
@@ -180,6 +193,9 @@ The project uses **Jest** with **Supertest** for comprehensive API integration t
 ```bash
 # Run all tests
 npm test
+
+# Run the new unit coverage around DeFi sync and onboarding dependencies
+npm run test:unit
 
 # Run chaos engineering and failure injection unit tests
 npm run test:chaos
@@ -445,4 +461,3 @@ The final `runner` image uses Debian slim and `npm ci --omit=dev`. If the image 
 - **Reward:** $2
 - **Source:** GitHub-Paid
 - **Date:** 2026-04-27
-

--- a/database/migrations/092_add_multichain_wallet_addresses.sql
+++ b/database/migrations/092_add_multichain_wallet_addresses.sql
@@ -1,0 +1,48 @@
+-- =============================================================================
+-- Migration: 092_add_multichain_wallet_addresses.sql
+-- Description: Add optional EVM addresses to wallets for multi-chain DeFi sync
+-- =============================================================================
+
+ALTER TABLE wallets
+ADD COLUMN IF NOT EXISTS ethereum_address VARCHAR(42),
+ADD COLUMN IF NOT EXISTS polygon_address VARCHAR(42);
+
+CREATE INDEX IF NOT EXISTS idx_wallets_ethereum_address
+  ON wallets(ethereum_address)
+  WHERE ethereum_address IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_wallets_polygon_address
+  ON wallets(polygon_address)
+  WHERE polygon_address IS NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'check_wallets_ethereum_address_format'
+  ) THEN
+    ALTER TABLE wallets
+    ADD CONSTRAINT check_wallets_ethereum_address_format
+    CHECK (
+      ethereum_address IS NULL
+      OR ethereum_address ~ '^0x[a-fA-F0-9]{40}$'
+    );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'check_wallets_polygon_address_format'
+  ) THEN
+    ALTER TABLE wallets
+    ADD CONSTRAINT check_wallets_polygon_address_format
+    CHECK (
+      polygon_address IS NULL
+      OR polygon_address ~ '^0x[a-fA-F0-9]{40}$'
+    );
+  END IF;
+END $$;
+
+COMMENT ON COLUMN wallets.ethereum_address IS 'Optional Ethereum wallet address used for DeFi portfolio aggregation';
+COMMENT ON COLUMN wallets.polygon_address IS 'Optional Polygon wallet address used for DeFi portfolio aggregation';

--- a/jest.unit.config.ts
+++ b/jest.unit.config.ts
@@ -1,0 +1,38 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  displayName: "unit",
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/src/**/*.unit.test.ts"],
+  testPathIgnorePatterns: ["/node_modules/", "/dist/"],
+  transform: {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        tsconfig: {
+          module: "commonjs",
+          target: "ES2020",
+          esModuleInterop: true,
+          allowSyntheticDefaultImports: true,
+          strict: true,
+          skipLibCheck: true,
+          resolveJsonModule: true,
+          types: ["node", "jest"],
+        },
+        diagnostics: {
+          ignoreCodes: [1343, 2345, 7006],
+        },
+      },
+    ],
+  },
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
+  },
+  collectCoverage: false,
+  clearMocks: true,
+  restoreMocks: true,
+  verbose: true,
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "node dist/bootstrap.js",
     "start:worker": "node dist/worker-bootstrap.js",
     "lint": "node --max-old-space-size=4096 node_modules/eslint/bin/eslint.js .",
+    "test:unit": "jest --config jest.unit.config.ts --runInBand",
     "test:validators": "ts-node --transpile-only src/validators/__tests__/run.ts",
     "test:cors": "ts-node --transpile-only src/middleware/__tests__/run.ts",
     "lint:fix": "eslint . --fix",

--- a/src/config/socket.ts
+++ b/src/config/socket.ts
@@ -147,6 +147,9 @@ export function createSocketServer(httpServer: HTTPServer): SocketIOServer {
 
     // Each socket joins a personal room for targeted emissions
     socket.join(`user:${userId}`);
+    if (role === 'admin') {
+      socket.join('admin');
+    }
 
     logger.info('Socket.IO: Client connected', { socketId: socket.id, userId, role });
 

--- a/src/controllers/wallets.controller.ts
+++ b/src/controllers/wallets.controller.ts
@@ -3,6 +3,7 @@ import { Response } from 'express';
 import { AuthenticatedRequest } from '../types';
 import { WalletsService } from '../services/wallets.service';
 import { stellarService } from '../services/stellar.service';
+import { defiWalletService } from '../services/defi-wallet.service';
 import { ResponseUtil } from '../utils/response.utils';
 import { logger } from '../utils/logger.utils';
 import type { 
@@ -14,6 +15,90 @@ import type {
 } from '../validators/schemas/wallet.schemas';
 
 export const WalletsController = {
+  /** POST /wallets/defi/sync */
+  async syncDeFiPositions(req: AuthenticatedRequest, res: Response): Promise<void> {
+    try {
+      const userId = req.user!.userId;
+      const positions = await defiWalletService.syncPositions(userId);
+      const totalValue = await defiWalletService.getPortfolioValue(userId);
+      const portfolioRisk = defiWalletService.calculatePortfolioRisk(positions);
+
+      await WalletsService.logWalletEvent(userId, {
+        eventType: 'balance_check',
+        metadata: {
+          action: 'defi_sync',
+          positionsCount: positions.length,
+          totalValue,
+          portfolioRisk,
+        },
+        ipAddress: req.ip,
+        userAgent: req.get('User-Agent'),
+      });
+
+      ResponseUtil.success(
+        res,
+        {
+          positions,
+          totalValue,
+          portfolioRisk,
+          cachedForSeconds: 600,
+          syncedAt: new Date().toISOString(),
+        },
+        'DeFi positions synced successfully',
+      );
+    } catch (error) {
+      logger.error('wallets.syncDeFiPositions failed', {
+        userId: req.user?.userId,
+        error: error instanceof Error ? error.message : error,
+      });
+      ResponseUtil.error(res, 'Failed to sync DeFi positions', 502);
+    }
+  },
+
+  /** GET /wallets/defi/positions */
+  async getDeFiPositions(req: AuthenticatedRequest, res: Response): Promise<void> {
+    try {
+      const userId = req.user!.userId;
+      const positions =
+        (await defiWalletService.getCachedPositions(userId)) ??
+        (await defiWalletService.syncPositions(userId));
+      const totalValue = positions.reduce(
+        (sum, position) => sum + parseFloat(position.value),
+        0,
+      );
+      const portfolioRisk = defiWalletService.calculatePortfolioRisk(positions);
+
+      await WalletsService.logWalletEvent(userId, {
+        eventType: 'balance_check',
+        metadata: {
+          action: 'defi_positions_view',
+          positionsCount: positions.length,
+          totalValue: totalValue.toFixed(2),
+          portfolioRisk,
+        },
+        ipAddress: req.ip,
+        userAgent: req.get('User-Agent'),
+      });
+
+      ResponseUtil.success(
+        res,
+        {
+          positions,
+          totalValue: totalValue.toFixed(2),
+          portfolioRisk,
+          cached: true,
+        },
+        'DeFi positions retrieved successfully',
+      );
+    } catch (error) {
+      logger.error('wallets.getDeFiPositions failed', {
+        userId: req.user?.userId,
+        error: error instanceof Error ? error.message : error,
+      });
+      ResponseUtil.error(res, 'Failed to retrieve DeFi positions', 502);
+    }
+  },
+
   /** GET /wallets/me */
   async getWalletInfo(req: AuthenticatedRequest, res: Response): Promise<void> {
     try {

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -7,6 +7,7 @@ import { CircuitBreakerError } from "../services/database.service";
 export interface AppError extends Error {
   statusCode?: number;
   isOperational?: boolean;
+  details?: unknown;
 }
 
 export const errorHandler = (
@@ -69,6 +70,7 @@ export const errorHandler = (
   res.status(statusCode).json({
     status: "error",
     message,
+    details: "details" in err ? (err as AppError).details : undefined,
     requestId,
     timestamp: new Date().toISOString(),
     ...(process.env.NODE_ENV === "development" && {
@@ -81,9 +83,11 @@ export const errorHandler = (
 export const createError = (
   message: string,
   statusCode: number = 500,
+  details?: unknown,
 ): AppError => {
   const error: AppError = new Error(message);
   error.statusCode = statusCode;
   error.isOperational = true;
+  error.details = details;
   return error;
 };

--- a/src/models/wallet.model.ts
+++ b/src/models/wallet.model.ts
@@ -4,6 +4,8 @@ export interface Wallet {
   id: string;
   user_id: string;
   stellar_public_key: string;
+  ethereum_address?: string | null;
+  polygon_address?: string | null;
   status: "active" | "inactive" | "suspended";
   wallet_activated?: boolean;
   created_at: Date;
@@ -60,6 +62,29 @@ export const WalletModel = {
       RETURNING *;
     `;
     const { rows } = await db.query(query, [userId, stellarPublicKey]);
+    return rows[0] || null;
+  },
+
+  async updateChainAddresses(
+    userId: string,
+    addresses: {
+      ethereumAddress?: string | null;
+      polygonAddress?: string | null;
+    },
+  ): Promise<Wallet | null> {
+    const query = `
+      UPDATE wallets
+      SET ethereum_address = COALESCE($2, ethereum_address),
+          polygon_address = COALESCE($3, polygon_address),
+          updated_at = CURRENT_TIMESTAMP
+      WHERE user_id = $1
+      RETURNING *;
+    `;
+    const { rows } = await db.query(query, [
+      userId,
+      addresses.ethereumAddress ?? null,
+      addresses.polygonAddress ?? null,
+    ]);
     return rows[0] || null;
   },
 

--- a/src/routes/wallets.routes.ts
+++ b/src/routes/wallets.routes.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { authenticate } from "../middleware/auth.middleware";
 import { asyncHandler } from "../utils/asyncHandler.utils";
 import { WalletActivationController } from "../controllers/walletActivation.controller";
+import { WalletsController } from "../controllers/wallets.controller";
 
 const router = Router();
 
@@ -21,6 +22,18 @@ router.post(
   "/activate",
   authenticate,
   asyncHandler(WalletActivationController.activate),
+);
+
+router.post(
+  "/defi/sync",
+  authenticate,
+  asyncHandler(WalletsController.syncDeFiPositions),
+);
+
+router.get(
+  "/defi/positions",
+  authenticate,
+  asyncHandler(WalletsController.getDeFiPositions),
 );
 
 export default router;

--- a/src/services/__tests__/defi-wallet.service.unit.test.ts
+++ b/src/services/__tests__/defi-wallet.service.unit.test.ts
@@ -1,0 +1,188 @@
+jest.mock("axios", () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+  },
+}));
+
+jest.mock("../../models/wallet.model", () => ({
+  WalletModel: {
+    findByUserId: jest.fn(),
+  },
+}));
+
+jest.mock("../cache.service", () => ({
+  CacheService: {
+    get: jest.fn(),
+    set: jest.fn(),
+  },
+}));
+
+jest.mock("../stellar.service", () => ({
+  stellarService: {
+    getAccount: jest.fn(),
+  },
+}));
+
+import axios from "axios";
+import { WalletModel } from "../../models/wallet.model";
+import { CacheService } from "../cache.service";
+import { stellarService } from "../stellar.service";
+import { DeFiWalletService } from "../defi-wallet.service";
+
+const axiosPost = axios.post as jest.Mock;
+const findByUserId = WalletModel.findByUserId as jest.Mock;
+const cacheGet = CacheService.get as jest.Mock;
+const cacheSet = CacheService.set as jest.Mock;
+const getAccount = stellarService.getAccount as jest.Mock;
+
+describe("DeFiWalletService", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.DEFI_WALLET_USE_MOCKS;
+    delete process.env.APP_ENV;
+    delete process.env.NODE_ENV;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns cached positions without re-syncing", async () => {
+    const service = new DeFiWalletService();
+    const cachedPositions = [
+      {
+        userId: "user-1",
+        protocol: "Aave",
+        chain: "ethereum",
+        asset: "USDC",
+        amount: "25.00",
+        apy: 4.1,
+        value: "25.00",
+        rewards: "0.00",
+        riskScore: 18,
+      },
+    ];
+
+    cacheGet.mockResolvedValueOnce(cachedPositions);
+
+    await expect(service.getUserPositions("user-1")).resolves.toEqual(
+      cachedPositions,
+    );
+    expect(findByUserId).not.toHaveBeenCalled();
+  });
+
+  it("syncs real multi-chain positions and caches them for 10 minutes", async () => {
+    const service = new DeFiWalletService();
+
+    findByUserId.mockResolvedValueOnce({
+      user_id: "user-1",
+      stellar_public_key: "GDUMMYSTELLARADDRESS",
+      ethereum_address: "0x1111111111111111111111111111111111111111",
+      polygon_address: "0x2222222222222222222222222222222222222222",
+      status: "active",
+    });
+
+    getAccount.mockResolvedValueOnce({
+      balances: [
+        {
+          assetType: "liquidity_pool_shares",
+          balance: "12.5000000",
+          liquidityPoolId: "abcdef1234567890",
+        },
+      ],
+    });
+
+    axiosPost
+      .mockResolvedValueOnce({
+        data: {
+          data: {
+            userReserves: [
+              {
+                currentATokenBalance: "10",
+                currentATokenBalanceUSD: "10",
+                reserve: {
+                  symbol: "USDC",
+                  liquidityRate: "0.05",
+                },
+              },
+            ],
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: {
+            account: {
+              tokens: [
+                {
+                  symbol: "WETH",
+                  supplyBalanceUnderlying: "1.25",
+                  supplyBalanceUnderlyingUSD: "2500",
+                  rewardsAccrued: "0.15",
+                  market: {
+                    supplyRate: "0.02",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: {
+            userReserves: [],
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: {
+            account: {
+              tokens: [],
+            },
+          },
+        },
+      });
+
+    process.env.DEFI_ETHEREUM_AAVE_SUBGRAPH_URL =
+      "https://graph.example/aave-eth";
+    process.env.DEFI_ETHEREUM_COMPOUND_SUBGRAPH_URL =
+      "https://graph.example/compound-eth";
+    process.env.DEFI_POLYGON_AAVE_SUBGRAPH_URL =
+      "https://graph.example/aave-polygon";
+    process.env.DEFI_POLYGON_COMPOUND_SUBGRAPH_URL =
+      "https://graph.example/compound-polygon";
+
+    const positions = await service.syncPositions("user-1");
+
+    expect(positions).toHaveLength(3);
+    expect(positions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          protocol: "Aave",
+          chain: "ethereum",
+          asset: "USDC",
+        }),
+        expect.objectContaining({
+          protocol: "Compound",
+          chain: "ethereum",
+          asset: "WETH",
+        }),
+        expect.objectContaining({
+          protocol: "Stellar AMM",
+          chain: "stellar",
+        }),
+      ]),
+    );
+    expect(cacheSet).toHaveBeenCalledWith(
+      "defi:positions:user-1",
+      positions,
+      600,
+    );
+  });
+});

--- a/src/services/__tests__/mentor-onboarding.service.unit.test.ts
+++ b/src/services/__tests__/mentor-onboarding.service.unit.test.ts
@@ -1,0 +1,213 @@
+jest.mock("../../config/database", () => ({
+  __esModule: true,
+  default: {
+    query: jest.fn(),
+  },
+}));
+
+jest.mock("../cache.service", () => ({
+  CacheService: {
+    del: jest.fn(),
+    get: jest.fn(),
+    set: jest.fn(),
+  },
+}));
+
+jest.mock("../rate-limiter.service", () => ({
+  RateLimiterService: {
+    check: jest.fn(),
+  },
+}));
+
+jest.mock("../verification.service", () => ({
+  VerificationService: {
+    getStatusByMentorId: jest.fn(),
+  },
+}));
+
+jest.mock("../background-check.service", () => ({
+  BackgroundCheckService: {
+    getMentorBackgroundChecks: jest.fn(),
+  },
+}));
+
+jest.mock("../../models/wallet.model", () => ({
+  WalletModel: {
+    findByUserId: jest.fn(),
+  },
+}));
+
+jest.mock("../socket.service", () => ({
+  SocketService: {
+    emitToRoom: jest.fn(),
+  },
+}));
+
+import pool from "../../config/database";
+import { CacheService } from "../cache.service";
+import { RateLimiterService } from "../rate-limiter.service";
+import { VerificationService } from "../verification.service";
+import { WalletModel } from "../../models/wallet.model";
+import { SocketService } from "../socket.service";
+import { MentorOnboardingService } from "../mentor-onboarding.service";
+
+const query = (pool as { query: jest.Mock }).query;
+const rateLimitCheck = RateLimiterService.check as jest.Mock;
+const verificationStatus = VerificationService.getStatusByMentorId as jest.Mock;
+const findWallet = WalletModel.findByUserId as jest.Mock;
+const cacheDel = CacheService.del as jest.Mock;
+const emitToRoom = SocketService.emitToRoom as jest.Mock;
+
+describe("MentorOnboardingService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns unmet step and verification dependencies", async () => {
+    jest
+      .spyOn(MentorOnboardingService, "getStepDependencies")
+      .mockResolvedValueOnce(["profile_setup"]);
+    verificationStatus.mockResolvedValueOnce({ status: "pending" });
+
+    const unmet = await MentorOnboardingService.getUnmetDependencies(
+      "mentor-1",
+      "identity_verification",
+      [],
+    );
+
+    expect(unmet).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ dependency: "profile_setup" }),
+        expect.objectContaining({ dependency: "identity_verification" }),
+      ]),
+    );
+  });
+
+  it("rejects completeStep with HTTP 422 details when prerequisites are missing", async () => {
+    jest
+      .spyOn(MentorOnboardingService, "getOnboarding")
+      .mockResolvedValueOnce({
+        id: "onb-1",
+        mentorId: "mentor-1",
+        status: "in_progress",
+        currentStep: 2,
+        totalSteps: 10,
+        stepsCompleted: ["profile_setup"],
+        startedAt: new Date(),
+        completedAt: null,
+        metadata: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as any);
+    rateLimitCheck.mockResolvedValueOnce({
+      allowed: true,
+      current: 1,
+      remaining: 9,
+      resetTime: new Date(),
+      limit: 10,
+    });
+    jest
+      .spyOn(MentorOnboardingService, "getUnmetDependencies")
+      .mockResolvedValueOnce([
+        {
+          dependency: "background_check",
+          reason: 'A completed background check with result "clear" is required.',
+        },
+      ]);
+
+    await expect(
+      MentorOnboardingService.completeStep("mentor-1", "background_check"),
+    ).rejects.toMatchObject({
+      statusCode: 422,
+      details: {
+        unmetDependencies: [
+          expect.objectContaining({ dependency: "background_check" }),
+        ],
+      },
+    });
+  });
+
+  it("emits an admin room event after a successful step completion", async () => {
+    jest
+      .spyOn(MentorOnboardingService, "getOnboarding")
+      .mockResolvedValueOnce({
+        id: "onb-1",
+        mentorId: "mentor-1",
+        status: "in_progress",
+        currentStep: 2,
+        totalSteps: 10,
+        stepsCompleted: ["profile_setup"],
+        startedAt: new Date(),
+        completedAt: null,
+        metadata: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as any);
+    rateLimitCheck.mockResolvedValueOnce({
+      allowed: true,
+      current: 1,
+      remaining: 9,
+      resetTime: new Date(),
+      limit: 10,
+    });
+    jest
+      .spyOn(MentorOnboardingService, "getUnmetDependencies")
+      .mockResolvedValueOnce([]);
+    jest
+      .spyOn(MentorOnboardingService, "trackAnalytics")
+      .mockResolvedValue(undefined);
+    jest
+      .spyOn(MentorOnboardingService, "transformOnboarding")
+      .mockImplementation((row: any) => row);
+
+    query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: "onb-1",
+          mentor_id: "mentor-1",
+          status: "in_progress",
+          current_step: 3,
+          total_steps: 10,
+          steps_completed: ["profile_setup", "identity_verification"],
+          started_at: new Date(),
+          completed_at: null,
+          metadata: {},
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+      ],
+    });
+
+    await MentorOnboardingService.completeStep(
+      "mentor-1",
+      "identity_verification",
+    );
+
+    expect(cacheDel).toHaveBeenCalledWith("onboarding:mentor-1");
+    expect(emitToRoom).toHaveBeenCalledWith(
+      "admin",
+      "mentor:onboarding_step_completed",
+      expect.objectContaining({
+        mentorId: "mentor-1",
+        stepId: "identity_verification",
+      }),
+    );
+  });
+
+  it("requires an active wallet before payment setup can complete", async () => {
+    jest
+      .spyOn(MentorOnboardingService, "getStepDependencies")
+      .mockResolvedValueOnce(["pricing_setup"]);
+    findWallet.mockResolvedValueOnce({ status: "inactive" });
+
+    const unmet = await MentorOnboardingService.getUnmetDependencies(
+      "mentor-1",
+      "payment_setup",
+      ["pricing_setup"],
+    );
+
+    expect(unmet).toEqual([
+      expect.objectContaining({ dependency: "payment_setup" }),
+    ]);
+  });
+});

--- a/src/services/defi-wallet.service.ts
+++ b/src/services/defi-wallet.service.ts
@@ -1,4 +1,8 @@
-import { logger } from "../utils/logger";
+import axios from "axios";
+import { CacheService } from "./cache.service";
+import { stellarService } from "./stellar.service";
+import { WalletModel, type Wallet } from "../models/wallet.model";
+import { logger } from "../utils/logger.utils";
 
 export interface DeFiPosition {
   userId: string;
@@ -23,6 +27,8 @@ export interface YieldStrategy {
 
 const SUPPORTED_CHAINS = ["ethereum", "polygon", "stellar"] as const;
 type SupportedChain = (typeof SUPPORTED_CHAINS)[number];
+
+const POSITIONS_CACHE_TTL_SECONDS = 10 * 60;
 
 const YIELD_STRATEGIES: YieldStrategy[] = [
   {
@@ -57,85 +63,70 @@ const YIELD_STRATEGIES: YieldStrategy[] = [
   },
 ];
 
-export class DeFiWalletService {
-  /**
-   * Get all DeFi positions for a user across supported chains.
-   */
-  async getUserPositions(userId: string): Promise<DeFiPosition[]> {
-    const positions: DeFiPosition[] = [];
+type ChainEndpointConfig = {
+  aave?: string;
+  compound?: string;
+};
 
-    for (const chain of SUPPORTED_CHAINS) {
-      try {
-        const chainPositions = await this.getPositionsForChain(userId, chain);
-        positions.push(...chainPositions);
-      } catch (err) {
-        logger.warn(
-          { userId, chain, err },
-          "Failed to fetch DeFi positions for chain",
-        );
+type AddressKey = "ethereum_address" | "polygon_address" | "stellar_public_key";
+
+const AAVE_POSITIONS_QUERY = `
+  query AavePositions($user: String!) {
+    userReserves(where: { user: $user }) {
+      currentATokenBalance
+      scaledATokenBalance
+      currentATokenBalanceUSD
+      reserve {
+        symbol
+        liquidityRate
+        price {
+          priceInUsd
+          priceUSD
+        }
       }
     }
-
-    return positions;
   }
+`;
 
-  /**
-   * Get available yield strategies, optionally filtered by risk level.
-   */
-  getYieldStrategies(riskLevel?: "low" | "medium" | "high"): YieldStrategy[] {
-    if (!riskLevel) return YIELD_STRATEGIES;
-    return YIELD_STRATEGIES.filter((s) => s.riskLevel === riskLevel);
+const COMPOUND_POSITIONS_QUERY = `
+  query CompoundPositions($account: String!) {
+    account(id: $account) {
+      tokens {
+        symbol
+        supplyBalanceUnderlying
+        supplyBalanceUnderlyingUSD
+        rewardsAccrued
+        market {
+          underlyingPriceUSD
+          supplyRate
+          rates {
+            side
+            rate
+          }
+        }
+      }
+    }
+    accounts(where: { id: $account }) {
+      tokens {
+        symbol
+        supplyBalanceUnderlying
+        supplyBalanceUnderlyingUSD
+        rewardsAccrued
+        market {
+          underlyingPriceUSD
+          supplyRate
+          rates {
+            side
+            rate
+          }
+        }
+      }
+    }
   }
+`;
 
-  /**
-   * Calculate the total portfolio value in USD across all positions.
-   */
-  async getPortfolioValue(userId: string): Promise<string> {
-    const positions = await this.getUserPositions(userId);
-    const total = positions.reduce((sum, p) => sum + parseFloat(p.value), 0);
-    return total.toFixed(2);
-  }
-
-  /**
-   * Estimate projected yield for a given strategy and principal amount.
-   */
-  estimateYield(
-    strategy: YieldStrategy,
-    principalUsd: number,
-    days: number,
-  ): number {
-    const dailyRate = strategy.expectedApy / 100 / 365;
-    return principalUsd * dailyRate * days;
-  }
-
-  /**
-   * Calculate a composite risk score (0–100) for a set of positions.
-   * Higher score = higher risk.
-   */
-  calculatePortfolioRisk(positions: DeFiPosition[]): number {
-    if (positions.length === 0) return 0;
-    const avg =
-      positions.reduce((sum, p) => sum + p.riskScore, 0) / positions.length;
-    return Math.min(100, Math.round(avg));
-  }
-
-  // ---------------------------------------------------------------------------
-  // Private helpers
-  // ---------------------------------------------------------------------------
-
-  private async getPositionsForChain(
-    userId: string,
-    chain: SupportedChain,
-  ): Promise<DeFiPosition[]> {
-    // In production this would call chain-specific indexers / subgraphs.
-    // Returning mock data so the service is functional without external deps.
-    return this.getMockPositions(userId, chain);
-  }
-
-  private getMockPositions(
-    userId: string,
-    chain: SupportedChain,
-  ): DeFiPosition[] {
+class MockAdapter {
+  getPositions(userId: string, chain: SupportedChain): DeFiPosition[] {
     const mockData: Record<SupportedChain, DeFiPosition[]> = {
       ethereum: [
         {
@@ -179,6 +170,339 @@ export class DeFiWalletService {
     };
 
     return mockData[chain] ?? [];
+  }
+}
+
+export class DeFiWalletService {
+  private readonly mockAdapter = new MockAdapter();
+
+  /**
+   * Get cached DeFi positions for a user, falling back to a fresh sync on miss.
+   */
+  async getUserPositions(userId: string): Promise<DeFiPosition[]> {
+    const cached = await this.getCachedPositions(userId);
+    if (cached) return cached;
+    return this.syncPositions(userId);
+  }
+
+  /**
+   * Trigger a fresh DeFi sync and cache the results for 10 minutes.
+   */
+  async syncPositions(userId: string): Promise<DeFiPosition[]> {
+    const wallet = await WalletModel.findByUserId(userId);
+    if (!wallet) {
+      await CacheService.set(this.getCacheKey(userId), [], POSITIONS_CACHE_TTL_SECONDS);
+      return [];
+    }
+
+    const positions: DeFiPosition[] = [];
+
+    for (const chain of SUPPORTED_CHAINS) {
+      try {
+        const chainPositions = await this.getPositionsForChain(userId, wallet, chain);
+        positions.push(...chainPositions);
+      } catch (err) {
+        logger.warn("Failed to sync DeFi positions for chain", {
+          userId,
+          chain,
+          error: err instanceof Error ? err.message : err,
+        });
+      }
+    }
+
+    await CacheService.set(this.getCacheKey(userId), positions, POSITIONS_CACHE_TTL_SECONDS);
+    return positions;
+  }
+
+  async getCachedPositions(userId: string): Promise<DeFiPosition[] | null> {
+    return CacheService.get<DeFiPosition[]>(this.getCacheKey(userId));
+  }
+
+  /**
+   * Get available yield strategies, optionally filtered by risk level.
+   */
+  getYieldStrategies(riskLevel?: "low" | "medium" | "high"): YieldStrategy[] {
+    if (!riskLevel) return YIELD_STRATEGIES;
+    return YIELD_STRATEGIES.filter((s) => s.riskLevel === riskLevel);
+  }
+
+  /**
+   * Calculate the total portfolio value in USD across all positions.
+   */
+  async getPortfolioValue(userId: string): Promise<string> {
+    const positions = await this.getUserPositions(userId);
+    const total = positions.reduce((sum, p) => sum + this.toNumber(p.value), 0);
+    return total.toFixed(2);
+  }
+
+  /**
+   * Estimate projected yield for a given strategy and principal amount.
+   */
+  estimateYield(
+    strategy: YieldStrategy,
+    principalUsd: number,
+    days: number,
+  ): number {
+    const dailyRate = strategy.expectedApy / 100 / 365;
+    return principalUsd * dailyRate * days;
+  }
+
+  /**
+   * Calculate a composite risk score (0–100) for a set of positions.
+   * Higher score = higher risk.
+   */
+  calculatePortfolioRisk(positions: DeFiPosition[]): number {
+    if (positions.length === 0) return 0;
+    const avg =
+      positions.reduce((sum, p) => sum + p.riskScore, 0) / positions.length;
+    return Math.min(100, Math.round(avg));
+  }
+
+  private getCacheKey(userId: string): string {
+    return `defi:positions:${userId}`;
+  }
+
+  private isSandboxEnvironment(): boolean {
+    return (
+      process.env.DEFI_WALLET_USE_MOCKS === "true" ||
+      process.env.APP_ENV === "sandbox" ||
+      process.env.NODE_ENV === "test"
+    );
+  }
+
+  private getChainGraphEndpoints(chain: "ethereum" | "polygon"): ChainEndpointConfig {
+    if (chain === "ethereum") {
+      return {
+        aave: process.env.DEFI_ETHEREUM_AAVE_SUBGRAPH_URL,
+        compound: process.env.DEFI_ETHEREUM_COMPOUND_SUBGRAPH_URL,
+      };
+    }
+
+    return {
+      aave: process.env.DEFI_POLYGON_AAVE_SUBGRAPH_URL,
+      compound: process.env.DEFI_POLYGON_COMPOUND_SUBGRAPH_URL,
+    };
+  }
+
+  private getAddressForChain(wallet: Wallet, chain: SupportedChain): string | null {
+    const addressKeyByChain: Record<SupportedChain, AddressKey> = {
+      ethereum: "ethereum_address",
+      polygon: "polygon_address",
+      stellar: "stellar_public_key",
+    };
+    const key = addressKeyByChain[chain];
+    const address = wallet[key];
+    return typeof address === "string" && address.trim().length > 0 ? address.trim() : null;
+  }
+
+  private async getPositionsForChain(
+    userId: string,
+    wallet: Wallet,
+    chain: SupportedChain,
+  ): Promise<DeFiPosition[]> {
+    if (this.isSandboxEnvironment()) {
+      return this.mockAdapter.getPositions(userId, chain);
+    }
+
+    if (chain === "stellar") {
+      const stellarAddress = this.getAddressForChain(wallet, "stellar");
+      if (!stellarAddress) return [];
+      return this.getStellarPositions(userId, stellarAddress);
+    }
+
+    const walletAddress = this.getAddressForChain(wallet, chain);
+    if (!walletAddress) return [];
+
+    const [aavePositions, compoundPositions] = await Promise.all([
+      this.getAavePositions(userId, chain, walletAddress),
+      this.getCompoundPositions(userId, chain, walletAddress),
+    ]);
+
+    return [...aavePositions, ...compoundPositions];
+  }
+
+  private async getStellarPositions(
+    userId: string,
+    publicKey: string,
+  ): Promise<DeFiPosition[]> {
+    const account = await stellarService.getAccount(publicKey);
+    const lpBalances = account.balances.filter(
+      (balance) => balance.assetType === "liquidity_pool_shares",
+    );
+
+    return lpBalances.map((balance) => {
+      const amount = this.toNumber(balance.balance);
+      const assetLabel = balance.liquidityPoolId
+        ? `LP:${balance.liquidityPoolId.slice(0, 12)}`
+        : "liquidity_pool_shares";
+
+      return {
+        userId,
+        protocol: "Stellar AMM",
+        chain: "stellar",
+        asset: assetLabel,
+        amount: amount.toFixed(7),
+        apy: 0,
+        value: amount.toFixed(2),
+        rewards: "0.00",
+        riskScore: 20,
+      };
+    });
+  }
+
+  private async getAavePositions(
+    userId: string,
+    chain: "ethereum" | "polygon",
+    walletAddress: string,
+  ): Promise<DeFiPosition[]> {
+    const endpoint = this.getChainGraphEndpoints(chain).aave;
+    if (!endpoint) return [];
+
+    const data = await this.queryGraph(endpoint, AAVE_POSITIONS_QUERY, {
+      user: walletAddress.toLowerCase(),
+    });
+    const positions = Array.isArray(data?.userReserves) ? data.userReserves : [];
+
+    return positions
+      .map((position: any) => {
+        const amount = this.firstDefinedNumber(
+          position.currentATokenBalance,
+          position.scaledATokenBalance,
+        );
+        if (amount <= 0) return null;
+
+        const priceUsd = this.firstDefinedNumber(
+          position.currentATokenBalanceUSD && amount > 0
+            ? this.toNumber(position.currentATokenBalanceUSD) / amount
+            : undefined,
+          position.reserve?.price?.priceInUsd,
+          position.reserve?.price?.priceUSD,
+        );
+        const value = this.firstDefinedNumber(
+          position.currentATokenBalanceUSD,
+          amount * priceUsd,
+          amount,
+        );
+
+        return {
+          userId,
+          protocol: "Aave",
+          chain,
+          asset: position.reserve?.symbol || "UNKNOWN",
+          amount: amount.toFixed(8),
+          apy: this.normalizeApy(position.reserve?.liquidityRate),
+          value: value.toFixed(2),
+          rewards: "0.00",
+          riskScore: chain === "ethereum" ? 18 : 22,
+        } satisfies DeFiPosition;
+      })
+      .filter((position): position is DeFiPosition => position !== null);
+  }
+
+  private async getCompoundPositions(
+    userId: string,
+    chain: "ethereum" | "polygon",
+    walletAddress: string,
+  ): Promise<DeFiPosition[]> {
+    const endpoint = this.getChainGraphEndpoints(chain).compound;
+    if (!endpoint) return [];
+
+    const data = await this.queryGraph(endpoint, COMPOUND_POSITIONS_QUERY, {
+      account: walletAddress.toLowerCase(),
+    });
+
+    const tokens =
+      data?.account?.tokens ??
+      (Array.isArray(data?.accounts) ? data.accounts[0]?.tokens : []) ??
+      [];
+
+    return (Array.isArray(tokens) ? tokens : [])
+      .map((token: any) => {
+        const amount = this.firstDefinedNumber(
+          token.supplyBalanceUnderlying,
+          token.cTokenBalance,
+        );
+        if (amount <= 0) return null;
+
+        const value = this.firstDefinedNumber(
+          token.supplyBalanceUnderlyingUSD,
+          amount * this.firstDefinedNumber(token.market?.underlyingPriceUSD, 0),
+          amount,
+        );
+        const rate =
+          token.market?.rates?.find?.((entry: any) => entry?.side === "LENDER")?.rate ??
+          token.market?.supplyRate;
+
+        return {
+          userId,
+          protocol: "Compound",
+          chain,
+          asset: token.symbol || token.market?.inputToken?.symbol || "UNKNOWN",
+          amount: amount.toFixed(8),
+          apy: this.normalizeApy(rate),
+          value: value.toFixed(2),
+          rewards: this.firstDefinedNumber(token.rewardsAccrued, 0).toFixed(2),
+          riskScore: chain === "ethereum" ? 24 : 28,
+        } satisfies DeFiPosition;
+      })
+      .filter((position): position is DeFiPosition => position !== null);
+  }
+
+  private async queryGraph(
+    endpoint: string,
+    query: string,
+    variables: Record<string, unknown>,
+  ): Promise<any> {
+    const response = await axios.post(
+      endpoint,
+      { query, variables },
+      {
+        headers: { "Content-Type": "application/json" },
+        timeout: 15_000,
+      },
+    );
+
+    if (response.data?.errors?.length) {
+      throw new Error(
+        `Graph query failed: ${response.data.errors
+          .map((error: { message?: string }) => error.message || "unknown error")
+          .join(", ")}`,
+      );
+    }
+
+    return response.data?.data ?? null;
+  }
+
+  private toNumber(value: unknown): number {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "string" && value.trim().length > 0) {
+      const parsed = Number.parseFloat(value);
+      return Number.isFinite(parsed) ? parsed : 0;
+    }
+    return 0;
+  }
+
+  private firstDefinedNumber(...values: unknown[]): number {
+    for (const value of values) {
+      const parsed = this.toNumber(value);
+      if (parsed > 0) return parsed;
+    }
+    return 0;
+  }
+
+  private normalizeApy(rawValue: unknown): number {
+    const numeric = this.toNumber(rawValue);
+    if (numeric === 0) return 0;
+
+    if (numeric > 1_000_000) {
+      return Number((numeric / 1e25).toFixed(2));
+    }
+
+    if (numeric > 1) {
+      return Number(numeric.toFixed(2));
+    }
+
+    return Number((numeric * 100).toFixed(2));
   }
 }
 

--- a/src/services/mentor-onboarding.service.ts
+++ b/src/services/mentor-onboarding.service.ts
@@ -3,6 +3,11 @@ import { CacheService } from "./cache.service";
 import { logger } from "../utils/logger.utils";
 import { createError } from "../middleware/errorHandler";
 import { MentorOnboarding } from "../models/certification.model";
+import { RateLimiterService } from "./rate-limiter.service";
+import { VerificationService } from "./verification.service";
+import { BackgroundCheckService } from "./background-check.service";
+import { WalletModel } from "../models/wallet.model";
+import { SocketService } from "./socket.service";
 
 export interface WizardStep {
   id: string;
@@ -50,18 +55,33 @@ export interface OnboardingAnalytics {
   occurredAt: Date;
 }
 
+interface StepDependencyFailure {
+  dependency: string;
+  reason: string;
+}
+
+const STEP_ALIAS_TO_WIZARD_KEY: Record<string, string> = {
+  profile_setup: "profile_basics",
+  first_session: "practice_session",
+};
+
+const WIZARD_KEY_TO_STEP_ALIAS: Record<string, string> = {
+  profile_basics: "profile_setup",
+  practice_session: "first_session",
+};
+
 export const MentorOnboardingService = {
   ONBOARDING_STEPS: [
-    { id: 'profile_setup', title: 'Complete Profile', description: 'Add your bio, expertise, and photo' },
-    { id: 'identity_verification', title: 'Verify Identity', description: 'Upload government-issued ID' },
-    { id: 'background_check', title: 'Background Check', description: 'Complete background screening' },
-    { id: 'platform_orientation', title: 'Platform Training', description: 'Learn how to use MentorsMind' },
-    { id: 'skill_assessment', title: 'Skill Assessment', description: 'Demonstrate your expertise' },
-    { id: 'pricing_setup', title: 'Set Your Rates', description: 'Configure your pricing and availability' },
-    { id: 'payment_setup', title: 'Payment Setup', description: 'Connect your Stellar wallet' },
-    { id: 'first_session', title: 'Practice Session', description: 'Complete a practice mentoring session' },
-    { id: 'policies_agreement', title: 'Review Policies', description: 'Accept platform terms and policies' },
-    { id: 'profile_review', title: 'Profile Review', description: 'Admin review and approval' },
+    { id: 'profile_setup', title: 'Complete Profile', description: 'Add your bio, expertise, and photo', dependsOn: [] as string[] },
+    { id: 'identity_verification', title: 'Verify Identity', description: 'Upload government-issued ID', dependsOn: ['profile_setup'] },
+    { id: 'background_check', title: 'Background Check', description: 'Complete background screening', dependsOn: ['identity_verification'] },
+    { id: 'platform_orientation', title: 'Platform Training', description: 'Learn how to use MentorsMind', dependsOn: ['background_check'] },
+    { id: 'skill_assessment', title: 'Skill Assessment', description: 'Demonstrate your expertise', dependsOn: ['platform_orientation'] },
+    { id: 'pricing_setup', title: 'Set Your Rates', description: 'Configure your pricing and availability', dependsOn: ['skill_assessment'] },
+    { id: 'payment_setup', title: 'Payment Setup', description: 'Connect your Stellar wallet', dependsOn: ['pricing_setup'] },
+    { id: 'first_session', title: 'Practice Session', description: 'Complete a practice mentoring session', dependsOn: ['payment_setup'] },
+    { id: 'policies_agreement', title: 'Review Policies', description: 'Accept platform terms and policies', dependsOn: ['first_session'] },
+    { id: 'profile_review', title: 'Profile Review', description: 'Admin review and approval', dependsOn: ['policies_agreement'] },
   ],
 
   async initializeOnboarding(mentorId: string): Promise<MentorOnboarding> {
@@ -114,6 +134,29 @@ export const MentorOnboardingService = {
       if (!step) throw createError("Invalid step ID", 400);
       if (onboarding.stepsCompleted.includes(stepId)) throw createError("Step already completed", 400);
 
+      const rateLimit = await RateLimiterService.check(
+        `mentor-onboarding:complete-step:${mentorId}`,
+        60 * 60 * 1000,
+        10,
+      );
+      if (!rateLimit.allowed) {
+        throw createError("Too many onboarding completion attempts. Please try again later.", 429, {
+          limit: rateLimit.limit,
+          resetTime: rateLimit.resetTime.toISOString(),
+        });
+      }
+
+      const unmetDependencies = await this.getUnmetDependencies(
+        mentorId,
+        stepId,
+        onboarding.stepsCompleted,
+      );
+      if (unmetDependencies.length > 0) {
+        throw createError("Step prerequisites not met", 422, {
+          unmetDependencies,
+        });
+      }
+
       const stepsCompleted = [...onboarding.stepsCompleted, stepId];
       const currentStep = stepsCompleted.length + 1;
       const isComplete = stepsCompleted.length === this.ONBOARDING_STEPS.length;
@@ -128,6 +171,13 @@ export const MentorOnboardingService = {
       logger.info("Onboarding step completed", { mentorId, stepId, isComplete });
       await CacheService.del(`onboarding:${mentorId}`);
       await this.trackAnalytics(mentorId, 'step_complete', stepId);
+      SocketService.emitToRoom('admin', 'mentor:onboarding_step_completed', {
+        mentorId,
+        stepId,
+        completedAt: new Date().toISOString(),
+        isComplete,
+        stepsCompletedCount: stepsCompleted.length,
+      });
 
       if (isComplete) {
         await this.trackAnalytics(mentorId, 'wizard_complete', null);
@@ -551,6 +601,84 @@ export const MentorOnboardingService = {
     } catch (error) {
       logger.error("Failed to get admin analytics", { error: error instanceof Error ? error.message : error });
       throw error;
+    }
+  },
+
+  async getUnmetDependencies(
+    mentorId: string,
+    stepId: string,
+    stepsCompleted: string[],
+  ): Promise<StepDependencyFailure[]> {
+    const unmetDependencies: StepDependencyFailure[] = [];
+    const requiredDependencies = await this.getStepDependencies(stepId);
+
+    for (const dependency of requiredDependencies) {
+      if (!stepsCompleted.includes(dependency)) {
+        unmetDependencies.push({
+          dependency,
+          reason: `Complete ${dependency} before marking ${stepId} as done.`,
+        });
+      }
+    }
+
+    if (stepId === 'identity_verification') {
+      const verification = await VerificationService.getStatusByMentorId(mentorId);
+      if (!verification || verification.status !== 'approved') {
+        unmetDependencies.push({
+          dependency: 'identity_verification',
+          reason: 'An approved mentor_verifications record is required.',
+        });
+      }
+    }
+
+    if (stepId === 'background_check') {
+      const backgroundChecks = await BackgroundCheckService.getMentorBackgroundChecks(mentorId);
+      const hasClearBackgroundCheck = backgroundChecks.some(
+        (check) => check.status === 'completed' && check.result === 'clear',
+      );
+      if (!hasClearBackgroundCheck) {
+        unmetDependencies.push({
+          dependency: 'background_check',
+          reason: 'A completed background check with result "clear" is required.',
+        });
+      }
+    }
+
+    if (stepId === 'payment_setup') {
+      const wallet = await WalletModel.findByUserId(mentorId);
+      if (!wallet || wallet.status !== 'active') {
+        unmetDependencies.push({
+          dependency: 'payment_setup',
+          reason: 'An active wallet record is required before payment setup can be completed.',
+        });
+      }
+    }
+
+    return unmetDependencies;
+  },
+
+  async getStepDependencies(stepId: string): Promise<string[]> {
+    const staticStep = this.ONBOARDING_STEPS.find((step) => step.id === stepId);
+    const staticDependencies = staticStep?.dependsOn ?? [];
+    const knownStepIds = new Set(this.ONBOARDING_STEPS.map((step) => step.id));
+    const wizardStepKey = STEP_ALIAS_TO_WIZARD_KEY[stepId] ?? stepId;
+
+    try {
+      const wizardSteps = await this.getWizardSteps();
+      const wizardStep = wizardSteps.find((step) => step.stepKey === wizardStepKey);
+      if (!wizardStep) return staticDependencies;
+
+      const mappedWizardDependencies = wizardStep.dependsOn
+        .map((dependency) => WIZARD_KEY_TO_STEP_ALIAS[dependency] ?? dependency)
+        .filter((dependency) => knownStepIds.has(dependency));
+
+      return Array.from(new Set([...staticDependencies, ...mappedWizardDependencies]));
+    } catch (error) {
+      logger.warn("Falling back to static onboarding dependencies", {
+        stepId,
+        error: error instanceof Error ? error.message : error,
+      });
+      return staticDependencies;
     }
   },
 

--- a/src/services/socket.service.ts
+++ b/src/services/socket.service.ts
@@ -69,6 +69,23 @@ export const SocketService = {
   },
 
   /**
+   * Emit an event to an arbitrary shared room (for example, the admin room).
+   */
+  emitToRoom(room: string, event: string, data: any): void {
+    if (!io) {
+      logger.warn("SocketService: Socket.IO not initialized");
+      return;
+    }
+
+    io.to(room).emit(event, data);
+
+    logger.debug(
+      { room, event, dataKeys: Object.keys(data || {}) },
+      "SocketService: Emitted event to room",
+    );
+  },
+
+  /**
    * Emit an event to all connected clients
    * @param event - The event name
    * @param data - The event data

--- a/src/types/stellar.types.ts
+++ b/src/types/stellar.types.ts
@@ -12,6 +12,7 @@ export interface StellarBalance {
   assetType: string;
   assetCode?: string;
   assetIssuer?: string;
+  liquidityPoolId?: string;
   balance: string;
   limit?: string;
 }

--- a/src/types/wallet.types.ts
+++ b/src/types/wallet.types.ts
@@ -10,6 +10,8 @@ export interface WalletRecord {
   id: string;
   user_id: string;
   stellar_public_key: string;
+  ethereum_address?: string | null;
+  polygon_address?: string | null;
   status: 'active' | 'inactive' | 'suspended';
   created_at: Date;
   updated_at: Date;

--- a/src/utils/stellar.utils.ts
+++ b/src/utils/stellar.utils.ts
@@ -24,6 +24,7 @@ function parseBalance(b: Horizon.HorizonApi.BalanceLine): StellarBalance {
   };
   if ('asset_code' in b) base.assetCode = b.asset_code;
   if ('asset_issuer' in b) base.assetIssuer = b.asset_issuer;
+  if ('liquidity_pool_id' in b) base.liquidityPoolId = b.liquidity_pool_id;
   if ('limit' in b) base.limit = b.limit;
   return base;
 }


### PR DESCRIPTION
Closes #766
Closes #767

## Summary
- replace mock DeFi positions with live Stellar LP-share reads and Graph-backed EVM queries
- cache synced positions and expose DeFi sync and read endpoints
- add multi-chain wallet address support
- enforce onboarding dependencies, prerequisite verification, rate limiting, and admin monitoring