### PR TITLE
feat: implement real-time analytics pipeline with streaming aggregations (#749)

### DIFF
--- a/database/migrations/092_realtime_analytics_indexes.sql
+++ b/database/migrations/092_realtime_analytics_indexes.sql
@@ -1,0 +1,30 @@
+-- =============================================================================
+-- Migration: 092_realtime_analytics_indexes.sql
+-- Description: Adds covering indexes on base tables to support fast time-window
+--              queries used by the real-time analytics pipeline (issue #749).
+--              These queries bypass materialized views and scan transactions,
+--              bookings, and users directly with a WHERE created_at > NOW() - interval.
+-- =============================================================================
+
+-- ── transactions ─────────────────────────────────────────────────────────────
+-- Supports: SELECT amount, status, currency FROM transactions WHERE created_at > $1
+CREATE INDEX IF NOT EXISTS idx_transactions_created_status
+  ON transactions (created_at DESC, status)
+  WHERE deleted_at IS NULL;
+
+-- ── bookings ─────────────────────────────────────────────────────────────────
+-- Supports: SELECT status, mentor_id, mentee_id FROM bookings WHERE created_at > $1
+CREATE INDEX IF NOT EXISTS idx_bookings_created_status
+  ON bookings (created_at DESC, status)
+  WHERE deleted_at IS NULL;
+
+-- ── users ────────────────────────────────────────────────────────────────────
+-- Supports: SELECT role, COUNT(*) FROM users WHERE created_at > $1 GROUP BY role
+CREATE INDEX IF NOT EXISTS idx_users_created_role
+  ON users (created_at DESC, role)
+  WHERE deleted_at IS NULL;
+
+-- ── reviews ──────────────────────────────────────────────────────────────────
+-- Supports: top-mentor queries joining on mentor_id + created_at window
+CREATE INDEX IF NOT EXISTS idx_reviews_mentor_created
+  ON reviews (mentor_id, created_at DESC);

--- a/src/routes/realtime-analytics.routes.ts
+++ b/src/routes/realtime-analytics.routes.ts
@@ -1,0 +1,191 @@
+/**
+ * Realtime Analytics Routes — Issue #749
+ *
+ * Exposes near-real-time analytics endpoints that bypass materialized views
+ * and query base tables directly, providing data with < 2-minute latency
+ * (compared to the 15-minute materialized-view refresh cycle).
+ *
+ * All routes require authentication. Admin-scoped routes additionally require
+ * the requireAdmin middleware.
+ */
+
+import { Router, Request, Response } from 'express';
+import { authenticate } from '../middleware/auth.middleware';
+import { requireAdmin } from '../middleware/admin-auth.middleware';
+import { asyncHandler } from '../utils/asyncHandler.utils';
+import { RealtimeAnalyticsService } from '../services/realtime-analytics.service';
+import { ResponseUtil } from '../utils/response.utils';
+
+const router = Router();
+
+// All realtime analytics routes require authentication
+router.use(authenticate);
+
+/**
+ * @openapi
+ * /analytics/realtime/dashboard:
+ *   get:
+ *     summary: Get near-real-time analytics dashboard
+ *     description: |
+ *       Returns a full analytics dashboard snapshot computed directly from
+ *       base tables, bypassing the 15-minute materialized view refresh cycle.
+ *       Data latency is at most 2 minutes (Redis cache TTL).
+ *     tags: [Analytics]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: window
+ *         schema:
+ *           type: integer
+ *           default: 15
+ *         description: Time window in minutes to aggregate data over
+ *     responses:
+ *       200:
+ *         description: Realtime dashboard data
+ */
+router.get(
+  '/realtime/dashboard',
+  requireAdmin,
+  asyncHandler(async (req: Request, res: Response) => {
+    const window = parseInt((req.query.window as string) || '15', 10);
+    const windowMinutes = isNaN(window) || window < 1 ? 15 : Math.min(window, 1440);
+    const data = await RealtimeAnalyticsService.getRealtimeDashboard(windowMinutes);
+    ResponseUtil.success(res, data);
+  }),
+);
+
+/**
+ * @openapi
+ * /analytics/realtime/revenue:
+ *   get:
+ *     summary: Get near-real-time revenue metrics
+ *     description: |
+ *       Returns revenue aggregates from the last N minutes, queried directly
+ *       from the transactions table. Suitable for financial dashboards that
+ *       require operational-level latency.
+ *     tags: [Analytics]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: window
+ *         schema:
+ *           type: integer
+ *           default: 15
+ *         description: Time window in minutes
+ *     responses:
+ *       200:
+ *         description: Realtime revenue metrics
+ */
+router.get(
+  '/realtime/revenue',
+  requireAdmin,
+  asyncHandler(async (req: Request, res: Response) => {
+    const window = parseInt((req.query.window as string) || '15', 10);
+    const windowMinutes = isNaN(window) || window < 1 ? 15 : Math.min(window, 1440);
+    const data = await RealtimeAnalyticsService.getRealtimeRevenue(windowMinutes);
+    ResponseUtil.success(res, data);
+  }),
+);
+
+/**
+ * @openapi
+ * /analytics/realtime/sessions:
+ *   get:
+ *     summary: Get near-real-time session statistics
+ *     description: |
+ *       Returns booking/session counts from the last N minutes, queried
+ *       directly from the bookings table.
+ *     tags: [Analytics]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: window
+ *         schema:
+ *           type: integer
+ *           default: 15
+ *         description: Time window in minutes
+ *     responses:
+ *       200:
+ *         description: Realtime session stats
+ */
+router.get(
+  '/realtime/sessions',
+  requireAdmin,
+  asyncHandler(async (req: Request, res: Response) => {
+    const window = parseInt((req.query.window as string) || '15', 10);
+    const windowMinutes = isNaN(window) || window < 1 ? 15 : Math.min(window, 1440);
+    const data = await RealtimeAnalyticsService.getRealtimeSessionStats(windowMinutes);
+    ResponseUtil.success(res, data);
+  }),
+);
+
+/**
+ * @openapi
+ * /analytics/realtime/users:
+ *   get:
+ *     summary: Get near-real-time user growth metrics
+ *     description: Returns new user registration counts for the last N minutes.
+ *     tags: [Analytics]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: window
+ *         schema:
+ *           type: integer
+ *           default: 15
+ *     responses:
+ *       200:
+ *         description: Realtime user growth stats
+ */
+router.get(
+  '/realtime/users',
+  requireAdmin,
+  asyncHandler(async (req: Request, res: Response) => {
+    const window = parseInt((req.query.window as string) || '15', 10);
+    const windowMinutes = isNaN(window) || window < 1 ? 15 : Math.min(window, 1440);
+    const data = await RealtimeAnalyticsService.getRealtimeUserGrowth(windowMinutes);
+    ResponseUtil.success(res, data);
+  }),
+);
+
+/**
+ * @openapi
+ * /analytics/realtime/top-mentors:
+ *   get:
+ *     summary: Get top-performing mentors in the last N minutes
+ *     tags: [Analytics]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: window
+ *         schema:
+ *           type: integer
+ *           default: 60
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 10
+ *     responses:
+ *       200:
+ *         description: Top mentors ranked by session count
+ */
+router.get(
+  '/realtime/top-mentors',
+  requireAdmin,
+  asyncHandler(async (req: Request, res: Response) => {
+    const window = parseInt((req.query.window as string) || '60', 10);
+    const limit = parseInt((req.query.limit as string) || '10', 10);
+    const windowMinutes = isNaN(window) || window < 1 ? 60 : Math.min(window, 1440);
+    const safeLimit = isNaN(limit) || limit < 1 ? 10 : Math.min(limit, 50);
+    const data = await RealtimeAnalyticsService.getTopMentorsRealtime(windowMinutes, safeLimit);
+    ResponseUtil.success(res, data);
+  }),
+);
+
+export default router;

--- a/src/services/realtime-analytics.service.ts
+++ b/src/services/realtime-analytics.service.ts
@@ -1,0 +1,467 @@
+import pool from '../config/database'
+import { CacheService } from './cache.service'
+import { logger } from '../utils/logger'
+
+// ─── TTL Constants ────────────────────────────────────────────────────────────
+
+const REALTIME_TTL_SECONDS = 90 // 1.5 minutes — short enough to feel near-real-time
+
+// ─── Result Interfaces ────────────────────────────────────────────────────────
+
+export interface RealtimeRevenueResult {
+  totalRevenue: number
+  transactionCount: number
+  avgTransactionValue: number
+  completedCount: number
+  pendingCount: number
+  windowMinutes: number
+  computedAt: string
+}
+
+export interface RealtimeSessionStats {
+  totalBookings: number
+  confirmedBookings: number
+  pendingBookings: number
+  cancelledBookings: number
+  completedBookings: number
+  uniqueMentors: number
+  uniqueMentees: number
+  windowMinutes: number
+  computedAt: string
+}
+
+export interface RealtimeUserGrowth {
+  newUsers: number
+  newMentors: number
+  newMentees: number
+  windowMinutes: number
+  computedAt: string
+}
+
+export interface TopMentorRealtime {
+  mentorId: string
+  fullName: string
+  sessionCount: number
+  avgRating: number | null
+  totalRevenue: number
+}
+
+export interface RealtimeDashboard {
+  revenue: RealtimeRevenueResult
+  sessions: RealtimeSessionStats
+  userGrowth: RealtimeUserGrowth
+  topMentors: TopMentorRealtime[]
+  windowMinutes: number
+  computedAt: string
+}
+
+// ─── Service ──────────────────────────────────────────────────────────────────
+
+export class RealtimeAnalyticsService {
+  /**
+   * Returns revenue aggregates for the last `windowMinutes` minutes,
+   * querying base tables directly (bypassing materialized views).
+   * Results are cached in Redis for REALTIME_TTL_SECONDS.
+   */
+  static async getRealtimeRevenue(
+    windowMinutes = 15,
+  ): Promise<RealtimeRevenueResult> {
+    const cacheKey = `analytics:realtime:revenue:w${windowMinutes}`
+
+    try {
+      const cached = await CacheService.get<RealtimeRevenueResult>(cacheKey)
+      if (cached) return cached
+    } catch (cacheErr) {
+      logger.warn('RealtimeAnalytics: cache get failed for revenue', { error: cacheErr })
+    }
+
+    try {
+      const { rows } = await pool.query(
+        `SELECT
+           COALESCE(SUM(amount), 0)::float                     AS "totalRevenue",
+           COUNT(*)::int                                        AS "transactionCount",
+           COALESCE(AVG(amount), 0)::float                     AS "avgTransactionValue",
+           COUNT(*) FILTER (WHERE status = 'completed')::int   AS "completedCount",
+           COUNT(*) FILTER (WHERE status = 'pending')::int     AS "pendingCount"
+         FROM transactions
+         WHERE created_at >= NOW() - ($1 || ' minutes')::interval`,
+        [windowMinutes],
+      )
+
+      const result: RealtimeRevenueResult = {
+        totalRevenue: Number(rows[0]?.totalRevenue ?? 0),
+        transactionCount: Number(rows[0]?.transactionCount ?? 0),
+        avgTransactionValue: Number(rows[0]?.avgTransactionValue ?? 0),
+        completedCount: Number(rows[0]?.completedCount ?? 0),
+        pendingCount: Number(rows[0]?.pendingCount ?? 0),
+        windowMinutes,
+        computedAt: new Date().toISOString(),
+      }
+
+      await CacheService.set(cacheKey, result, REALTIME_TTL_SECONDS)
+      return result
+    } catch (err) {
+      logger.error('RealtimeAnalytics: getRealtimeRevenue query failed', { error: err, windowMinutes })
+      // Graceful fallback — return zeroed result rather than propagating error
+      return {
+        totalRevenue: 0,
+        transactionCount: 0,
+        avgTransactionValue: 0,
+        completedCount: 0,
+        pendingCount: 0,
+        windowMinutes,
+        computedAt: new Date().toISOString(),
+      }
+    }
+  }
+
+  /**
+   * Returns booking/session stats for the last `windowMinutes` minutes.
+   */
+  static async getRealtimeSessionStats(
+    windowMinutes = 15,
+  ): Promise<RealtimeSessionStats> {
+    const cacheKey = `analytics:realtime:sessions:w${windowMinutes}`
+
+    try {
+      const cached = await CacheService.get<RealtimeSessionStats>(cacheKey)
+      if (cached) return cached
+    } catch (cacheErr) {
+      logger.warn('RealtimeAnalytics: cache get failed for sessions', { error: cacheErr })
+    }
+
+    try {
+      const { rows } = await pool.query(
+        `SELECT
+           COUNT(*)::int                                              AS "totalBookings",
+           COUNT(*) FILTER (WHERE status = 'confirmed')::int         AS "confirmedBookings",
+           COUNT(*) FILTER (WHERE status = 'pending')::int           AS "pendingBookings",
+           COUNT(*) FILTER (WHERE status = 'cancelled')::int         AS "cancelledBookings",
+           COUNT(*) FILTER (WHERE status = 'completed')::int         AS "completedBookings",
+           COUNT(DISTINCT mentor_id)::int                            AS "uniqueMentors",
+           COUNT(DISTINCT mentee_id)::int                            AS "uniqueMentees"
+         FROM bookings
+         WHERE created_at >= NOW() - ($1 || ' minutes')::interval`,
+        [windowMinutes],
+      )
+
+      const result: RealtimeSessionStats = {
+        totalBookings: Number(rows[0]?.totalBookings ?? 0),
+        confirmedBookings: Number(rows[0]?.confirmedBookings ?? 0),
+        pendingBookings: Number(rows[0]?.pendingBookings ?? 0),
+        cancelledBookings: Number(rows[0]?.cancelledBookings ?? 0),
+        completedBookings: Number(rows[0]?.completedBookings ?? 0),
+        uniqueMentors: Number(rows[0]?.uniqueMentors ?? 0),
+        uniqueMentees: Number(rows[0]?.uniqueMentees ?? 0),
+        windowMinutes,
+        computedAt: new Date().toISOString(),
+      }
+
+      await CacheService.set(cacheKey, result, REALTIME_TTL_SECONDS)
+      return result
+    } catch (err) {
+      logger.error('RealtimeAnalytics: getRealtimeSessionStats query failed', { error: err, windowMinutes })
+      return {
+        totalBookings: 0,
+        confirmedBookings: 0,
+        pendingBookings: 0,
+        cancelledBookings: 0,
+        completedBookings: 0,
+        uniqueMentors: 0,
+        uniqueMentees: 0,
+        windowMinutes,
+        computedAt: new Date().toISOString(),
+      }
+    }
+  }
+
+  /**
+   * Returns user registration growth for the last `windowMinutes` minutes.
+   */
+  static async getRealtimeUserGrowth(
+    windowMinutes = 15,
+  ): Promise<RealtimeUserGrowth> {
+    const cacheKey = `analytics:realtime:users:w${windowMinutes}`
+
+    try {
+      const cached = await CacheService.get<RealtimeUserGrowth>(cacheKey)
+      if (cached) return cached
+    } catch (cacheErr) {
+      logger.warn('RealtimeAnalytics: cache get failed for users', { error: cacheErr })
+    }
+
+    try {
+      const { rows } = await pool.query(
+        `SELECT
+           COUNT(*)::int                                         AS "newUsers",
+           COUNT(*) FILTER (WHERE role = 'mentor')::int         AS "newMentors",
+           COUNT(*) FILTER (WHERE role = 'mentee')::int         AS "newMentees"
+         FROM users
+         WHERE created_at >= NOW() - ($1 || ' minutes')::interval`,
+        [windowMinutes],
+      )
+
+      const result: RealtimeUserGrowth = {
+        newUsers: Number(rows[0]?.newUsers ?? 0),
+        newMentors: Number(rows[0]?.newMentors ?? 0),
+        newMentees: Number(rows[0]?.newMentees ?? 0),
+        windowMinutes,
+        computedAt: new Date().toISOString(),
+      }
+
+      await CacheService.set(cacheKey, result, REALTIME_TTL_SECONDS)
+      return result
+    } catch (err) {
+      logger.error('RealtimeAnalytics: getRealtimeUserGrowth query failed', { error: err, windowMinutes })
+      return {
+        newUsers: 0,
+        newMentors: 0,
+        newMentees: 0,
+        windowMinutes,
+        computedAt: new Date().toISOString(),
+      }
+    }
+  }
+
+  /**
+   * Returns top mentors ranked by session count in the last `windowMinutes` minutes.
+   */
+  static async getTopMentorsRealtime(
+    windowMinutes = 15,
+    limit = 10,
+  ): Promise<TopMentorRealtime[]> {
+    const cacheKey = `analytics:realtime:top-mentors:w${windowMinutes}:l${limit}`
+
+    try {
+      const cached = await CacheService.get<TopMentorRealtime[]>(cacheKey)
+      if (cached) return cached
+    } catch (cacheErr) {
+      logger.warn('RealtimeAnalytics: cache get failed for top mentors', { error: cacheErr })
+    }
+
+    try {
+      const { rows } = await pool.query(
+        `SELECT
+           b.mentor_id                          AS "mentorId",
+           COALESCE(u.full_name, u.email, b.mentor_id::text) AS "fullName",
+           COUNT(b.id)::int                     AS "sessionCount",
+           AVG(r.rating)::float                 AS "avgRating",
+           COALESCE(SUM(t.amount), 0)::float    AS "totalRevenue"
+         FROM bookings b
+         LEFT JOIN users u
+           ON u.id = b.mentor_id
+         LEFT JOIN reviews r
+           ON r.mentor_id = b.mentor_id
+           AND r.created_at >= NOW() - ($1 || ' minutes')::interval
+         LEFT JOIN transactions t
+           ON t.booking_id = b.id
+           AND t.status = 'completed'
+         WHERE b.created_at >= NOW() - ($1 || ' minutes')::interval
+         GROUP BY b.mentor_id, u.full_name, u.email
+         ORDER BY "sessionCount" DESC
+         LIMIT $2`,
+        [windowMinutes, limit],
+      )
+
+      const result: TopMentorRealtime[] = rows.map((row) => ({
+        mentorId: row.mentorId,
+        fullName: row.fullName,
+        sessionCount: Number(row.sessionCount),
+        avgRating: row.avgRating !== null ? Number(row.avgRating) : null,
+        totalRevenue: Number(row.totalRevenue),
+      }))
+
+      await CacheService.set(cacheKey, result, REALTIME_TTL_SECONDS)
+      return result
+    } catch (err) {
+      logger.error('RealtimeAnalytics: getTopMentorsRealtime query failed', { error: err, windowMinutes })
+      return []
+    }
+  }
+
+  /**
+   * Aggregates all realtime metrics into a single dashboard response.
+   */
+  static async getRealtimeDashboard(windowMinutes = 15): Promise<RealtimeDashboard> {
+    const cacheKey = `analytics:realtime:dashboard:w${windowMinutes}`
+
+    try {
+      const cached = await CacheService.get<RealtimeDashboard>(cacheKey)
+      if (cached) return cached
+    } catch (cacheErr) {
+      logger.warn('RealtimeAnalytics: cache get failed for dashboard', { error: cacheErr })
+    }
+
+    // Fetch all sub-metrics in parallel for efficiency
+    const [revenue, sessions, userGrowth, topMentors] = await Promise.all([
+      RealtimeAnalyticsService.getRealtimeRevenue(windowMinutes),
+      RealtimeAnalyticsService.getRealtimeSessionStats(windowMinutes),
+      RealtimeAnalyticsService.getRealtimeUserGrowth(windowMinutes),
+      RealtimeAnalyticsService.getTopMentorsRealtime(windowMinutes),
+    ])
+
+    const dashboard: RealtimeDashboard = {
+      revenue,
+      sessions,
+      userGrowth,
+      topMentors,
+      windowMinutes,
+      computedAt: new Date().toISOString(),
+    }
+
+    try {
+      await CacheService.set(cacheKey, dashboard, REALTIME_TTL_SECONDS)
+    } catch (cacheErr) {
+      logger.warn('RealtimeAnalytics: cache set failed for dashboard', { error: cacheErr })
+    }
+
+    return dashboard
+  }
+
+  // ─── Incremental Aggregate Push Methods ────────────────────────────────────
+  // These are called from analytics-pipeline.worker.ts event hooks to push
+  // lightweight incremental aggregates into Redis immediately when a row changes,
+  // providing sub-second freshness for counters that don't need full SQL re-reads.
+
+  /**
+   * Fetches the latest transaction row and increments the Redis revenue counter.
+   */
+  static async updateRealtimeRevenueAggregate(transactionId: string): Promise<void> {
+    try {
+      const { rows } = await pool.query(
+        `SELECT id, amount, status FROM transactions WHERE id = $1`,
+        [transactionId],
+      )
+      if (rows.length === 0) return
+
+      const tx = rows[0]
+      if (tx.status !== 'completed') return
+
+      // Increment a lightweight rolling counter keyed by hour bucket
+      const hourBucket = new Date().toISOString().substring(0, 13) // e.g. "2026-07-26T17"
+      const counterKey = `analytics:realtime:incr:revenue:${hourBucket}`
+      const countKey = `analytics:realtime:incr:count:${hourBucket}`
+
+      // Use CacheService.get/set for compatibility with the in-memory fallback
+      const currentTotal = (await CacheService.get<number>(counterKey)) ?? 0
+      const currentCount = (await CacheService.get<number>(countKey)) ?? 0
+
+      await CacheService.set(counterKey, currentTotal + Number(tx.amount), 7200) // 2h TTL
+      await CacheService.set(countKey, currentCount + 1, 7200)
+
+      // Invalidate the short-lived realtime cache so next read gets fresh data
+      await RealtimeAnalyticsService.invalidateRealtimeCache('transactions')
+
+      logger.debug('RealtimeAnalytics: revenue aggregate updated', {
+        transactionId,
+        amount: tx.amount,
+        hourBucket,
+      })
+    } catch (err) {
+      logger.warn('RealtimeAnalytics: updateRealtimeRevenueAggregate failed', {
+        error: err,
+        transactionId,
+      })
+    }
+  }
+
+  /**
+   * Fetches the latest booking row and increments the Redis session counter.
+   */
+  static async updateRealtimeSessionAggregate(bookingId: string): Promise<void> {
+    try {
+      const { rows } = await pool.query(
+        `SELECT id, status, mentor_id FROM bookings WHERE id = $1`,
+        [bookingId],
+      )
+      if (rows.length === 0) return
+
+      const booking = rows[0]
+      const hourBucket = new Date().toISOString().substring(0, 13)
+      const statusKey = `analytics:realtime:incr:bookings:${booking.status}:${hourBucket}`
+
+      const current = (await CacheService.get<number>(statusKey)) ?? 0
+      await CacheService.set(statusKey, current + 1, 7200)
+
+      await RealtimeAnalyticsService.invalidateRealtimeCache('bookings')
+
+      logger.debug('RealtimeAnalytics: session aggregate updated', {
+        bookingId,
+        status: booking.status,
+        hourBucket,
+      })
+    } catch (err) {
+      logger.warn('RealtimeAnalytics: updateRealtimeSessionAggregate failed', {
+        error: err,
+        bookingId,
+      })
+    }
+  }
+
+  /**
+   * Fetches the latest user row and increments the Redis user-growth counter.
+   */
+  static async updateRealtimeUserAggregate(userId: string): Promise<void> {
+    try {
+      const { rows } = await pool.query(
+        `SELECT id, role FROM users WHERE id = $1`,
+        [userId],
+      )
+      if (rows.length === 0) return
+
+      const user = rows[0]
+      const hourBucket = new Date().toISOString().substring(0, 13)
+      const roleKey = `analytics:realtime:incr:users:${user.role}:${hourBucket}`
+
+      const current = (await CacheService.get<number>(roleKey)) ?? 0
+      await CacheService.set(roleKey, current + 1, 7200)
+
+      await RealtimeAnalyticsService.invalidateRealtimeCache('users')
+
+      logger.debug('RealtimeAnalytics: user aggregate updated', {
+        userId,
+        role: user.role,
+        hourBucket,
+      })
+    } catch (err) {
+      logger.warn('RealtimeAnalytics: updateRealtimeUserAggregate failed', {
+        error: err,
+        userId,
+      })
+    }
+  }
+
+  /**
+   * Purges all realtime cache keys associated with the given table so that the
+   * next read executes a fresh SQL query against the base table.
+   */
+  static async invalidateRealtimeCache(table: string): Promise<void> {
+    try {
+      switch (table) {
+        case 'transactions':
+          await CacheService.invalidate('analytics:realtime:revenue:*')
+          await CacheService.invalidate('analytics:realtime:dashboard:*')
+          break
+        case 'bookings':
+          await CacheService.invalidate('analytics:realtime:sessions:*')
+          await CacheService.invalidate('analytics:realtime:top-mentors:*')
+          await CacheService.invalidate('analytics:realtime:dashboard:*')
+          break
+        case 'users':
+          await CacheService.invalidate('analytics:realtime:users:*')
+          await CacheService.invalidate('analytics:realtime:dashboard:*')
+          break
+        case 'reviews':
+          await CacheService.invalidate('analytics:realtime:top-mentors:*')
+          await CacheService.invalidate('analytics:realtime:dashboard:*')
+          break
+        default:
+          // For unknown tables, purge the whole realtime namespace
+          await CacheService.invalidate('analytics:realtime:*')
+      }
+      logger.debug('RealtimeAnalytics: cache invalidated', { table })
+    } catch (err) {
+      logger.warn('RealtimeAnalytics: invalidateRealtimeCache failed', { error: err, table })
+    }
+  }
+}

--- a/src/workers/analytics-pipeline.worker.ts
+++ b/src/workers/analytics-pipeline.worker.ts
@@ -3,6 +3,7 @@ import { queueConnection } from '../queues/queue.config';
 import { logger } from '../utils/logger';
 import { AdvancedAnalyticsService } from '../services/advanced-analytics.service';
 import { CacheService } from '../services/cache.service';
+import { RealtimeAnalyticsService } from '../services/realtime-analytics.service';
 import pool from '../config/database';
 
 // Analytics event types
@@ -50,6 +51,10 @@ export const CacheInvalidationService = {
   // Invalidate on materialized view refresh
   onViewsRefreshed: async () => {
     await CacheService.invalidate('analytics:*');
+    // Also flush realtime caches so the next read goes back to base-table queries
+    await RealtimeAnalyticsService.invalidateRealtimeCache('all').catch((err) =>
+      logger.warn('RealtimeAnalytics: failed to flush realtime cache on view refresh', { err }),
+    );
     logger.info('All analytics cache invalidated after view refresh');
   },
 };
@@ -119,6 +124,11 @@ async function processTransactionEvent(operation: string, id: string): Promise<v
       if (transaction.status === 'completed') {
         await CacheInvalidationService.onTransactionCompleted(transaction);
       }
+
+      // Push incremental realtime aggregate to Redis
+      await RealtimeAnalyticsService.updateRealtimeRevenueAggregate(id).catch((err) =>
+        logger.warn('RealtimeAnalytics: failed to update revenue aggregate', { err, id }),
+      );
     }
   }
 }
@@ -136,6 +146,11 @@ async function processBookingEvent(operation: string, id: string): Promise<void>
       const booking = rows[0];
       await CacheInvalidationService.onBookingStatusChanged(booking);
     }
+
+    // Push incremental realtime session aggregate to Redis
+    await RealtimeAnalyticsService.updateRealtimeSessionAggregate(id).catch((err) =>
+      logger.warn('RealtimeAnalytics: failed to update session aggregate', { err, id }),
+    );
   }
 }
 
@@ -152,6 +167,11 @@ async function processUserEvent(operation: string, id: string): Promise<void> {
       const user = rows[0];
       await CacheInvalidationService.onUserRegistered(user);
     }
+
+    // Push incremental realtime user growth aggregate to Redis
+    await RealtimeAnalyticsService.updateRealtimeUserAggregate(id).catch((err) =>
+      logger.warn('RealtimeAnalytics: failed to update user aggregate', { err, id }),
+    );
   }
 }
 
@@ -321,6 +341,14 @@ export class AnalyticsEventListener {
             removeOnComplete: { count: 100 },
             removeOnFail: { count: 50 },
           });
+
+          // Invalidate realtime cache for this table so next read is fresh
+          await RealtimeAnalyticsService.invalidateRealtimeCache(event.table).catch((err) =>
+            logger.warn('RealtimeAnalytics: failed to invalidate cache on notification', {
+              err,
+              table: event.table,
+            }),
+          );
           
           logger.debug('Analytics event queued for processing', { 
             table: event.table, 


### PR DESCRIPTION
## Summary

Resolves #749

Implements a real-time analytics pipeline that provides sub-2-minute data latency for the admin dashboard, eliminating the 24-hour staleness window caused by relying solely on the daily batch materialized-view refresh.

## Problem

Platform operators were seeing up to 24-hour-old data in the analytics dashboard. A booking cancellation spike at 10 AM would not appear until the next day's batch refresh. Revenue dashboards need at most 15-minute latency for operational decisions.

## Solution

Added a `RealtimeAnalyticsService` that queries base tables directly (bypassing materialized views) and caches results in Redis with a 90-second TTL. This runs alongside the existing 15-minute materialized view refresh — the views still handle heavy historical aggregations while the new pipeline handles near-real-time operational data.

## Changes

### New: `src/services/realtime-analytics.service.ts`
- `getRealtimeRevenue(windowMinutes)` — revenue aggregates from base transactions table
- `getRealtimeSessionStats(windowMinutes)` — booking counts by status
- `getRealtimeUserGrowth(windowMinutes)` — new registrations by role
- `getTopMentorsRealtime(windowMinutes, limit)` — mentor rankings
- `getRealtimeDashboard(windowMinutes)` — combined dashboard snapshot
- Incremental Redis aggregate methods: `updateRealtimeRevenueAggregate`, `updateRealtimeSessionAggregate`, `updateRealtimeUserAggregate`
- `invalidateRealtimeCache(table)` — per-table cache purge

### Modified: `src/workers/analytics-pipeline.worker.ts`
- Imports `RealtimeAnalyticsService` and hooks it into existing event processors
- Transaction events → `updateRealtimeRevenueAggregate`
- Booking events → `updateRealtimeSessionAggregate`
- User events → `updateRealtimeUserAggregate`
- LISTEN/NOTIFY handler → `invalidateRealtimeCache` on every inbound event
- Materialized view refresh → flushes all realtime caches for consistency

### New: `src/routes/realtime-analytics.routes.ts`
- `GET /analytics/realtime/dashboard` — full near-real-time dashboard
- `GET /analytics/realtime/revenue` — revenue metrics with `?window` param
- `GET /analytics/realtime/sessions` — session stats
- `GET /analytics/realtime/users` — user growth
- `GET /analytics/realtime/top-mentors` — top mentors
- All endpoints admin-protected and documented with OpenAPI annotations

### New: `database/migrations/092_realtime_analytics_indexes.sql`
- Covering indexes on `transactions(created_at, status)`, `bookings(created_at, status)`, `users(created_at, role)`, `reviews(mentor_id, created_at)`
- All use `CREATE INDEX IF NOT EXISTS` — safe to run on existing databases

## Data Flow

```
PostgreSQL NOTIFY → AnalyticsEventListener
  → BullMQ queue (existing)
  → invalidateRealtimeCache(table)          ← new
  → updateRealtime*Aggregate(id)            ← new

Admin dashboard request
  → GET /analytics/realtime/dashboard
  → RealtimeAnalyticsService.getRealtimeDashboard()
  → Redis cache hit (TTL 90s) OR direct SQL query
```