### PR TITLE
feat: implement structured logging with ELK stack integration (#740)

### DIFF
--- a/docs/logging-examples/filebeat.yml
+++ b/docs/logging-examples/filebeat.yml
@@ -1,20 +1,93 @@
-# Example Filebeat configuration to ship JSON logs from container stdout to Elasticsearch
+# Filebeat configuration for MentorsMind Backend — Issue #740
+# Ships JSON structured logs (Pino format) from container stdout to Elasticsearch.
+#
+# Usage:
+#   filebeat -c filebeat.yml -e
+#
+# Or via Docker:
+#   docker run --rm \
+#     -v $(pwd)/docs/logging-examples/filebeat.yml:/usr/share/filebeat/filebeat.yml \
+#     -v /var/lib/docker/containers:/var/lib/docker/containers:ro \
+#     elastic/filebeat:8.13.0
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Input: container stdout (Docker JSON log driver)
+# ─────────────────────────────────────────────────────────────────────────────
 filebeat.inputs:
   - type: container
     paths:
       - /var/lib/docker/containers/*/*.log
+    # Filter to only collect logs from the mentorminds-backend container
     processors:
-      - add_docker_metadata: ~
+      - add_docker_metadata:
+          host: "unix:///var/run/docker.sock"
       - decode_json_fields:
           fields: ["message"]
-          target: "json"
+          target: ""        # merge JSON fields into root
           overwrite_keys: true
+          add_error_key: true
+      # Rename Pino 'msg' field to ECS 'message'
+      - rename:
+          fields:
+            - from: "msg"
+              to: "message"
+          ignore_missing: true
+      # Map Pino numeric level to ECS log.level string
+      - script:
+          lang: javascript
+          source: >
+            function process(event) {
+              var level = event.Get("level");
+              if (typeof level === "number") {
+                var label = "info";
+                if (level >= 60) label = "fatal";
+                else if (level >= 50) label = "error";
+                else if (level >= 40) label = "warn";
+                else if (level >= 30) label = "info";
+                else if (level >= 20) label = "debug";
+                else label = "trace";
+                event.Put("log.level", label);
+                event.Delete("level");
+              }
+            }
+      # Add service metadata
+      - add_fields:
+          target: "service"
+          fields:
+            name: "mentorminds-backend"
+            environment: "${NODE_ENV:development}"
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Output: Elasticsearch
+# ─────────────────────────────────────────────────────────────────────────────
 output.elasticsearch:
-  hosts: ["${ELASTICSEARCH_HOST:elasticsearch:9200}"]
+  hosts: ["${ELASTICSEARCH_HOST:localhost}:${ELASTICSEARCH_PORT:9200}"]
   username: "${ELASTICSEARCH_USERNAME:}"
   password: "${ELASTICSEARCH_PASSWORD:}"
+  api_key: "${ELASTICSEARCH_API_KEY:}"
+  # Write to the ILM rolling alias created by setup-elk-index-template.ts
+  index: "mentorminds-logs"
 
+# ─────────────────────────────────────────────────────────────────────────────
+# ILM
+# ─────────────────────────────────────────────────────────────────────────────
 setup.ilm.enabled: true
-setup.ilm.policy_name: "mentorminds_policy"
+setup.ilm.policy_name: "mentorminds-logs-ilm-policy"
 setup.ilm.rollover_alias: "mentorminds-logs"
+# Skip template setup — managed by setup-elk-index-template.ts
+setup.template.enabled: false
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Processors (global)
+# ─────────────────────────────────────────────────────────────────────────────
+processors:
+  - drop_fields:
+      fields: ["agent", "input", "ecs", "host.architecture", "host.os"]
+      ignore_missing: true
+  - add_host_metadata: ~
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Logging (Filebeat's own logs)
+# ─────────────────────────────────────────────────────────────────────────────
+logging.level: info
+logging.to_files: false

--- a/docs/logging-examples/ilm-policy.json
+++ b/docs/logging-examples/ilm-policy.json
@@ -1,22 +1,51 @@
 {
+  "_meta": {
+    "description": "ILM policy for mentorminds-logs-* indices — Issue #740",
+    "version": "1.0.0"
+  },
   "policy": {
     "phases": {
       "hot": {
+        "min_age": "0ms",
         "actions": {
-          "rollover": { "max_age": "7d", "max_size": "50gb" }
+          "rollover": {
+            "max_primary_shard_size": "50gb",
+            "max_age": "1d"
+          },
+          "set_priority": {
+            "priority": 100
+          }
         }
       },
       "warm": {
         "min_age": "7d",
         "actions": {
-          "forcemerge": { "max_num_segments": 1 },
-          "shrink": { "number_of_shards": 1 }
+          "shrink": {
+            "number_of_shards": 1
+          },
+          "forcemerge": {
+            "max_num_segments": 1
+          },
+          "set_priority": {
+            "priority": 50
+          }
+        }
+      },
+      "cold": {
+        "min_age": "30d",
+        "actions": {
+          "freeze": {},
+          "set_priority": {
+            "priority": 0
+          }
         }
       },
       "delete": {
         "min_age": "90d",
         "actions": {
-          "delete": {}
+          "delete": {
+            "delete_searchable_snapshot": true
+          }
         }
       }
     }

--- a/docs/logging-examples/kibana-dashboard.json
+++ b/docs/logging-examples/kibana-dashboard.json
@@ -1,20 +1,79 @@
 {
-  "title": "MentorMinds - Service Logs Overview",
-  "panels": [
+  "_meta": {
+    "description": "MentorsMind Backend — Structured Log Dashboard (ELK Issue #740)",
+    "version": "1.0.0"
+  },
+  "objects": [
     {
-      "type": "visualization",
-      "title": "Error Rate",
-      "id": "error-rate-chart"
+      "id": "mentorminds-logs-index-pattern",
+      "type": "index-pattern",
+      "attributes": {
+        "title": "mentorminds-logs-*",
+        "timeFieldName": "@timestamp",
+        "fields": "[]"
+      }
     },
     {
+      "id": "mentorminds-error-rate",
       "type": "visualization",
-      "title": "Requests by Endpoint",
-      "id": "requests-by-endpoint"
+      "attributes": {
+        "title": "Error Rate Over Time",
+        "visState": "{\"type\":\"line\",\"params\":{},\"aggs\":[{\"id\":\"1\",\"type\":\"count\"},{\"id\":\"2\",\"type\":\"date_histogram\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\"}}],\"filters\":[{\"meta\":{\"type\":\"phrase\"},\"query\":{\"match_phrase\":{\"log.level\":\"error\"}}}]}",
+        "uiStateJSON": "{}",
+        "description": "HTTP 5xx and application errors per minute",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"index\":\"mentorminds-logs-*\",\"filter\":[{\"match_phrase\":{\"log.level\":\"error\"}}],\"query\":{\"match_all\":{}}}"
+        }
+      }
     },
     {
+      "id": "mentorminds-request-latency",
       "type": "visualization",
-      "title": "Latency (P50/P95)",
-      "id": "latency-chart"
+      "attributes": {
+        "title": "API Response Latency (P50/P95/P99)",
+        "visState": "{\"type\":\"metric\",\"aggs\":[{\"id\":\"1\",\"type\":\"percentiles\",\"params\":{\"field\":\"durationMs\",\"percents\":[50,95,99]}}]}",
+        "description": "Response time percentiles in milliseconds",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"index\":\"mentorminds-logs-*\",\"query\":{\"match_all\":{}},\"filter\":[{\"exists\":{\"field\":\"durationMs\"}}]}"
+        }
+      }
+    },
+    {
+      "id": "mentorminds-top-endpoints",
+      "type": "visualization",
+      "attributes": {
+        "title": "Top API Endpoints by Request Count",
+        "visState": "{\"type\":\"table\",\"aggs\":[{\"id\":\"1\",\"type\":\"count\"},{\"id\":\"2\",\"type\":\"terms\",\"params\":{\"field\":\"http.request.url.path\",\"size\":20}}]}",
+        "description": "Most frequently called endpoints",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"index\":\"mentorminds-logs-*\",\"query\":{\"match_all\":{}},\"filter\":[{\"exists\":{\"field\":\"http.request.method\"}}]}"
+        }
+      }
+    },
+    {
+      "id": "mentorminds-log-levels",
+      "type": "visualization",
+      "attributes": {
+        "title": "Log Volume by Level",
+        "visState": "{\"type\":\"pie\",\"aggs\":[{\"id\":\"1\",\"type\":\"count\"},{\"id\":\"2\",\"type\":\"terms\",\"params\":{\"field\":\"log.level\",\"size\":7}}]}",
+        "description": "Distribution of log levels (error, warn, info, debug)",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"index\":\"mentorminds-logs-*\",\"query\":{\"match_all\":{}}}"
+        }
+      }
+    },
+    {
+      "id": "mentorminds-dashboard",
+      "type": "dashboard",
+      "attributes": {
+        "title": "MentorsMind Backend — Observability",
+        "description": "Structured log monitoring dashboard — Issue #740",
+        "panelsJSON": "[{\"id\":\"mentorminds-error-rate\",\"type\":\"visualization\",\"gridData\":{\"x\":0,\"y\":0,\"w\":24,\"h\":15}},{\"id\":\"mentorminds-request-latency\",\"type\":\"visualization\",\"gridData\":{\"x\":24,\"y\":0,\"w\":24,\"h\":15}},{\"id\":\"mentorminds-top-endpoints\",\"type\":\"visualization\",\"gridData\":{\"x\":0,\"y\":15,\"w\":36,\"h\":15}},{\"id\":\"mentorminds-log-levels\",\"type\":\"visualization\",\"gridData\":{\"x\":36,\"y\":15,\"w\":12,\"h\":15}}]",
+        "timeRestore": false,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"language\":\"kuery\",\"query\":\"\"},\"filter\":[]}"
+        }
+      }
     }
   ]
 }

--- a/docs/logging-examples/logstash-pipeline.conf
+++ b/docs/logging-examples/logstash-pipeline.conf
@@ -1,0 +1,112 @@
+# Logstash pipeline for MentorsMind Backend — Issue #740
+# Receives JSON logs from Filebeat/Fluent Bit, normalises to ECS, and
+# forwards to Elasticsearch with daily rolling indices.
+#
+# Place at: /etc/logstash/pipeline/mentorminds.conf
+# (or mount as a Docker volume)
+
+input {
+  beats {
+    port => 5044
+    codec => json
+  }
+}
+
+filter {
+  # ── Timestamp normalisation ──────────────────────────────────────────────
+  date {
+    match => ["time", "ISO8601", "yyyy-MM-dd'T'HH:mm:ss.SSSZ"]
+    target => "@timestamp"
+    remove_field => ["time"]
+  }
+
+  # ── Level label (Pino uses numeric levels) ───────────────────────────────
+  if [level] =~ /^\d+$/ {
+    ruby {
+      code => "
+        level = event.get('level').to_i
+        label = case level
+          when 60..100 then 'fatal'
+          when 50..59  then 'error'
+          when 40..49  then 'warn'
+          when 30..39  then 'info'
+          when 20..29  then 'debug'
+          else 'trace'
+          end
+        event.set('[log][level]', label)
+        event.remove('level')
+      "
+    }
+  } else if [level] {
+    mutate { rename => { "level" => "[log][level]" } }
+  }
+
+  # ── Message field ────────────────────────────────────────────────────────
+  if [msg] and ![message] {
+    mutate { rename => { "msg" => "message" } }
+  }
+
+  # ── HTTP fields (ECS) ────────────────────────────────────────────────────
+  if [method] {
+    mutate { rename => { "method" => "[http][request][method]" } }
+  }
+  if [url] {
+    mutate { rename => { "url" => "[url][full]" } }
+  }
+  if [statusCode] {
+    mutate { rename => { "statusCode" => "[http][response][status_code]" } }
+    mutate { convert => { "[http][response][status_code]" => "integer" } }
+  }
+  if [responseTime] {
+    mutate { rename => { "responseTime" => "durationMs" } }
+    mutate { convert => { "durationMs" => "integer" } }
+  }
+
+  # ── Error fields (ECS) ───────────────────────────────────────────────────
+  if [err][message] {
+    mutate {
+      rename => { "[err][message]" => "[error][message]" }
+      rename => { "[err][stack]" => "[error][stack_trace]" }
+      rename => { "[err][type]" => "[error][type]" }
+    }
+  }
+
+  # ── Redact sensitive fields ──────────────────────────────────────────────
+  mutate {
+    remove_field => [
+      "password", "token", "secret", "secretKey",
+      "authorization", "refreshToken", "apiKey", "privateKey",
+      "pid", "hostname"
+    ]
+  }
+
+  # ── Service metadata ─────────────────────────────────────────────────────
+  mutate {
+    add_field => {
+      "[service][name]" => "mentorminds-backend"
+      "[service][environment]" => "%{[NODE_ENV]}"
+    }
+  }
+
+  # ── Drop heartbeat/health check noise ───────────────────────────────────
+  if [url][full] =~ /^\/health/ and [http][response][status_code] == 200 {
+    drop { }
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => ["${ELASTICSEARCH_HOST:localhost}:9200"]
+    user => "${ELASTICSEARCH_USERNAME:}"
+    password => "${ELASTICSEARCH_PASSWORD:}"
+    # ILM rolling alias created by setup-elk-index-template.ts
+    ilm_enabled => true
+    ilm_rollover_alias => "mentorminds-logs"
+    ilm_policy => "mentorminds-logs-ilm-policy"
+    # ECS compatibility
+    ecs_compatibility => "v8"
+  }
+
+  # Uncomment for debugging:
+  # stdout { codec => rubydebug }
+}

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -139,3 +139,88 @@ npx jest --testPathPattern="logger|correlation-id|request-logger" --verbose
 
 If you want, I can add optional sample Filebeat/Logstash config and an example Kibana dashboard template next.
 ```
+
+
+---
+
+## ELK Stack Integration (Issue #740)
+
+### Components
+
+| Component | File | Role |
+|-----------|------|------|
+| `ELKTransport` | `src/utils/elk-transport.ts` | Batches and ships Pino logs to Elasticsearch via `_bulk` API |
+| `elkLoggingMiddleware` | `src/middleware/elk-logging.middleware.ts` | Captures per-request HTTP logs in ECS format |
+| `elkErrorLoggingMiddleware` | `src/middleware/elk-logging.middleware.ts` | Forwards unhandled errors to Elasticsearch |
+| `setup-elk-index-template.ts` | `scripts/setup-elk-index-template.ts` | One-time setup of ILM policy + index template |
+| `filebeat.yml` | `docs/logging-examples/filebeat.yml` | Filebeat config for container stdout shipping |
+| `logstash-pipeline.conf` | `docs/logging-examples/logstash-pipeline.conf` | Logstash pipeline for field normalisation |
+| `kibana-dashboard.json` | `docs/logging-examples/kibana-dashboard.json` | Importable Kibana dashboard |
+
+### Environment variables
+
+```bash
+ELASTICSEARCH_ENABLED=true
+ELASTICSEARCH_URL=http://localhost:9200
+ELASTICSEARCH_USERNAME=elastic
+ELASTICSEARCH_PASSWORD=changeme
+ELASTICSEARCH_API_KEY=          # alternative to username/password
+ELASTICSEARCH_INDEX_PREFIX=mentorminds
+
+# Batch transport tuning
+ELK_BATCH_SIZE=100              # Documents per Elasticsearch _bulk request
+ELK_FLUSH_INTERVAL_MS=5000      # Auto-flush every 5 seconds
+ELK_MAX_RETRIES=3               # Retry on transient 5xx from Elasticsearch
+```
+
+### Setup (one-time)
+
+```bash
+# 1. Create ILM policy, index template, and initial write index
+npm run elk:setup
+
+# 2. Import the Kibana dashboard
+# Kibana → Management → Saved Objects → Import → kibana-dashboard.json
+
+# 3. (Optional) Start Filebeat to ship container stdout
+filebeat -c docs/logging-examples/filebeat.yml -e
+```
+
+### Mounting middleware
+
+```typescript
+// src/app.ts
+import { elkLoggingMiddleware, elkErrorLoggingMiddleware } from './middleware/elk-logging.middleware';
+
+// After tracing + auth middleware:
+app.use(elkLoggingMiddleware());
+
+// After error handler:
+app.use(errorHandler);
+app.use(elkErrorLoggingMiddleware());
+```
+
+### Index naming
+
+Logs are indexed to `mentorminds-logs-YYYY.MM.DD` daily rolling indices,
+managed by the `mentorminds-logs-ilm-policy` ILM policy (hot→warm→cold→delete at 90 days).
+
+### Log schema (ECS)
+
+Every log document includes ECS core fields:
+
+| Field | Type | Example |
+|-------|------|---------|
+| `@timestamp` | date | `2026-07-29T05:00:00.000Z` |
+| `log.level` | keyword | `info`, `warn`, `error` |
+| `message` | text | `GET /api/v1/mentors 200 45ms` |
+| `service.name` | keyword | `mentorminds-backend` |
+| `service.environment` | keyword | `production` |
+| `http.request.method` | keyword | `GET` |
+| `http.response.status_code` | short | `200` |
+| `durationMs` | long | `45` |
+| `requestId` | keyword | `req-uuid` |
+| `correlationId` | keyword | `corr-uuid` |
+| `trace.id` | keyword | `otel-trace-id` |
+| `userId` | keyword | `user-uuid` |
+| `client.ip` | ip | `1.2.3.4` |

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "migrate:create": "node-pg-migrate create --migrations-dir database/migrations",
     "migrate:validate": "ts-node database/validate-migrations.ts",
     "migrate:renumber": "ts-node database/renumber-migrations.ts",
+    "elk:setup": "ts-node --transpile-only scripts/setup-elk-index-template.ts",
     "test:e2e": "jest --config jest.e2e.config.ts --forceExit",
     "test:e2e:verbose": "E2E_VERBOSE=1 jest --config jest.e2e.config.ts --forceExit --verbose",
     "test:e2e:single": "jest --config jest.e2e.config.ts --forceExit",

--- a/scripts/setup-elk-index-template.ts
+++ b/scripts/setup-elk-index-template.ts
@@ -1,0 +1,233 @@
+/**
+ * Elasticsearch Index Template Setup — Issue #740
+ *
+ * Creates an index template with ECS-compatible field mappings and an
+ * Index Lifecycle Management (ILM) policy for the MentorsMind log indices.
+ *
+ * Run with:
+ *   npx ts-node scripts/setup-elk-index-template.ts
+ *
+ * Prerequisites:
+ *   - ELASTICSEARCH_URL set (and credentials if auth is enabled)
+ *   - Elasticsearch 7.x or 8.x running
+ */
+
+import { env } from "../src/config/env";
+
+const ES_URL = env.ELASTICSEARCH_URL.replace(/\/$/, "");
+const INDEX_PREFIX = env.ELASTICSEARCH_INDEX_PREFIX || "mentorminds";
+
+// ---------------------------------------------------------------------------
+// Build auth headers
+// ---------------------------------------------------------------------------
+
+function buildAuthHeaders(): Record<string, string> {
+  if (env.ELASTICSEARCH_API_KEY) {
+    return { Authorization: `ApiKey ${env.ELASTICSEARCH_API_KEY}` };
+  }
+  if (env.ELASTICSEARCH_USERNAME && env.ELASTICSEARCH_PASSWORD) {
+    const creds = Buffer.from(
+      `${env.ELASTICSEARCH_USERNAME}:${env.ELASTICSEARCH_PASSWORD}`,
+    ).toString("base64");
+    return { Authorization: `Basic ${creds}` };
+  }
+  return {};
+}
+
+// ---------------------------------------------------------------------------
+// ILM policy
+// ---------------------------------------------------------------------------
+
+const ILM_POLICY = {
+  policy: {
+    phases: {
+      hot: {
+        min_age: "0ms",
+        actions: {
+          rollover: {
+            max_primary_shard_size: "50gb",
+            max_age: "1d",
+          },
+        },
+      },
+      warm: {
+        min_age: "7d",
+        actions: {
+          shrink: { number_of_shards: 1 },
+          forcemerge: { max_num_segments: 1 },
+        },
+      },
+      cold: {
+        min_age: "30d",
+        actions: {
+          freeze: {},
+        },
+      },
+      delete: {
+        min_age: "90d",
+        actions: {
+          delete: {},
+        },
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Index template with ECS field mappings
+// ---------------------------------------------------------------------------
+
+const INDEX_TEMPLATE = {
+  index_patterns: [`${INDEX_PREFIX}-logs-*`],
+  template: {
+    settings: {
+      number_of_shards: 1,
+      number_of_replicas: 1,
+      "index.lifecycle.name": `${INDEX_PREFIX}-logs-ilm-policy`,
+      "index.lifecycle.rollover_alias": `${INDEX_PREFIX}-logs`,
+    },
+    mappings: {
+      dynamic: true,
+      properties: {
+        // ECS core
+        "@timestamp": { type: "date" },
+        "log.level": { type: "keyword" },
+        message: { type: "text", fields: { keyword: { type: "keyword", ignore_above: 1024 } } },
+
+        // Service
+        "service.name": { type: "keyword" },
+        "service.version": { type: "keyword" },
+        "service.environment": { type: "keyword" },
+
+        // Host
+        "host.name": { type: "keyword" },
+
+        // HTTP request
+        "http.request.method": { type: "keyword" },
+        "http.request.url.path": { type: "keyword" },
+        "url.full": { type: "keyword" },
+
+        // HTTP response
+        "http.response.status_code": { type: "short" },
+        "http.response.body.bytes": { type: "long" },
+
+        // Network / client
+        "client.ip": { type: "ip" },
+        "user_agent.original": { type: "keyword" },
+
+        // Tracing
+        "trace.id": { type: "keyword" },
+        "span.id": { type: "keyword" },
+        requestId: { type: "keyword" },
+        correlationId: { type: "keyword" },
+
+        // Application
+        userId: { type: "keyword" },
+        durationMs: { type: "long" },
+        instanceId: { type: "keyword" },
+
+        // Error fields
+        "error.type": { type: "keyword" },
+        "error.message": { type: "text" },
+        "error.stack_trace": { type: "text" },
+      },
+    },
+  },
+  priority: 100,
+  composed_of: [],
+  _meta: {
+    description: "MentorsMind structured log index template (ECS-compatible)",
+    version: "1.0.0",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Bootstrap alias (initial write index)
+// ---------------------------------------------------------------------------
+
+async function esRequest(
+  method: string,
+  path: string,
+  body?: object,
+): Promise<{ ok: boolean; status: number; body: unknown }> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...buildAuthHeaders(),
+  };
+  const res = await fetch(`${ES_URL}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  let responseBody: unknown;
+  try {
+    responseBody = await res.json();
+  } catch {
+    responseBody = null;
+  }
+  return { ok: res.ok, status: res.status, body: responseBody };
+}
+
+async function setup(): Promise<void> {
+  console.log(`\n🔧  Setting up ELK index template for ${INDEX_PREFIX}…`);
+  console.log(`    Elasticsearch: ${ES_URL}`);
+
+  // 1. Create ILM policy
+  console.log("\n[1/3] Creating ILM policy…");
+  const ilmResult = await esRequest(
+    "PUT",
+    `/_ilm/policy/${INDEX_PREFIX}-logs-ilm-policy`,
+    ILM_POLICY,
+  );
+  if (!ilmResult.ok) {
+    console.error("    ✗ ILM policy failed:", ilmResult.status, JSON.stringify(ilmResult.body));
+  } else {
+    console.log("    ✓ ILM policy created");
+  }
+
+  // 2. Create index template
+  console.log("\n[2/3] Creating index template…");
+  const templateResult = await esRequest(
+    "PUT",
+    `/_index_template/${INDEX_PREFIX}-logs-template`,
+    INDEX_TEMPLATE,
+  );
+  if (!templateResult.ok) {
+    console.error("    ✗ Index template failed:", templateResult.status, JSON.stringify(templateResult.body));
+  } else {
+    console.log("    ✓ Index template created");
+  }
+
+  // 3. Bootstrap the initial write index (if it doesn't exist)
+  const today = new Date().toISOString().slice(0, 10).replace(/-/g, ".");
+  const initialIndex = `${INDEX_PREFIX}-logs-${today}-000001`;
+  console.log(`\n[3/3] Bootstrapping initial index ${initialIndex}…`);
+  const existsResult = await esRequest("HEAD", `/${initialIndex}`);
+  if (existsResult.status === 200) {
+    console.log("    ℹ  Index already exists, skipping");
+  } else {
+    const createResult = await esRequest("PUT", `/${initialIndex}`, {
+      aliases: {
+        [`${INDEX_PREFIX}-logs`]: {
+          is_write_index: true,
+        },
+      },
+    });
+    if (!createResult.ok) {
+      console.error("    ✗ Index creation failed:", createResult.status, JSON.stringify(createResult.body));
+    } else {
+      console.log("    ✓ Initial index created with write alias");
+    }
+  }
+
+  console.log("\n✅  ELK setup complete.\n");
+  console.log(`    Index alias:    ${INDEX_PREFIX}-logs`);
+  console.log(`    ILM policy:     ${INDEX_PREFIX}-logs-ilm-policy`);
+  console.log(`    Index template: ${INDEX_PREFIX}-logs-template`);
+  console.log(`    Kibana pattern: ${INDEX_PREFIX}-logs-*\n`);
+}
+
+setup().catch((err) => {
+  console.error("ELK setup failed:", err);
+  process.exit(1);
+});

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -218,13 +218,19 @@ const envSchema = z.object({
   CDN_FASTLY_SERVICE_ID: z.string().optional(),
   CDN_FASTLY_API_KEY: z.string().optional(),
 
-  // Elasticsearch
+  // Elasticsearch / ELK Stack (issue #740)
   ELASTICSEARCH_URL: z.string().url().default("http://localhost:9200"),
   ELASTICSEARCH_USERNAME: z.string().optional(),
   ELASTICSEARCH_PASSWORD: z.string().optional(),
   ELASTICSEARCH_API_KEY: z.string().optional(),
   ELASTICSEARCH_ENABLED: z.enum(["true", "false"]).default("true"),
   ELASTICSEARCH_INDEX_PREFIX: z.string().default("mentorminds"),
+  /** Max log documents to buffer before flushing to Elasticsearch */
+  ELK_BATCH_SIZE: z.string().regex(/^\d+$/).default("100"),
+  /** Flush interval in ms for the ELK batch transport */
+  ELK_FLUSH_INTERVAL_MS: z.string().regex(/^\d+$/).default("5000"),
+  /** Max retry attempts for failed ELK bulk requests */
+  ELK_MAX_RETRIES: z.string().regex(/^\d+$/).default("3"),
 
   // Stellar (additional keys)
   STELLAR_FUNDING_SECRET: z.string().optional(),

--- a/src/middleware/elk-logging.middleware.ts
+++ b/src/middleware/elk-logging.middleware.ts
@@ -1,0 +1,140 @@
+/**
+ * ELK Log Aggregation Middleware — Issue #740
+ *
+ * Captures structured request/response log entries and forwards them to
+ * the ELK transport for batched ingestion into Elasticsearch.
+ *
+ * Each entry includes:
+ *  - ECS-standard fields (@timestamp, log.level, message, service.*, host.*)
+ *  - HTTP request context (method, path, status, duration, client IP, user-agent)
+ *  - Trace correlation (requestId, correlationId, traceId, spanId)
+ *  - User context (userId) when available
+ *
+ * The middleware is designed to be lightweight — it delegates all I/O to the
+ * ELKTransport batch queue and never blocks the request/response cycle.
+ */
+
+import { Request, Response, NextFunction } from "express";
+import { getELKTransport, toECSDocument } from "../utils/elk-transport";
+import { env } from "../config/env";
+
+// ---------------------------------------------------------------------------
+// ELK request logging middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Mount this middleware AFTER tracing and auth middleware so that requestId,
+ * correlationId, and userId are all available on the request object.
+ *
+ * @example
+ * // src/app.ts
+ * app.use(tracingMiddleware);
+ * app.use(authenticate);
+ * app.use(elkLoggingMiddleware());
+ * app.use(router);
+ */
+export function elkLoggingMiddleware() {
+  return function (req: Request, res: Response, next: NextFunction): void {
+    const transport = getELKTransport();
+    if (!transport) {
+      // ELK disabled — no-op
+      return next();
+    }
+
+    const startTime = Date.now();
+
+    res.on("finish", () => {
+      const durationMs = Date.now() - startTime;
+      const status = res.statusCode;
+      const level = status >= 500 ? "error" : status >= 400 ? "warn" : "info";
+
+      const rawLog: Record<string, unknown> = {
+        time: new Date().toISOString(),
+        level,
+        msg: `${req.method} ${req.originalUrl} ${status} ${durationMs}ms`,
+        // HTTP fields
+        "http.request.method": req.method,
+        "http.request.url.path": req.path,
+        "url.full": req.originalUrl,
+        "http.response.status_code": status,
+        "http.response.body.bytes": parseInt(
+          res.getHeader("Content-Length") as string || "0",
+          10,
+        ) || 0,
+        // Network
+        "client.ip": extractClientIp(req),
+        "user_agent.original": req.headers["user-agent"] ?? "",
+        // Timing
+        durationMs,
+        // Correlation
+        requestId: (req as any).requestId ?? (req as any).id,
+        correlationId: (req as any).correlationId,
+        traceId: (req as any).traceId,
+        spanId: (req as any).spanId,
+        // User
+        userId: (req as any).user?.userId ?? (req as any).user?.id,
+        // Service
+        service: "mentorminds-backend",
+        instanceId: env.INSTANCE_ID,
+      };
+
+      const doc = toECSDocument(rawLog);
+      transport.write(doc);
+    });
+
+    next();
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ELK error logging middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Error handler that forwards unhandled exceptions to Elasticsearch as
+ * error-level log documents before re-throwing to the next error handler.
+ *
+ * Mount this AFTER your primary error handler:
+ *   app.use(errorHandler);
+ *   app.use(elkErrorLoggingMiddleware());
+ */
+export function elkErrorLoggingMiddleware() {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return function (
+    err: Error,
+    req: Request,
+    _res: Response,
+    next: NextFunction,
+  ): void {
+    const transport = getELKTransport();
+    if (transport) {
+      const rawLog: Record<string, unknown> = {
+        time: new Date().toISOString(),
+        level: "error",
+        msg: err.message,
+        "error.type": err.constructor.name,
+        "error.message": err.message,
+        "error.stack_trace": err.stack,
+        "http.request.method": req.method,
+        "http.request.url.path": req.path,
+        requestId: (req as any).requestId,
+        correlationId: (req as any).correlationId,
+        userId: (req as any).user?.userId,
+        service: "mentorminds-backend",
+        instanceId: env.INSTANCE_ID,
+      };
+      transport.write(toECSDocument(rawLog));
+    }
+    next(err);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function extractClientIp(req: Request): string {
+  const forwarded = req.headers["x-forwarded-for"];
+  if (typeof forwarded === "string") return forwarded.split(",")[0].trim();
+  return req.ip ?? req.socket?.remoteAddress ?? "unknown";
+}

--- a/src/utils/__tests__/elk-transport.test.ts
+++ b/src/utils/__tests__/elk-transport.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Unit tests for ELKTransport and toECSDocument — Issue #740
+ */
+
+import { ELKTransport, toECSDocument } from "../../../utils/elk-transport";
+
+// ---------------------------------------------------------------------------
+// toECSDocument
+// ---------------------------------------------------------------------------
+
+describe("toECSDocument", () => {
+  it("maps Pino log fields to ECS structure", () => {
+    const pinoLog = {
+      time: "2026-07-29T05:00:00.000Z",
+      level: 30,
+      msg: "User logged in",
+      service: "mentorminds-backend",
+      instanceId: "pod-1",
+      requestId: "req-abc",
+      correlationId: "corr-xyz",
+      userId: "user-123",
+      traceId: "trace-456",
+      spanId: "span-789",
+    };
+
+    const doc = toECSDocument(pinoLog);
+
+    expect(doc["@timestamp"]).toBe("2026-07-29T05:00:00.000Z");
+    expect(doc["log.level"]).toBe("info");
+    expect(doc.message).toBe("User logged in");
+    expect(doc["service.name"]).toBe("mentorminds-backend");
+    expect(doc["host.name"]).toBe("pod-1");
+    expect(doc.requestId).toBe("req-abc");
+    expect(doc.correlationId).toBe("corr-xyz");
+    expect(doc.userId).toBe("user-123");
+    expect(doc["trace.id"]).toBe("trace-456");
+    expect(doc["span.id"]).toBe("span-789");
+  });
+
+  it("maps numeric Pino level 50 to error", () => {
+    const doc = toECSDocument({ level: 50, msg: "err" });
+    expect(doc["log.level"]).toBe("error");
+  });
+
+  it("maps numeric Pino level 40 to warn", () => {
+    const doc = toECSDocument({ level: 40, msg: "warn" });
+    expect(doc["log.level"]).toBe("warn");
+  });
+
+  it("maps numeric Pino level 60 to fatal", () => {
+    const doc = toECSDocument({ level: 60, msg: "fatal" });
+    expect(doc["log.level"]).toBe("fatal");
+  });
+
+  it("maps numeric Pino level 20 to debug", () => {
+    const doc = toECSDocument({ level: 20, msg: "debug" });
+    expect(doc["log.level"]).toBe("debug");
+  });
+
+  it("passes through additional fields", () => {
+    const doc = toECSDocument({ level: 30, msg: "ok", customField: "value" });
+    expect(doc["customField"]).toBe("value");
+  });
+
+  it("excludes standard pino housekeeping fields from passthrough", () => {
+    const doc = toECSDocument({
+      level: 30,
+      msg: "ok",
+      pid: 1234,
+      hostname: "server-1",
+    });
+    // pid and hostname should not be in the ECS doc
+    expect(doc["pid"]).toBeUndefined();
+    expect(doc["hostname"]).toBeUndefined();
+  });
+
+  it("uses fallback timestamp when time is missing", () => {
+    const before = Date.now();
+    const doc = toECSDocument({ level: 30, msg: "no time" });
+    const after = Date.now();
+    const ts = new Date(doc["@timestamp"] as string).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ELKTransport
+// ---------------------------------------------------------------------------
+
+describe("ELKTransport", () => {
+  let fetchMock: jest.Mock;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ errors: false, items: [] }),
+    });
+    global.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it("buffers documents before flushing", async () => {
+    const transport = new ELKTransport({
+      url: "http://localhost:9200",
+      batchSize: 10,
+      flushIntervalMs: 60_000,
+    });
+
+    transport.write({ "@timestamp": new Date().toISOString(), "log.level": "info", message: "test", "service.name": "svc", "service.environment": "test", "host.name": "h1" });
+    transport.write({ "@timestamp": new Date().toISOString(), "log.level": "info", message: "test2", "service.name": "svc", "service.environment": "test", "host.name": "h1" });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(transport.getStats().buffered).toBe(2);
+  });
+
+  it("flushes when batchSize is reached", async () => {
+    const transport = new ELKTransport({
+      url: "http://localhost:9200",
+      batchSize: 2,
+      flushIntervalMs: 60_000,
+    });
+
+    transport.write({ "@timestamp": new Date().toISOString(), "log.level": "info", message: "a", "service.name": "svc", "service.environment": "test", "host.name": "h1" });
+    transport.write({ "@timestamp": new Date().toISOString(), "log.level": "info", message: "b", "service.name": "svc", "service.environment": "test", "host.name": "h1" });
+
+    // Allow microtask queue to settle
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(transport.getStats().buffered).toBe(0);
+  });
+
+  it("sends ndjson to /_bulk endpoint", async () => {
+    const transport = new ELKTransport({
+      url: "http://localhost:9200",
+      batchSize: 1,
+    });
+
+    transport.write({ "@timestamp": "2026-07-29T05:00:00.000Z", "log.level": "info", message: "hello", "service.name": "svc", "service.environment": "test", "host.name": "h1" });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/_bulk"),
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    const callArgs = fetchMock.mock.calls[0];
+    expect(callArgs[1].headers["Content-Type"]).toBe("application/x-ndjson");
+  });
+
+  it("flush() sends buffered documents", async () => {
+    const transport = new ELKTransport({
+      url: "http://localhost:9200",
+      batchSize: 100,
+      flushIntervalMs: 60_000,
+    });
+
+    transport.write({ "@timestamp": new Date().toISOString(), "log.level": "warn", message: "manual flush", "service.name": "svc", "service.environment": "test", "host.name": "h1" });
+
+    await transport.flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(transport.getStats().buffered).toBe(0);
+  });
+
+  it("retries on server error and then drops batch after max retries", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503 });
+
+    const transport = new ELKTransport({
+      url: "http://localhost:9200",
+      batchSize: 100,
+      maxRetries: 2,
+      retryBaseDelayMs: 10,
+    });
+
+    transport.write({ "@timestamp": new Date().toISOString(), "log.level": "info", message: "retry test", "service.name": "svc", "service.environment": "test", "host.name": "h1" });
+
+    await transport.flush();
+
+    // 2 retries means fetch was called maxRetries times
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(transport.getStats().dropped).toBe(1);
+  });
+
+  it("does not retry on 4xx client error", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 400 });
+
+    const transport = new ELKTransport({
+      url: "http://localhost:9200",
+      batchSize: 100,
+      maxRetries: 3,
+      retryBaseDelayMs: 10,
+    });
+
+    transport.write({ "@timestamp": new Date().toISOString(), "log.level": "info", message: "client err", "service.name": "svc", "service.environment": "test", "host.name": "h1" });
+
+    await transport.flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1); // no retry
+    expect(transport.getStats().dropped).toBe(1);
+  });
+
+  it("stop() flushes remaining buffer", async () => {
+    const transport = new ELKTransport({
+      url: "http://localhost:9200",
+      batchSize: 100,
+      flushIntervalMs: 60_000,
+    });
+
+    transport.write({ "@timestamp": new Date().toISOString(), "log.level": "info", message: "stop flush", "service.name": "svc", "service.environment": "test", "host.name": "h1" });
+
+    await transport.stop();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/elk-transport.ts
+++ b/src/utils/elk-transport.ts
@@ -1,0 +1,307 @@
+/**
+ * ELK Stack Log Transport — Issue #740
+ *
+ * Implements a log aggregation pipeline that forwards structured JSON log
+ * entries from the Pino logger to Elasticsearch (the "E" in ELK) in real-time.
+ *
+ * Architecture:
+ *   Pino logger (stdout JSON)
+ *     └─ ELKTransport (this file) ─── batch/retry ──► Elasticsearch HTTP API
+ *
+ * Design decisions:
+ *  - Writes are batched (configurable interval + max-batch size) to avoid
+ *    one HTTP request per log line at high throughput.
+ *  - Failed batches are retried with exponential back-off up to a max of 3
+ *    attempts before being dropped (with a `warn` log of the drop count).
+ *  - The transport is disabled when ELASTICSEARCH_ENABLED=false or when
+ *    NODE_ENV=test, so tests are never affected by ES connectivity.
+ *  - Index name follows the ILM rolling alias pattern:
+ *      mentorminds-logs-YYYY.MM.DD
+ *  - Documents are enriched with a `@timestamp` field (ISO-8601) and a
+ *    `service.name` field so Kibana Discover shows them correctly.
+ *  - The Elasticsearch `_bulk` API is used for efficient batch ingestion.
+ */
+
+import { env } from "../config/env";
+import { logger } from "./logger";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface LogDocument {
+  "@timestamp": string;
+  "log.level": string;
+  message: string;
+  "service.name": string;
+  "service.version"?: string;
+  "service.environment": string;
+  "host.name": string;
+  "trace.id"?: string;
+  "span.id"?: string;
+  requestId?: string;
+  correlationId?: string;
+  userId?: string;
+  [key: string]: unknown;
+}
+
+interface BulkAction {
+  index: { _index: string };
+}
+
+// ---------------------------------------------------------------------------
+// Index naming
+// ---------------------------------------------------------------------------
+
+function getIndexName(): string {
+  const prefix = env.ELASTICSEARCH_INDEX_PREFIX || "mentorminds";
+  const date = new Date().toISOString().slice(0, 10).replace(/-/g, ".");
+  return `${prefix}-logs-${date}`;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helper (no external deps)
+// ---------------------------------------------------------------------------
+
+async function httpBulk(
+  url: string,
+  body: string,
+  headers: Record<string, string>,
+): Promise<{ ok: boolean; status: number }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-ndjson", ...headers },
+      body,
+      signal: controller.signal,
+    });
+    return { ok: res.ok, status: res.status };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ELKTransport class
+// ---------------------------------------------------------------------------
+
+export interface ELKTransportOptions {
+  /** Elasticsearch base URL (defaults to env.ELASTICSEARCH_URL) */
+  url?: string;
+  /** Index prefix (defaults to env.ELASTICSEARCH_INDEX_PREFIX) */
+  indexPrefix?: string;
+  /** Max log entries to buffer before flushing (default: 100) */
+  batchSize?: number;
+  /** How often to auto-flush in ms (default: 5000) */
+  flushIntervalMs?: number;
+  /** Max retry attempts on failure (default: 3) */
+  maxRetries?: number;
+  /** Base back-off delay in ms for retries (default: 500) */
+  retryBaseDelayMs?: number;
+}
+
+export class ELKTransport {
+  private readonly url: string;
+  private readonly batchSize: number;
+  private readonly flushIntervalMs: number;
+  private readonly maxRetries: number;
+  private readonly retryBaseDelayMs: number;
+  private readonly authHeaders: Record<string, string>;
+
+  private buffer: LogDocument[] = [];
+  private flushTimer: ReturnType<typeof setInterval> | null = null;
+  private isFlushing = false;
+  private droppedCount = 0;
+
+  constructor(options: ELKTransportOptions = {}) {
+    this.url = (options.url ?? env.ELASTICSEARCH_URL).replace(/\/$/, "");
+    this.batchSize = options.batchSize ?? 100;
+    this.flushIntervalMs = options.flushIntervalMs ?? 5_000;
+    this.maxRetries = options.maxRetries ?? 3;
+    this.retryBaseDelayMs = options.retryBaseDelayMs ?? 500;
+
+    // Build auth headers
+    this.authHeaders = {};
+    if (env.ELASTICSEARCH_API_KEY) {
+      this.authHeaders["Authorization"] = `ApiKey ${env.ELASTICSEARCH_API_KEY}`;
+    } else if (env.ELASTICSEARCH_USERNAME && env.ELASTICSEARCH_PASSWORD) {
+      const creds = Buffer.from(
+        `${env.ELASTICSEARCH_USERNAME}:${env.ELASTICSEARCH_PASSWORD}`,
+      ).toString("base64");
+      this.authHeaders["Authorization"] = `Basic ${creds}`;
+    }
+  }
+
+  /**
+   * Start the periodic flush timer.
+   * Call once during application bootstrap.
+   */
+  start(): void {
+    if (this.flushTimer) return;
+    this.flushTimer = setInterval(() => {
+      this.flush().catch(() => {}); // errors handled inside flush()
+    }, this.flushIntervalMs);
+
+    // Allow process to exit even if timer is active
+    if (this.flushTimer.unref) this.flushTimer.unref();
+  }
+
+  /**
+   * Stop the periodic flush timer and flush remaining buffer.
+   * Call during graceful shutdown.
+   */
+  async stop(): Promise<void> {
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer);
+      this.flushTimer = null;
+    }
+    await this.flush();
+  }
+
+  /**
+   * Enqueue a log document. Triggers an immediate flush when buffer is full.
+   */
+  write(doc: LogDocument): void {
+    this.buffer.push(doc);
+    if (this.buffer.length >= this.batchSize) {
+      this.flush().catch(() => {});
+    }
+  }
+
+  /**
+   * Flush buffered log documents to Elasticsearch via the _bulk API.
+   */
+  async flush(): Promise<void> {
+    if (this.isFlushing || this.buffer.length === 0) return;
+    this.isFlushing = true;
+
+    const batch = this.buffer.splice(0, this.batchSize);
+    const indexName = getIndexName();
+
+    // Build ndjson bulk body
+    const lines: string[] = [];
+    for (const doc of batch) {
+      const action: BulkAction = { index: { _index: indexName } };
+      lines.push(JSON.stringify(action));
+      lines.push(JSON.stringify(doc));
+    }
+    const body = lines.join("\n") + "\n";
+
+    let attempt = 0;
+    let success = false;
+
+    while (attempt < this.maxRetries && !success) {
+      try {
+        const result = await httpBulk(
+          `${this.url}/_bulk`,
+          body,
+          this.authHeaders,
+        );
+        if (result.ok) {
+          success = true;
+        } else if (result.status >= 400 && result.status < 500) {
+          // Client error — do not retry
+          logger.warn("ELK bulk rejected (client error)", {
+            status: result.status,
+            dropped: batch.length,
+          });
+          this.droppedCount += batch.length;
+          break;
+        } else {
+          throw new Error(`ES bulk returned ${result.status}`);
+        }
+      } catch (err) {
+        attempt++;
+        if (attempt < this.maxRetries) {
+          const delay = this.retryBaseDelayMs * Math.pow(2, attempt - 1);
+          await new Promise((r) => setTimeout(r, delay));
+        } else {
+          logger.warn("ELK bulk failed after max retries — dropping batch", {
+            dropped: batch.length,
+            err: err instanceof Error ? err.message : String(err),
+          });
+          this.droppedCount += batch.length;
+        }
+      }
+    }
+
+    this.isFlushing = false;
+  }
+
+  getStats(): { buffered: number; dropped: number } {
+    return { buffered: this.buffer.length, dropped: this.droppedCount };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton transport instance
+// ---------------------------------------------------------------------------
+
+let _transport: ELKTransport | null = null;
+
+export function getELKTransport(): ELKTransport | null {
+  const enabled =
+    env.ELASTICSEARCH_ENABLED === "true" &&
+    env.NODE_ENV !== "test" &&
+    !!env.ELASTICSEARCH_URL;
+
+  if (!enabled) return null;
+
+  if (!_transport) {
+    _transport = new ELKTransport();
+    _transport.start();
+  }
+  return _transport;
+}
+
+/**
+ * Convert a raw Pino log object into an ECS (Elastic Common Schema)-compatible
+ * Elasticsearch document. This ensures Kibana understands the fields natively.
+ *
+ * ECS reference: https://www.elastic.co/guide/en/ecs/current/index.html
+ */
+export function toECSDocument(pinoLog: Record<string, unknown>): LogDocument {
+  const level = typeof pinoLog.level === "number"
+    ? pinoLevelToLabel(pinoLog.level as number)
+    : (pinoLog.level as string) ?? "info";
+
+  return {
+    "@timestamp": (pinoLog.time as string) ?? new Date().toISOString(),
+    "log.level": level,
+    message: (pinoLog.msg as string) ?? "",
+    "service.name": (pinoLog.service as string) ?? "mentorminds-backend",
+    "service.environment": env.NODE_ENV,
+    "host.name": (pinoLog.instanceId as string) ?? "",
+    "trace.id": pinoLog.traceId as string | undefined,
+    "span.id": pinoLog.spanId as string | undefined,
+    requestId: pinoLog.requestId as string | undefined,
+    correlationId: pinoLog.correlationId as string | undefined,
+    userId: pinoLog.userId as string | undefined,
+    // Forward remaining fields
+    ...Object.fromEntries(
+      Object.entries(pinoLog).filter(
+        ([k]) =>
+          ![
+            "time",
+            "level",
+            "msg",
+            "pid",
+            "hostname",
+            "service",
+            "instanceId",
+          ].includes(k),
+      ),
+    ),
+  };
+}
+
+function pinoLevelToLabel(level: number): string {
+  if (level >= 60) return "fatal";
+  if (level >= 50) return "error";
+  if (level >= 40) return "warn";
+  if (level >= 30) return "info";
+  if (level >= 20) return "debug";
+  return "trace";
+}


### PR DESCRIPTION
- Add ELKTransport (src/utils/elk-transport.ts): batched _bulk ingestion to Elasticsearch with exponential back-off retry, 4xx no-retry, and dropped-count metrics
- Add toECSDocument helper that converts Pino log objects to ECS format (log.level, @timestamp, service.*, host.*, trace.id, span.id, etc.)
- Add elkLoggingMiddleware: captures per-request HTTP logs in ECS format (method, path, status, durationMs, client.ip, user-agent, userId, requestId, correlationId, traceId)
- Add elkErrorLoggingMiddleware: forwards unhandled errors with error.type, error.message, error.stack_trace to Elasticsearch
- Add scripts/setup-elk-index-template.ts: one-time ILM policy + index template + bootstrap alias setup (npm run elk:setup)
- Add docs/logging-examples/logstash-pipeline.conf: full Logstash pipeline with field normalisation, redaction, and ILM output
- Update docs/logging-examples/filebeat.yml: container input, JSON decode, level mapping, ECS service metadata, ILM config
- Update docs/logging-examples/kibana-dashboard.json: importable dashboard with error rate, latency percentiles, top endpoints, log levels
- Update docs/logging-examples/ilm-policy.json: hot/warm/cold/delete lifecycle (hot 1d rollover, warm 7d, cold 30d, delete 90d)
- Add ELK_BATCH_SIZE, ELK_FLUSH_INTERVAL_MS, ELK_MAX_RETRIES env vars
- Add elk:setup npm script
- Add unit tests for ELKTransport and toECSDocument

Closes #740 