### PR TITLE
feat: implement geo-distributed CDN config and smart API response cac…

### DIFF
--- a/docs/cdn-configuration.md
+++ b/docs/cdn-configuration.md
@@ -1,0 +1,154 @@
+# CDN Configuration Guide — Issue #745
+
+Geo-distributed CDN setup for MentorsMind Backend: static assets + API response caching.
+
+## Overview
+
+Three files implement CDN support:
+
+| File | Purpose |
+|------|---------|
+| `src/config/cdn-geo.config.ts` | Provider-specific config (CloudFront, Cloudflare, Fastly) + cache strategies |
+| `src/middleware/smart-cdn-headers.middleware.ts` | Applies correct `Cache-Control`, `Vary`, `Surrogate-Control`, and cache tag headers |
+| `src/services/cdn.service.ts` | URL rewriting, image optimisation, cache invalidation API |
+
+## Cache Strategies
+
+| Strategy | `max-age` | `stale-while-revalidate` | `Surrogate-Control` | Use case |
+|----------|-----------|-------------------------|---------------------|----------|
+| `staticImmutable` | 1 year | — | — | Hash-named assets (`/static/*`) |
+| `static` | 30 days | 1 day | — | Versioned assets |
+| `images` | 1 day | 1 hour | 7 days | `/assets/images/*` |
+| `videos` | 7 days | 1 day | 30 days | `/assets/videos/*` |
+| `apiPublic` | 1 min | 5 min | 5 min | Generic public API |
+| `apiListings` | 30 sec | 2 min | 2 min | `/api/v1/mentors` |
+| `apiAnalytics` | 5 min | 10 min | 10 min | `/api/v1/analytics` |
+| `apiAuthenticated` | 0 | — | — | Any route with `Authorization` header |
+| `noCache` | 0 (no-store) | — | — | Health checks, webhooks |
+
+## Middleware usage
+
+### Global (recommended)
+
+Mount after auth middleware so `req.user` is available for auth-bypass logic:
+
+```typescript
+// src/app.ts
+import { smartCdnHeaders } from './middleware/smart-cdn-headers.middleware';
+
+app.use(authenticate);         // set req.user
+app.use(smartCdnHeaders());    // set Cache-Control based on auth state
+app.use(router);
+```
+
+### Per-route
+
+```typescript
+import {
+  apiPublicCdnHeaders,
+  immutableCdnHeaders,
+  noCdnCache,
+} from '../middleware/smart-cdn-headers.middleware';
+
+// Public listing — 30s browser / 2min edge TTL
+router.get('/mentors', apiPublicCdnHeaders(), listMentors);
+
+// Static assets with content hash in filename
+router.use('/static', immutableCdnHeaders(), express.static(distDir));
+
+// Webhooks / mutations — never cache
+router.post('/webhooks/stripe', noCdnCache(), stripeWebhookHandler);
+```
+
+## Provider setup
+
+### CloudFront (AWS)
+
+```bash
+# Required env vars
+CDN_PROVIDER=cloudfront
+CDN_BASE_URL=https://d1234abcdef.cloudfront.net
+CDN_CLOUDFRONT_DISTRIBUTION_ID=E1234ABCDEF
+AWS_REGION=us-east-1
+```
+
+The `getCloudFrontConfig()` function returns a full distribution configuration object.
+Use it with the AWS CDK or Terraform `aws_cloudfront_distribution` resource.
+
+Key settings:
+- `PriceClass_All` — uses all global edge locations for lowest latency worldwide
+- HTTP/2 + HTTP/3 enabled
+- Gzip + Brotli compression enabled
+- Per-path cache behaviours with tailored TTLs (see `cacheBehaviours` array)
+
+### Cloudflare
+
+```bash
+CDN_PROVIDER=cloudflare
+CDN_BASE_URL=https://assets.mentorminds.com
+CDN_CLOUDFLARE_ZONE_ID=your_zone_id
+CDN_CLOUDFLARE_API_TOKEN=your_api_token
+```
+
+Cache rules from `getCloudflareConfig()` should be applied via the Cloudflare dashboard
+or Terraform `cloudflare_ruleset` resource. Key rules:
+- `Authorization` header present → bypass cache (private route protection)
+- `/static/*` → 1 year edge TTL
+- `/api/v1/mentors` GET → 2 min edge TTL
+
+Enable **Tiered Cache** (Argo) in Cloudflare dashboard for geo-distributed origin shielding.
+
+### Fastly
+
+```bash
+CDN_PROVIDER=fastly
+CDN_BASE_URL=https://assets.mentorminds.com
+CDN_FASTLY_SERVICE_ID=your_service_id
+CDN_FASTLY_API_KEY=your_api_key
+```
+
+`getFastlyConfig()` returns VCL snippets and surrogate key group definitions.
+Upload VCL via the Fastly API or Terraform `fastly_service_vcl` resource.
+
+## Cache invalidation
+
+### Via API (admin only)
+
+```bash
+POST /api/v1/cdn/invalidate
+Authorization: Bearer <admin_token>
+Content-Type: application/json
+
+{ "paths": ["/api/v1/mentors", "/assets/emails/*"] }
+```
+
+### Via cache tags (Cloudflare / Fastly)
+
+Every public response receives `Cache-Tag` and `Surrogate-Key` headers.
+Purge by tag without a full cache flush:
+
+```bash
+# Cloudflare
+curl -X POST "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/purge_cache" \
+  -H "Authorization: Bearer $CF_TOKEN" \
+  -d '{"tags":["mentor-listings"]}'
+
+# Fastly
+curl -X POST "https://api.fastly.com/service/$SERVICE_ID/purge" \
+  -H "Fastly-Key: $FASTLY_KEY" \
+  -H "Surrogate-Key: mentor-listings"
+```
+
+## API response caching
+
+Public endpoints that are safe to cache at the CDN edge:
+
+| Endpoint | TTL (browser) | TTL (CDN edge) | Auth bypass |
+|----------|---------------|----------------|-------------|
+| `GET /api/v1/mentors` | 30s | 2 min | Yes (private when authed) |
+| `GET /api/v1/timezones` | 30 days | — | No |
+| `GET /api/v1/analytics/*` | 5 min | 10 min | Yes |
+| `GET /api/v1/platform-health` | 1 min | 5 min | No |
+| `GET /health` | no-store | bypass | No |
+
+All other routes default to `private, no-cache`.

--- a/src/config/cdn-geo.config.ts
+++ b/src/config/cdn-geo.config.ts
@@ -1,0 +1,545 @@
+/**
+ * Geo-Distributed CDN Configuration — Issue #745
+ *
+ * Provides provider-specific CDN behaviour configuration for:
+ *  - CloudFront (AWS)
+ *  - Cloudflare
+ *  - Fastly
+ *
+ * Covers three concerns from the issue:
+ *  1. Geo-distributed CDN provider configuration (origins, edge locations, TTLs)
+ *  2. Smart Cache-Control header strategy per content type
+ *  3. API response caching rules for public endpoints
+ */
+
+import { env } from "./env";
+
+// ---------------------------------------------------------------------------
+// Cache strategy types
+// ---------------------------------------------------------------------------
+
+export type CacheScope = "public" | "private" | "no-store";
+
+export interface CacheStrategy {
+  /** Cache-Control max-age in seconds */
+  maxAge: number;
+  /** stale-while-revalidate in seconds (0 = omit) */
+  staleWhileRevalidate?: number;
+  /** stale-if-error in seconds (0 = omit) */
+  staleIfError?: number;
+  /** Whether to allow CDN edge caching */
+  scope: CacheScope;
+  /** Whether to vary on Accept-Encoding (gzip) */
+  varyAcceptEncoding?: boolean;
+  /** Whether to vary on Accept (for WebP image negotiation) */
+  varyAccept?: boolean;
+  /** Surrogate-Control TTL for Fastly / Varnish (separate from browser TTL) */
+  surrogateMaxAge?: number;
+  /** Cloudflare Cache-Control override directive */
+  cfCacheTtl?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Default cache strategies per content category
+// ---------------------------------------------------------------------------
+
+export const CACHE_STRATEGIES: Record<string, CacheStrategy> = {
+  // ── Static assets — long-lived, immutable after hash-rename
+  staticImmutable: {
+    maxAge: 31_536_000, // 1 year
+    scope: "public",
+    varyAcceptEncoding: true,
+  },
+
+  // ── Static assets — versioned but can change
+  static: {
+    maxAge: 2_592_000, // 30 days
+    staleWhileRevalidate: 86_400,
+    staleIfError: 86_400,
+    scope: "public",
+    varyAcceptEncoding: true,
+  },
+
+  // ── Images / media files
+  images: {
+    maxAge: 86_400, // 1 day
+    staleWhileRevalidate: 3_600,
+    staleIfError: 3_600,
+    scope: "public",
+    varyAcceptEncoding: true,
+    varyAccept: true, // WebP negotiation
+    surrogateMaxAge: 604_800, // 7 days on CDN edge
+  },
+
+  // ── Video files
+  videos: {
+    maxAge: 604_800, // 7 days
+    staleWhileRevalidate: 86_400,
+    staleIfError: 86_400,
+    scope: "public",
+    varyAcceptEncoding: false,
+    surrogateMaxAge: 2_592_000, // 30 days on edge
+  },
+
+  // ── Public API responses — short TTL, good for listings
+  apiPublic: {
+    maxAge: 60, // 1 minute in browser
+    staleWhileRevalidate: 300,
+    staleIfError: 600,
+    scope: "public",
+    surrogateMaxAge: 300, // 5 min on CDN edge
+    cfCacheTtl: 300,
+  },
+
+  // ── Mentor/learner listings — frequently updated
+  apiListings: {
+    maxAge: 30, // 30 seconds in browser
+    staleWhileRevalidate: 120,
+    staleIfError: 600,
+    scope: "public",
+    surrogateMaxAge: 120,
+  },
+
+  // ── Analytics / reporting — semi-static
+  apiAnalytics: {
+    maxAge: 300, // 5 minutes
+    staleWhileRevalidate: 600,
+    staleIfError: 3_600,
+    scope: "public",
+    surrogateMaxAge: 600,
+  },
+
+  // ── Authenticated user data — never cached by CDN
+  apiAuthenticated: {
+    maxAge: 0,
+    scope: "private",
+  },
+
+  // ── No cache at all (e.g., POST/mutation responses, webhooks)
+  noCache: {
+    maxAge: 0,
+    scope: "no-store",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// CloudFront provider configuration
+// ---------------------------------------------------------------------------
+
+export interface CloudFrontConfig {
+  distributionId: string;
+  region: string;
+  /** Default TTL for objects not explicitly assigned a cache policy */
+  defaultTTL: number;
+  /** Maximum TTL that CloudFront will cache an object */
+  maxTTL: number;
+  /** Minimum TTL for objects with Cache-Control: no-cache */
+  minTTL: number;
+  /** Cache behaviours mapped to path patterns */
+  cacheBehaviours: CloudFrontCacheBehaviour[];
+  /** Geo restriction config */
+  geoRestriction?: {
+    restrictionType: "whitelist" | "blacklist";
+    locations: string[]; // ISO 3166-1 alpha-2 country codes
+  };
+  /** Compress objects automatically */
+  compress: boolean;
+  /** Enable HTTP/2 and HTTP/3 */
+  httpVersions: Array<"http1.1" | "http2" | "http3">;
+  /** Price class — controls which edge locations are used */
+  priceClass: "PriceClass_100" | "PriceClass_200" | "PriceClass_All";
+  /** Custom error page TTL for 4xx/5xx */
+  customErrorTTL: number;
+}
+
+export interface CloudFrontCacheBehaviour {
+  pathPattern: string;
+  /** TTL in seconds */
+  defaultTTL: number;
+  maxTTL: number;
+  minTTL: number;
+  compress: boolean;
+  allowedMethods: Array<"GET" | "HEAD" | "OPTIONS" | "PUT" | "POST" | "PATCH" | "DELETE">;
+  cachedMethods: Array<"GET" | "HEAD" | "OPTIONS">;
+  /** Query strings to forward / cache on */
+  queryStringKeys?: string[];
+  /** Headers to forward */
+  headers?: string[];
+  /** Forward cookies: none | whitelist | all */
+  forwardCookies: "none" | "whitelist" | "all";
+}
+
+export function getCloudFrontConfig(): CloudFrontConfig | null {
+  if (!env.CDN_CLOUDFRONT_DISTRIBUTION_ID) return null;
+
+  return {
+    distributionId: env.CDN_CLOUDFRONT_DISTRIBUTION_ID,
+    region: env.AWS_REGION,
+    defaultTTL: 86_400,
+    maxTTL: 31_536_000,
+    minTTL: 0,
+    compress: true,
+    httpVersions: ["http2", "http3"],
+    priceClass: "PriceClass_All", // All edge locations worldwide
+    customErrorTTL: 10,
+    cacheBehaviours: [
+      // Static assets — immutable
+      {
+        pathPattern: "/static/*",
+        defaultTTL: 31_536_000,
+        maxTTL: 31_536_000,
+        minTTL: 0,
+        compress: true,
+        allowedMethods: ["GET", "HEAD"],
+        cachedMethods: ["GET", "HEAD"],
+        forwardCookies: "none",
+      },
+      // Images
+      {
+        pathPattern: "/assets/images/*",
+        defaultTTL: 86_400,
+        maxTTL: 604_800,
+        minTTL: 0,
+        compress: false,
+        allowedMethods: ["GET", "HEAD"],
+        cachedMethods: ["GET", "HEAD"],
+        forwardCookies: "none",
+        headers: ["Accept"], // WebP negotiation
+      },
+      // Videos
+      {
+        pathPattern: "/assets/videos/*",
+        defaultTTL: 604_800,
+        maxTTL: 2_592_000,
+        minTTL: 0,
+        compress: false,
+        allowedMethods: ["GET", "HEAD"],
+        cachedMethods: ["GET", "HEAD"],
+        forwardCookies: "none",
+      },
+      // Public API — mentor listings
+      {
+        pathPattern: "/api/v1/mentors",
+        defaultTTL: 120,
+        maxTTL: 300,
+        minTTL: 0,
+        compress: true,
+        allowedMethods: ["GET", "HEAD", "OPTIONS"],
+        cachedMethods: ["GET", "HEAD", "OPTIONS"],
+        queryStringKeys: ["page", "limit", "sort", "skill", "timezone"],
+        forwardCookies: "none",
+      },
+      // Public API — timezone list (rarely changes)
+      {
+        pathPattern: "/api/v1/timezones",
+        defaultTTL: 86_400,
+        maxTTL: 604_800,
+        minTTL: 0,
+        compress: true,
+        allowedMethods: ["GET", "HEAD"],
+        cachedMethods: ["GET", "HEAD"],
+        forwardCookies: "none",
+      },
+      // Health check — never cache
+      {
+        pathPattern: "/health",
+        defaultTTL: 0,
+        maxTTL: 0,
+        minTTL: 0,
+        compress: false,
+        allowedMethods: ["GET", "HEAD"],
+        cachedMethods: ["GET", "HEAD"],
+        forwardCookies: "none",
+      },
+      // Email assets
+      {
+        pathPattern: "/assets/emails/*",
+        defaultTTL: 31_536_000,
+        maxTTL: 31_536_000,
+        minTTL: 0,
+        compress: false,
+        allowedMethods: ["GET", "HEAD"],
+        cachedMethods: ["GET", "HEAD"],
+        forwardCookies: "none",
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cloudflare provider configuration
+// ---------------------------------------------------------------------------
+
+export interface CloudflareConfig {
+  zoneId: string;
+  /** Cache rules mapped to URL patterns */
+  cacheRules: CloudflareCacheRule[];
+  /** Tiered caching — use Cloudflare's Argo smart routing */
+  tieredCaching: boolean;
+  /** Purge by cache tag support */
+  cacheTagsEnabled: boolean;
+  /** Whether to use Cloudflare's image resizing (requires Business/Enterprise) */
+  imageResizingEnabled: boolean;
+  /** Minimum TTL the zone allows (depends on Cloudflare plan) */
+  minTTL: number;
+}
+
+export interface CloudflareCacheRule {
+  /** URL match expression (Cloudflare filter expression syntax) */
+  expression: string;
+  /** Edge TTL in seconds */
+  edgeTTL: number;
+  /** Browser TTL in seconds */
+  browserTTL: number;
+  /** Cache status: eligible | bypass | ignore */
+  cacheStatus: "eligible" | "bypass" | "ignore";
+}
+
+export function getCloudflareConfig(): CloudflareConfig | null {
+  if (!env.CDN_CLOUDFLARE_ZONE_ID) return null;
+
+  return {
+    zoneId: env.CDN_CLOUDFLARE_ZONE_ID,
+    tieredCaching: true,
+    cacheTagsEnabled: true,
+    imageResizingEnabled: false, // Enable on Business/Enterprise plan
+    minTTL: 0,
+    cacheRules: [
+      // Static assets — immutable
+      {
+        expression: '(http.request.uri.path matches "^/static/.*")',
+        edgeTTL: 31_536_000,
+        browserTTL: 31_536_000,
+        cacheStatus: "eligible",
+      },
+      // Images
+      {
+        expression: '(http.request.uri.path matches "^/assets/images/.*")',
+        edgeTTL: 604_800,
+        browserTTL: 86_400,
+        cacheStatus: "eligible",
+      },
+      // Email assets
+      {
+        expression: '(http.request.uri.path matches "^/assets/emails/.*")',
+        edgeTTL: 31_536_000,
+        browserTTL: 31_536_000,
+        cacheStatus: "eligible",
+      },
+      // Public API mentor listings
+      {
+        expression:
+          '(http.request.uri.path eq "/api/v1/mentors") and (http.request.method eq "GET")',
+        edgeTTL: 120,
+        browserTTL: 30,
+        cacheStatus: "eligible",
+      },
+      // Authenticated requests — bypass cache
+      {
+        expression: '(http.request.headers["authorization"] ne "")',
+        edgeTTL: 0,
+        browserTTL: 0,
+        cacheStatus: "bypass",
+      },
+      // Health check — bypass cache
+      {
+        expression: '(http.request.uri.path eq "/health")',
+        edgeTTL: 0,
+        browserTTL: 0,
+        cacheStatus: "bypass",
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fastly provider configuration
+// ---------------------------------------------------------------------------
+
+export interface FastlyConfig {
+  serviceId: string;
+  /** Surrogate key groups for targeted purging */
+  surrogateKeyGroups: Record<string, string[]>;
+  /** VCL snippets for custom cache logic (human-readable descriptions only) */
+  vcl: FastlyVclSnippet[];
+}
+
+export interface FastlyVclSnippet {
+  name: string;
+  type: "recv" | "pass" | "hit" | "miss" | "fetch" | "deliver" | "error";
+  priority: number;
+  /** VCL code snippet */
+  content: string;
+}
+
+export function getFastlyConfig(): FastlyConfig | null {
+  if (!env.CDN_FASTLY_SERVICE_ID) return null;
+
+  return {
+    serviceId: env.CDN_FASTLY_SERVICE_ID,
+    surrogateKeyGroups: {
+      "mentor-listings": ["mentor-*", "category-*"],
+      "session-data": ["session-*", "booking-*"],
+      "static-assets": ["static", "images", "emails"],
+    },
+    vcl: [
+      {
+        name: "recv-api-public-cache",
+        type: "recv",
+        priority: 100,
+        content: `
+          # Allow caching of public API GET requests without Authorization header
+          if (req.method == "GET" && !req.http.Authorization &&
+              req.url ~ "^/api/v1/(mentors|timezones)") {
+            unset req.http.Cookie;
+            return(hash);
+          }
+        `.trim(),
+      },
+      {
+        name: "pass-authenticated",
+        type: "recv",
+        priority: 90,
+        content: `
+          # Pass (bypass cache) for authenticated requests
+          if (req.http.Authorization) {
+            return(pass);
+          }
+        `.trim(),
+      },
+      {
+        name: "deliver-surrogate-keys",
+        type: "deliver",
+        priority: 100,
+        content: `
+          # Add surrogate keys based on path for targeted cache invalidation
+          if (req.url ~ "^/assets/emails/") {
+            set resp.http.Surrogate-Key = "static-assets emails";
+          } elsif (req.url ~ "^/api/v1/mentors") {
+            set resp.http.Surrogate-Key = "mentor-listings";
+          }
+        `.trim(),
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// API response cache header rules (public endpoints)
+// ---------------------------------------------------------------------------
+
+export interface ApiCacheRule {
+  /** URL pattern (prefix match) */
+  pathPrefix: string;
+  /** HTTP methods this rule applies to */
+  methods: string[];
+  /** The cache strategy key from CACHE_STRATEGIES */
+  strategy: keyof typeof CACHE_STRATEGIES;
+  /** Whether authorization header bypass rule applies */
+  bypassIfAuthenticated: boolean;
+}
+
+/**
+ * Rules applied by SmartCacheHeadersMiddleware to set correct Cache-Control
+ * headers on API responses. Earlier rules take precedence.
+ */
+export const API_CACHE_RULES: ApiCacheRule[] = [
+  // Health check — no cache
+  { pathPrefix: "/health", methods: ["GET"], strategy: "noCache", bypassIfAuthenticated: false },
+
+  // Timezone list — very long TTL (rarely changes)
+  { pathPrefix: "/api/v1/timezones", methods: ["GET"], strategy: "static", bypassIfAuthenticated: false },
+
+  // Public mentor listings
+  { pathPrefix: "/api/v1/mentors", methods: ["GET"], strategy: "apiListings", bypassIfAuthenticated: true },
+
+  // Analytics — semi-static
+  { pathPrefix: "/api/v1/analytics", methods: ["GET"], strategy: "apiAnalytics", bypassIfAuthenticated: true },
+
+  // Platform health snapshots
+  { pathPrefix: "/api/v1/platform-health", methods: ["GET"], strategy: "apiPublic", bypassIfAuthenticated: false },
+
+  // All other authenticated routes — private, no CDN caching
+  { pathPrefix: "/api/", methods: ["GET", "POST", "PUT", "PATCH", "DELETE"], strategy: "apiAuthenticated", bypassIfAuthenticated: false },
+];
+
+/**
+ * Build a Cache-Control header value from a CacheStrategy.
+ */
+export function buildCacheControlHeader(strategy: CacheStrategy): string {
+  const parts: string[] = [];
+
+  if (strategy.scope === "no-store") return "no-store";
+  if (strategy.scope === "private") return "private, no-cache";
+
+  parts.push("public");
+  parts.push(`max-age=${strategy.maxAge}`);
+
+  if (strategy.staleWhileRevalidate) {
+    parts.push(`stale-while-revalidate=${strategy.staleWhileRevalidate}`);
+  }
+  if (strategy.staleIfError) {
+    parts.push(`stale-if-error=${strategy.staleIfError}`);
+  }
+
+  return parts.join(", ");
+}
+
+/**
+ * Build a Vary header value from a CacheStrategy.
+ */
+export function buildVaryHeader(strategy: CacheStrategy): string | null {
+  const vary: string[] = [];
+  if (strategy.varyAcceptEncoding) vary.push("Accept-Encoding");
+  if (strategy.varyAccept) vary.push("Accept");
+  return vary.length > 0 ? vary.join(", ") : null;
+}
+
+/**
+ * Build a Surrogate-Control header for Fastly/Varnish edge caches.
+ * This allows a longer edge TTL than the browser Cache-Control TTL.
+ */
+export function buildSurrogateControlHeader(strategy: CacheStrategy): string | null {
+  if (strategy.scope !== "public" || !strategy.surrogateMaxAge) return null;
+  return `max-age=${strategy.surrogateMaxAge}`;
+}
+
+/**
+ * Get the applicable cache strategy for an API path.
+ * Returns the first matching rule, or apiAuthenticated if none matches.
+ */
+export function getApiCacheStrategy(
+  path: string,
+  method: string,
+  hasAuthHeader: boolean,
+): CacheStrategy {
+  for (const rule of API_CACHE_RULES) {
+    if (
+      path.startsWith(rule.pathPrefix) &&
+      rule.methods.includes(method.toUpperCase())
+    ) {
+      // If the rule is supposed to bypass when authenticated and request has auth
+      if (rule.bypassIfAuthenticated && hasAuthHeader) {
+        return CACHE_STRATEGIES["apiAuthenticated"];
+      }
+      return CACHE_STRATEGIES[rule.strategy];
+    }
+  }
+  return CACHE_STRATEGIES["apiAuthenticated"];
+}
+
+// ---------------------------------------------------------------------------
+// Combined config export
+// ---------------------------------------------------------------------------
+
+export const CDNGeoConfig = {
+  CACHE_STRATEGIES,
+  API_CACHE_RULES,
+  getCloudFrontConfig,
+  getCloudflareConfig,
+  getFastlyConfig,
+  buildCacheControlHeader,
+  buildVaryHeader,
+  buildSurrogateControlHeader,
+  getApiCacheStrategy,
+};

--- a/src/middleware/__tests__/smart-cdn-headers.middleware.test.ts
+++ b/src/middleware/__tests__/smart-cdn-headers.middleware.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Unit tests for SmartCdnHeaders middleware and CDNGeoConfig — Issue #745
+ */
+
+import { Request, Response, NextFunction } from "express";
+import {
+  CDNGeoConfig,
+  buildCacheControlHeader,
+  buildVaryHeader,
+  buildSurrogateControlHeader,
+  getApiCacheStrategy,
+  CACHE_STRATEGIES,
+} from "../../config/cdn-geo.config";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeResMock() {
+  const headers: Record<string, string> = {};
+  const res = {
+    statusCode: 200,
+    setHeader: jest.fn((name: string, value: string) => { headers[name] = value; }),
+    send: jest.fn(),
+    json: jest.fn(),
+    _headers: headers,
+  } as unknown as Response;
+  return { res, headers };
+}
+
+function makeReqMock(path: string, method = "GET", hasAuth = false): Request {
+  return {
+    path,
+    method,
+    originalUrl: path,
+    headers: hasAuth ? { authorization: "Bearer token" } : {},
+    user: hasAuth ? { userId: "user-1" } : undefined,
+  } as unknown as Request;
+}
+
+// ---------------------------------------------------------------------------
+// buildCacheControlHeader
+// ---------------------------------------------------------------------------
+
+describe("buildCacheControlHeader", () => {
+  it("returns no-store for noCache strategy", () => {
+    expect(buildCacheControlHeader(CACHE_STRATEGIES["noCache"])).toBe("no-store");
+  });
+
+  it("returns private, no-cache for apiAuthenticated strategy", () => {
+    expect(buildCacheControlHeader(CACHE_STRATEGIES["apiAuthenticated"])).toBe(
+      "private, no-cache"
+    );
+  });
+
+  it("includes max-age for public strategies", () => {
+    const header = buildCacheControlHeader(CACHE_STRATEGIES["apiPublic"]);
+    expect(header).toContain("public");
+    expect(header).toContain("max-age=60");
+  });
+
+  it("includes stale-while-revalidate when set", () => {
+    const header = buildCacheControlHeader(CACHE_STRATEGIES["apiListings"]);
+    expect(header).toContain("stale-while-revalidate=120");
+  });
+
+  it("includes stale-if-error when set", () => {
+    const header = buildCacheControlHeader(CACHE_STRATEGIES["images"]);
+    expect(header).toContain("stale-if-error=3600");
+  });
+
+  it("static immutable has 1 year max-age", () => {
+    const header = buildCacheControlHeader(CACHE_STRATEGIES["staticImmutable"]);
+    expect(header).toContain("max-age=31536000");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildVaryHeader
+// ---------------------------------------------------------------------------
+
+describe("buildVaryHeader", () => {
+  it("returns null for strategies with no vary", () => {
+    expect(buildVaryHeader(CACHE_STRATEGIES["apiAuthenticated"])).toBeNull();
+  });
+
+  it("returns Accept-Encoding for static strategy", () => {
+    const vary = buildVaryHeader(CACHE_STRATEGIES["static"]);
+    expect(vary).toContain("Accept-Encoding");
+  });
+
+  it("returns Accept and Accept-Encoding for images", () => {
+    const vary = buildVaryHeader(CACHE_STRATEGIES["images"]);
+    expect(vary).toContain("Accept");
+    expect(vary).toContain("Accept-Encoding");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSurrogateControlHeader
+// ---------------------------------------------------------------------------
+
+describe("buildSurrogateControlHeader", () => {
+  it("returns null for private strategy", () => {
+    expect(buildSurrogateControlHeader(CACHE_STRATEGIES["apiAuthenticated"])).toBeNull();
+  });
+
+  it("returns null when surrogateMaxAge is not set", () => {
+    expect(buildSurrogateControlHeader(CACHE_STRATEGIES["staticImmutable"])).toBeNull();
+  });
+
+  it("returns max-age when surrogateMaxAge is set", () => {
+    const header = buildSurrogateControlHeader(CACHE_STRATEGIES["images"]);
+    expect(header).toBe("max-age=604800");
+  });
+
+  it("api public listing has 5 min edge TTL", () => {
+    const header = buildSurrogateControlHeader(CACHE_STRATEGIES["apiListings"]);
+    expect(header).toBe("max-age=120");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getApiCacheStrategy
+// ---------------------------------------------------------------------------
+
+describe("getApiCacheStrategy", () => {
+  it("health endpoint always returns noCache", () => {
+    const strategy = getApiCacheStrategy("/health", "GET", false);
+    expect(strategy.scope).toBe("no-store");
+  });
+
+  it("timezones endpoint is cacheable publicly", () => {
+    const strategy = getApiCacheStrategy("/api/v1/timezones", "GET", false);
+    expect(strategy.scope).toBe("public");
+    expect(strategy.maxAge).toBeGreaterThan(0);
+  });
+
+  it("mentor listings without auth returns apiListings strategy", () => {
+    const strategy = getApiCacheStrategy("/api/v1/mentors", "GET", false);
+    expect(strategy.scope).toBe("public");
+    expect(strategy.maxAge).toBe(30);
+  });
+
+  it("mentor listings WITH auth returns apiAuthenticated (bypass CDN)", () => {
+    const strategy = getApiCacheStrategy("/api/v1/mentors", "GET", true);
+    expect(strategy.scope).toBe("private");
+  });
+
+  it("authenticated API routes return private, no-cache", () => {
+    const strategy = getApiCacheStrategy("/api/v1/users/me", "GET", true);
+    expect(strategy.scope).toBe("private");
+  });
+
+  it("POST requests return apiAuthenticated strategy", () => {
+    const strategy = getApiCacheStrategy("/api/v1/bookings", "POST", true);
+    expect(strategy.scope).toBe("private");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CloudFront config
+// ---------------------------------------------------------------------------
+
+describe("CDNGeoConfig.getCloudFrontConfig", () => {
+  beforeEach(() => {
+    process.env.CDN_CLOUDFRONT_DISTRIBUTION_ID = "E123ABC";
+    process.env.AWS_REGION = "us-east-1";
+  });
+
+  afterEach(() => {
+    delete process.env.CDN_CLOUDFRONT_DISTRIBUTION_ID;
+  });
+
+  it("returns config when distribution ID is set", () => {
+    const config = CDNGeoConfig.getCloudFrontConfig();
+    expect(config).not.toBeNull();
+    expect(config!.distributionId).toBe("E123ABC");
+  });
+
+  it("includes /assets/emails/* behaviour", () => {
+    const config = CDNGeoConfig.getCloudFrontConfig();
+    const emailBehaviour = config!.cacheBehaviours.find(
+      (b) => b.pathPattern === "/assets/emails/*"
+    );
+    expect(emailBehaviour).toBeDefined();
+    expect(emailBehaviour!.defaultTTL).toBe(31_536_000);
+  });
+
+  it("includes /api/v1/mentors behaviour with query string forwarding", () => {
+    const config = CDNGeoConfig.getCloudFrontConfig();
+    const mentorBehaviour = config!.cacheBehaviours.find(
+      (b) => b.pathPattern === "/api/v1/mentors"
+    );
+    expect(mentorBehaviour).toBeDefined();
+    expect(mentorBehaviour!.queryStringKeys).toContain("page");
+  });
+
+  it("returns null when distribution ID is not set", () => {
+    delete process.env.CDN_CLOUDFRONT_DISTRIBUTION_ID;
+    const config = CDNGeoConfig.getCloudFrontConfig();
+    expect(config).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cloudflare config
+// ---------------------------------------------------------------------------
+
+describe("CDNGeoConfig.getCloudflareConfig", () => {
+  beforeEach(() => {
+    process.env.CDN_CLOUDFLARE_ZONE_ID = "zone123";
+  });
+
+  afterEach(() => {
+    delete process.env.CDN_CLOUDFLARE_ZONE_ID;
+  });
+
+  it("returns config when zone ID is set", () => {
+    const config = CDNGeoConfig.getCloudflareConfig();
+    expect(config).not.toBeNull();
+    expect(config!.tieredCaching).toBe(true);
+  });
+
+  it("has a rule to bypass cache for Authorization header", () => {
+    const config = CDNGeoConfig.getCloudflareConfig();
+    const bypassRule = config!.cacheRules.find(
+      (r) => r.cacheStatus === "bypass" && r.expression.includes("authorization")
+    );
+    expect(bypassRule).toBeDefined();
+  });
+
+  it("returns null when zone ID is not set", () => {
+    delete process.env.CDN_CLOUDFLARE_ZONE_ID;
+    expect(CDNGeoConfig.getCloudflareConfig()).toBeNull();
+  });
+});

--- a/src/middleware/smart-cdn-headers.middleware.ts
+++ b/src/middleware/smart-cdn-headers.middleware.ts
@@ -1,0 +1,225 @@
+/**
+ * Smart CDN Cache Headers Middleware — Issue #745
+ *
+ * Applies correct Cache-Control, Vary, Surrogate-Control, and CDN-vendor
+ * headers to every response based on:
+ *   - The request path (matched against API_CACHE_RULES in cdn-geo.config.ts)
+ *   - Whether the request is authenticated
+ *   - The asset type (static, image, API response)
+ *
+ * This replaces the simple CDN header middleware (`cdn-headers.middleware.ts`)
+ * with a full strategy-based approach that supports:
+ *   - Geo-distributed CDN edge TTLs (Surrogate-Control for Fastly/Varnish)
+ *   - Cloudflare cache-bypass hint via `Cache-Control: private` for auth routes
+ *   - CloudFront cache behaviour alignment via consistent Cache-Control values
+ *   - WebP negotiation via `Vary: Accept` for image routes
+ *   - Cache purge tag injection via `Surrogate-Key` / `Cache-Tag` headers
+ *
+ * Mount this middleware AFTER authentication middleware so it can inspect
+ * `req.user` to determine whether to bypass CDN caching.
+ */
+
+import { Request, Response, NextFunction } from "express";
+import {
+  CACHE_STRATEGIES,
+  CacheStrategy,
+  buildCacheControlHeader,
+  buildVaryHeader,
+  buildSurrogateControlHeader,
+  getApiCacheStrategy,
+} from "../config/cdn-geo.config";
+import { CDNService } from "../services/cdn.service";
+import { logger } from "../utils/logger";
+
+// ---------------------------------------------------------------------------
+// Surrogate / cache tag helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns CDN surrogate/cache tags for the response based on the request path.
+ * These tags allow targeted CDN invalidation (purge by tag) without a full flush.
+ *
+ * - CloudFront:  `Cache-Tag` header
+ * - Cloudflare:  `Cache-Tag` header
+ * - Fastly:      `Surrogate-Key` header
+ */
+function getResponseCacheTags(path: string): string[] {
+  const tags: string[] = [];
+
+  if (path.startsWith("/api/v1/mentors")) tags.push("mentor-listings");
+  if (path.startsWith("/api/v1/sessions")) tags.push("session-data");
+  if (path.startsWith("/api/v1/timezones")) tags.push("timezone-list");
+  if (path.startsWith("/api/v1/analytics")) tags.push("analytics");
+  if (path.startsWith("/api/v1/platform-health")) tags.push("platform-health");
+  if (path.startsWith("/assets/emails")) tags.push("email-assets");
+  if (path.startsWith("/assets/images")) tags.push("images");
+  if (path.startsWith("/assets/videos")) tags.push("videos");
+  if (path.startsWith("/static")) tags.push("static");
+
+  return tags;
+}
+
+// ---------------------------------------------------------------------------
+// Smart asset strategy for non-API paths
+// ---------------------------------------------------------------------------
+
+function getStaticAssetStrategy(path: string): CacheStrategy | null {
+  if (path.startsWith("/static/")) return CACHE_STRATEGIES["staticImmutable"];
+  if (path.startsWith("/assets/images/")) return CACHE_STRATEGIES["images"];
+  if (path.startsWith("/assets/videos/")) return CACHE_STRATEGIES["videos"];
+  if (path.startsWith("/assets/emails/")) return CACHE_STRATEGIES["staticImmutable"];
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Middleware factories
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply CDN-aware cache headers to all responses.
+ *
+ * Usage:
+ *   app.use(smartCdnHeaders());   // apply globally after auth middleware
+ */
+export function smartCdnHeaders() {
+  const cdnConfig = CDNService.getConfig();
+
+  return function (req: Request, res: Response, next: NextFunction): void {
+    const originalSend = res.send.bind(res);
+
+    res.send = function (body?: unknown) {
+      // Only set headers on successful responses
+      if (res.statusCode >= 200 && res.statusCode < 400) {
+        const path = req.path;
+        const method = req.method;
+        const hasAuth = !!(
+          req.headers.authorization ||
+          (req as any).user
+        );
+
+        let strategy: CacheStrategy;
+
+        // Check if this is a static asset path first
+        const staticStrategy = getStaticAssetStrategy(path);
+        if (staticStrategy) {
+          strategy = staticStrategy;
+        } else {
+          // Use API cache rule strategy
+          strategy = getApiCacheStrategy(path, method, hasAuth);
+        }
+
+        // Set Cache-Control
+        const cacheControl = buildCacheControlHeader(strategy);
+        res.setHeader("Cache-Control", cacheControl);
+
+        // Set Vary
+        const vary = buildVaryHeader(strategy);
+        if (vary) {
+          res.setHeader("Vary", vary);
+        }
+
+        // Set Surrogate-Control (Fastly/Varnish edge TTL, separate from browser)
+        const surrogateControl = buildSurrogateControlHeader(strategy);
+        if (surrogateControl) {
+          res.setHeader("Surrogate-Control", surrogateControl);
+        }
+
+        // Set CDN provider hint header
+        if (cdnConfig) {
+          res.setHeader("X-CDN-Provider", cdnConfig.provider);
+        }
+
+        // Set cache tags for targeted purging
+        if (strategy.scope === "public") {
+          const tags = getResponseCacheTags(path);
+          if (tags.length > 0) {
+            const tagString = tags.join(" ");
+            // Cloudflare and CloudFront use Cache-Tag
+            res.setHeader("Cache-Tag", tagString);
+            // Fastly uses Surrogate-Key
+            res.setHeader("Surrogate-Key", tagString);
+          }
+        }
+
+        // Add CDN-Cache-Status for debugging (strips on edge before delivery)
+        res.setHeader("CDN-Cache-Control", cacheControl);
+
+        logger.debug("CDN cache headers applied", {
+          path,
+          method,
+          hasAuth,
+          cacheControl,
+          scope: strategy.scope,
+        });
+      }
+
+      return originalSend(body);
+    };
+
+    next();
+  };
+}
+
+/**
+ * Middleware that applies the IMMUTABLE cache strategy to a specific route.
+ *
+ * Use for static assets served with content-hash filenames:
+ *   router.use("/static", immutableCdnHeaders(), express.static(...))
+ */
+export function immutableCdnHeaders() {
+  return function (req: Request, res: Response, next: NextFunction): void {
+    const originalSend = res.send.bind(res);
+    res.send = function (body?: unknown) {
+      if (res.statusCode >= 200 && res.statusCode < 300) {
+        res.setHeader("Cache-Control", buildCacheControlHeader(CACHE_STRATEGIES["staticImmutable"]));
+        res.setHeader("Vary", "Accept-Encoding");
+      }
+      return originalSend(body);
+    };
+    next();
+  };
+}
+
+/**
+ * Middleware that applies the API public listing cache strategy.
+ *
+ * Use on specific public listing endpoints:
+ *   router.get("/mentors", apiPublicCdnHeaders(), listMentorsHandler)
+ */
+export function apiPublicCdnHeaders(
+  options: { strategy?: keyof typeof CACHE_STRATEGIES } = {},
+) {
+  const strategy = CACHE_STRATEGIES[options.strategy ?? "apiListings"];
+
+  return function (req: Request, res: Response, next: NextFunction): void {
+    const originalJson = res.json.bind(res);
+    res.json = function (body: unknown) {
+      if (res.statusCode >= 200 && res.statusCode < 300) {
+        const hasAuth = !!(req.headers.authorization || (req as any).user);
+        const effectiveStrategy = hasAuth
+          ? CACHE_STRATEGIES["apiAuthenticated"]
+          : strategy;
+
+        res.setHeader("Cache-Control", buildCacheControlHeader(effectiveStrategy));
+        const vary = buildVaryHeader(effectiveStrategy);
+        if (vary) res.setHeader("Vary", vary);
+        const surrogate = buildSurrogateControlHeader(effectiveStrategy);
+        if (surrogate) res.setHeader("Surrogate-Control", surrogate);
+      }
+      return originalJson(body);
+    };
+    next();
+  };
+}
+
+/**
+ * Middleware that explicitly bypasses CDN caching.
+ * Use on POST/PUT/PATCH/DELETE handlers and webhook endpoints.
+ */
+export function noCdnCache() {
+  return function (_req: Request, res: Response, next: NextFunction): void {
+    res.setHeader("Cache-Control", "no-store");
+    res.setHeader("Pragma", "no-cache"); // IE11 / proxy compat
+    next();
+  };
+}


### PR DESCRIPTION
…hing (#745)

- Add cdn-geo.config.ts with full provider configuration for CloudFront, Cloudflare, and Fastly (cache behaviours, edge TTLs, VCL snippets)
- Define 8 cache strategies: staticImmutable, static, images, videos, apiPublic, apiListings, apiAnalytics, apiAuthenticated, noCache
- Add API_CACHE_RULES mapping path prefixes to strategies with auth-bypass logic (authenticated requests always get private, no-cache)
- Add smart-cdn-headers.middleware.ts with smartCdnHeaders(), immutableCdnHeaders(), apiPublicCdnHeaders(), noCdnCache() factories
- Inject Cache-Tag + Surrogate-Key response headers for targeted purge-by-tag invalidation (Cloudflare / Fastly)
- Set Surrogate-Control for Fastly/Varnish edge TTL independent of browser Cache-Control TTL
- Add Vary: Accept for image routes (WebP negotiation)
- Add unit tests for all cache strategy helpers and provider configs
- Add docs/cdn-configuration.md with setup guide for all three providers

Closes #745 