### PR TITLE
feat: add personalized role-based insight generation pipeline

### DIFF
--- a/database/migrations/108_add_analytics_insights_audience.sql
+++ b/database/migrations/108_add_analytics_insights_audience.sql
@@ -1,0 +1,57 @@
+-- =============================================================================
+-- Migration: 108_add_analytics_insights_audience.sql
+-- Description: Add role-based targeting columns to analytics_insights for
+--              personalized per-user insight delivery
+-- =============================================================================
+
+-- Audience for insight visibility: admin | mentor | learner | all
+ALTER TABLE analytics_insights
+    ADD COLUMN IF NOT EXISTS target_audience VARCHAR(20) NOT NULL DEFAULT 'all';
+
+ALTER TABLE analytics_insights
+    DROP CONSTRAINT IF EXISTS check_analytics_insights_target_audience;
+
+ALTER TABLE analytics_insights
+    ADD CONSTRAINT check_analytics_insights_target_audience
+    CHECK (target_audience IN ('admin', 'mentor', 'learner', 'all'));
+
+-- Owner of a personalized insight (NULL = platform-wide)
+ALTER TABLE analytics_insights
+    ADD COLUMN IF NOT EXISTS user_id UUID REFERENCES users(id) ON DELETE CASCADE;
+
+-- Entity the insight is about (mentor or learner subject)
+ALTER TABLE analytics_insights
+    ADD COLUMN IF NOT EXISTS entity_id UUID REFERENCES users(id) ON DELETE SET NULL;
+
+-- Backfill existing platform insights as admin-only (they contain revenue/growth data)
+UPDATE analytics_insights
+SET target_audience = 'admin'
+WHERE user_id IS NULL
+  AND target_audience = 'all'
+  AND (
+    metric_name ILIKE '%revenue%'
+    OR metric_name ILIKE '%growth%'
+    OR title ILIKE '%revenue%'
+    OR title ILIKE '%user growth%'
+  );
+
+CREATE INDEX IF NOT EXISTS idx_analytics_insights_user_id
+    ON analytics_insights (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_analytics_insights_audience
+    ON analytics_insights (target_audience, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_analytics_insights_entity_id
+    ON analytics_insights (entity_id)
+    WHERE entity_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_analytics_insights_user_unread
+    ON analytics_insights (user_id, created_at DESC)
+    WHERE is_read = false AND user_id IS NOT NULL;
+
+COMMENT ON COLUMN analytics_insights.target_audience IS
+    'Who may see this insight: admin, mentor, learner, or all';
+COMMENT ON COLUMN analytics_insights.user_id IS
+    'Personalized recipient; NULL means platform-wide (filtered by target_audience)';
+COMMENT ON COLUMN analytics_insights.entity_id IS
+    'The mentor or learner the insight is about';

--- a/docs/analytics-insights.md
+++ b/docs/analytics-insights.md
@@ -1,0 +1,52 @@
+# Analytics Insights — Generation Methodology
+
+Migration `108_add_analytics_insights_audience.sql` adds role-based targeting to `analytics_insights`:
+
+| Column | Purpose |
+|--------|---------|
+| `target_audience` | `admin` \| `mentor` \| `learner` \| `all` |
+| `user_id` | Personalized recipient (`NULL` = platform-wide) |
+| `entity_id` | Mentor/learner the insight is about |
+
+## Pipeline
+
+1. **Scheduler** (`scheduler.ts`) enqueues `insight-generation-scheduled` every **6 hours** (`0 */6 * * *`).
+2. **Worker** (`insight-generation.worker.ts`) runs `InsightGeneratorService.generateInsights()`.
+3. Admin/platform insights are generated once and stored with `target_audience = 'admin'`, `user_id = NULL`.
+4. One BullMQ job is enqueued per active user (`insight-generation-user`) and processed at concurrency **20** (SLA: ~1,000 users within 10 minutes).
+5. On insert, `SocketService` emits `insight:new` to `user:{userId}` (or the `admin` room for platform insights).
+6. Per user, only the **20 most recent unread** insights are kept; older unread rows are auto-marked read.
+
+## Role-based signals
+
+### Admin (platform-wide)
+- Revenue trend from `mv_daily_revenue` (30d linear slope)
+- Session completion anomalies from `mv_session_stats` (z-score > 2)
+- User growth anomalies (weekly signup counts)
+- Rule-based recommendations from `AdvancedAnalyticsService.getMetrics`
+
+### Mentor (personal — `user_id = mentor`)
+- Own session completion rate MoM
+- Earnings trend (`bookings.mentor_payout`)
+- Review rating trend (`reviews.reviewee_id`)
+- Booking inquiry volume WoW
+
+### Learner (personal — `user_id = mentee`, audience `learner`)
+- Session attendance rate (30d)
+- Goal progress velocity (`learner_goals` + `goal_progress_logs`)
+- Personal spending trend (never platform revenue)
+- Recommended next session hour from completed booking history
+
+## Read path
+
+`getInsights(userId)` joins `users` and returns:
+
+- rows where `user_id = $1` (personal), **or**
+- platform rows (`user_id IS NULL`) whose `target_audience` matches the caller’s role (`mentee` → `learner`)
+
+Mentor A cannot see Mentor B’s personal insights. Learners are additionally filtered so revenue / admin metrics never appear.
+
+## Consumers
+
+- `AdvancedAnalyticsService.getInsights` → dashboard payload
+- Socket.IO event `insight:new` (see `docs/websocket.md`)

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -169,3 +169,30 @@ function connect() {
 When `REDIS_URL` is set, all published events go through the `mm:ws:events` Redis channel. This allows multiple server instances to deliver messages to the correct client regardless of which instance holds the connection.
 
 If Redis is unavailable, delivery falls back to in-process routing (single-instance only).
+
+---
+
+## Socket.IO — `insight:new`
+
+Emitted by `InsightGeneratorService` when a new analytics insight is stored (see `docs/analytics-insights.md`).
+
+| Recipient | Room |
+|-----------|------|
+| Personalized mentor/learner insight | `user:{userId}` |
+| Platform admin insight | `admin` |
+
+```json
+{
+  "id": "uuid",
+  "type": "trend",
+  "severity": "warning",
+  "title": "Your session completion declined",
+  "description": "Your sessions declined 20% this month (65% vs 85% last month)",
+  "metricName": "mentor_session_completion",
+  "metricValue": -20,
+  "targetAudience": "mentor",
+  "userId": "uuid",
+  "entityId": "uuid",
+  "createdAt": "2026-07-29T20:00:00.000Z"
+}
+```

--- a/src/config/queue.ts
+++ b/src/config/queue.ts
@@ -56,6 +56,7 @@ export const QUEUE_NAMES = {
   ANALYTICS_REFRESH: "analytics-refresh-queue",
   QUALITY_SCORE: "quality-score-queue",
   CDN_INVALIDATION: "cdn-invalidation-queue",
+  INSIGHT_GENERATION: "insight-generation-queue",
 } as const;
 
 export type QueueName = (typeof QUEUE_NAMES)[keyof typeof QUEUE_NAMES];
@@ -113,4 +114,6 @@ export const CONCURRENCY = {
   TRANSCRIPTION: 5,
   QUALITY_SCORE: 1,
   CDN_INVALIDATION: 5,
+  /** Parallel per-user insight jobs — supports ~1k users within 10 minutes */
+  INSIGHT_GENERATION: 20,
 } as const;

--- a/src/queues/insightGeneration.queue.ts
+++ b/src/queues/insightGeneration.queue.ts
@@ -1,0 +1,22 @@
+import { Queue } from "bullmq";
+import { redisConnection, defaultJobOptions, QUEUE_NAMES } from "./queue.config";
+
+export const INSIGHT_GENERATION_QUEUE = QUEUE_NAMES.INSIGHT_GENERATION;
+
+export type InsightGenerationJobType =
+  | "insight-generation-dispatch"
+  | "insight-generation-admin"
+  | "insight-generation-user";
+
+export interface InsightGenerationJobData {
+  jobType: InsightGenerationJobType;
+  /** Present when jobType === 'insight-generation-user' */
+  userId?: string;
+  /** DB role: admin | mentor | mentee */
+  role?: string;
+}
+
+export const insightGenerationQueue = new Queue<InsightGenerationJobData>(
+  INSIGHT_GENERATION_QUEUE,
+  { connection: redisConnection, defaultJobOptions },
+);

--- a/src/services/advanced-analytics.service.ts
+++ b/src/services/advanced-analytics.service.ts
@@ -71,6 +71,9 @@ export interface Insight {
   metricValue?: number;
   createdAt: string;
   isRead: boolean;
+  targetAudience?: "admin" | "mentor" | "learner" | "all";
+  userId?: string | null;
+  entityId?: string | null;
 }
 
 export interface CurrencyBreakdown {

--- a/src/services/insight-generator.service.ts
+++ b/src/services/insight-generator.service.ts
@@ -1,334 +1,954 @@
+/**
+ * InsightGeneratorService
+ *
+ * Role-based analytics insight generation and personalized delivery.
+ *
+ * Methodology: see docs/analytics-insights.md
+ */
+
+import { randomUUID } from "crypto";
 import pool from "../config/database";
 import { logger } from "../utils/logger";
 import { AdvancedAnalyticsService, Insight } from "./advanced-analytics.service";
+import { SocketService } from "./socket.service";
+import { insightGenerationQueue } from "../queues/insightGeneration.queue";
 
-export interface TrendInsight {
-  type: 'trend';
-  direction: 'up' | 'down' | 'stable';
-  magnitude: number;
-  significance: 'low' | 'medium' | 'high';
+export type InsightAudience = "admin" | "mentor" | "learner" | "all";
+
+export interface StoredInsight extends Insight {
+  targetAudience: InsightAudience;
+  userId: string | null;
+  entityId: string | null;
 }
 
-export interface AnomalyInsight {
-  type: 'anomaly';
-  deviation: number;
-  expectedValue: number;
-  actualValue: number;
+const MAX_UNREAD_PER_USER = 20;
+const INSIGHT_TTL_DAYS = 30;
+
+/** Map DB user.role → insight target_audience */
+function roleToAudience(role: string): InsightAudience {
+  if (role === "admin") return "admin";
+  if (role === "mentor") return "mentor";
+  return "learner"; // mentee / learner
 }
 
-export interface RecommendationInsight {
-  type: 'recommendation';
-  category: 'performance' | 'growth' | 'efficiency';
-  priority: 'low' | 'medium' | 'high';
-  actionItems: string[];
+function makeInsight(
+  partial: Omit<StoredInsight, "id" | "createdAt" | "isRead"> & {
+    id?: string;
+  },
+): StoredInsight {
+  return {
+    id: partial.id ?? randomUUID(),
+    type: partial.type,
+    severity: partial.severity,
+    title: partial.title,
+    description: partial.description,
+    metricName: partial.metricName,
+    metricValue: partial.metricValue,
+    createdAt: new Date().toISOString(),
+    isRead: false,
+    targetAudience: partial.targetAudience,
+    userId: partial.userId,
+    entityId: partial.entityId,
+  };
 }
 
 export const InsightGeneratorService = {
   /**
-   * Analyze metrics and generate insights
+   * Entry point for the scheduled pipeline.
+   * Generates platform admin insights immediately, then enqueues one job per
+   * active user so the worker can personalize in parallel (SLA: 1k users / 10m).
    */
-  async generateInsights(): Promise<Insight[]> {
-    try {
-      logger.info('Starting insight generation');
-      
-      const insights: Insight[] = [];
-      
-      // Get current metrics
-      const metrics = await AdvancedAnalyticsService.getMetrics('admin', '30d');
-      
-      // Generate different types of insights
-      const trendInsights = await this.detectTrends('revenue', []);
-      const anomalyInsights = await this.detectAnomalies('sessions', []);
-      const recommendations = await this.generateRecommendations(metrics);
-      
-      insights.push(...trendInsights, ...anomalyInsights, ...recommendations);
-      
-      // Store insights in database
-      await this.storeInsights(insights);
-      
-      logger.info('Insight generation completed', { count: insights.length });
-      return insights;
-    } catch (error) {
-      logger.error('Failed to generate insights', { error });
-      throw error;
+  async generateInsights(): Promise<{ adminCount: number; usersEnqueued: number }> {
+    const startedAt = Date.now();
+    logger.info("Starting insight generation pipeline");
+
+    const adminInsights = await this.generateAdminInsights();
+    await this.storeInsights(adminInsights);
+    await this.capPlatformUnreadInsights("admin");
+
+    const { rows: users } = await pool.query<{ id: string; role: string }>(
+      `SELECT id, role::text AS role
+       FROM users
+       WHERE is_active = true
+         AND role IN ('mentor', 'mentee')
+         AND deleted_at IS NULL`,
+    );
+
+    // Admins already received platform insights; still enqueue for personal ones if any.
+    // Mentors/learners get personalized jobs.
+    let usersEnqueued = 0;
+    const jobs = users.map((u) => ({
+      name: "insight-generation-user",
+      data: {
+        jobType: "insight-generation-user" as const,
+        userId: u.id,
+        role: u.role,
+      },
+      opts: {
+        removeOnComplete: 100,
+        removeOnFail: 50,
+        attempts: 2,
+      },
+    }));
+
+    if (jobs.length > 0) {
+      // BullMQ supports bulk add for throughput
+      const chunkSize = 200;
+      for (let i = 0; i < jobs.length; i += chunkSize) {
+        await insightGenerationQueue.addBulk(jobs.slice(i, i + chunkSize));
+        usersEnqueued += Math.min(chunkSize, jobs.length - i);
+      }
     }
+
+    logger.info("Insight generation dispatch completed", {
+      adminCount: adminInsights.length,
+      usersEnqueued,
+      durationMs: Date.now() - startedAt,
+    });
+
+    return { adminCount: adminInsights.length, usersEnqueued };
   },
 
   /**
-   * Detect trends in time series data
+   * Generate + store + emit insights for a single user based on role.
    */
-  async detectTrends(metricName: string, data: any[]): Promise<Insight[]> {
+  async generateInsightsForUser(userId: string, role: string): Promise<StoredInsight[]> {
+    const audience = roleToAudience(role);
+    let insights: StoredInsight[] = [];
+
+    if (audience === "mentor") {
+      insights = await this.generateMentorInsights(userId);
+    } else if (audience === "learner") {
+      insights = await this.generateLearnerInsights(userId);
+    } else if (audience === "admin") {
+      // Admins primarily get platform insights (generated once per cycle).
+      // Skip duplicate personal admin noise unless they also mentor (rare).
+      insights = [];
+    }
+
+    if (insights.length > 0) {
+      await this.storeInsights(insights);
+      await this.capUnreadInsights(userId);
+    }
+
+    return insights;
+  },
+
+  // ── Admin / platform ──────────────────────────────────────────────────────
+
+  async generateAdminInsights(): Promise<StoredInsight[]> {
+    const insights: StoredInsight[] = [];
+
     try {
-      // Get revenue trend data
-      const query = `
-        SELECT date, SUM(total_amount) as value
+      const metrics = await AdvancedAnalyticsService.getMetrics("admin", "30d");
+      insights.push(...(await this.detectPlatformRevenueTrends()));
+      insights.push(...(await this.detectSessionCompletionAnomalies()));
+      insights.push(...(await this.detectUserGrowthAnomalies()));
+      insights.push(...this.buildAdminRecommendations(metrics));
+    } catch (error) {
+      logger.error("Failed to generate admin insights", { error });
+    }
+
+    return insights.map((i) => ({
+      ...i,
+      targetAudience: "admin" as const,
+      userId: null,
+      entityId: null,
+    }));
+  },
+
+  async detectPlatformRevenueTrends(): Promise<StoredInsight[]> {
+    try {
+      const { rows } = await pool.query<{ date: string; value: string }>(`
+        SELECT date, SUM(total_amount)::text AS value
         FROM mv_daily_revenue
         WHERE date >= CURRENT_DATE - INTERVAL '30 days'
         GROUP BY date
         ORDER BY date
-      `;
-      
-      const { rows } = await pool.query(query);
-      
+      `);
+
       if (rows.length < 7) return [];
-      
-      // Calculate trend
-      const values = rows.map(r => parseFloat(r.value || '0'));
+
+      const values = rows.map((r) => parseFloat(r.value || "0"));
       const trend = this.calculateTrend(values);
-      
-      const insights: Insight[] = [];
-      
-      if (Math.abs(trend.slope) > 0.1) { // Significant trend
-        insights.push({
-          id: `trend_${metricName}_${Date.now()}`,
-          type: 'trend',
-          severity: trend.slope > 0.2 ? 'info' : trend.slope < -0.2 ? 'warning' : 'info',
-          title: `${metricName} Trend Detected`,
-          description: `${metricName} is ${trend.slope > 0 ? 'increasing' : 'decreasing'} by ${Math.abs(trend.slope * 100).toFixed(1)}% over the last 30 days`,
-          metricName,
+      if (Math.abs(trend.slope) <= 0.1) return [];
+
+      const pct = Math.abs(trend.slope * 100).toFixed(1);
+      return [
+        makeInsight({
+          type: "trend",
+          severity: trend.slope < -0.2 ? "warning" : "info",
+          title: "Platform Revenue Trend",
+          description: `Platform revenue is ${trend.slope > 0 ? "up" : "down"} approximately ${pct}% over the last 30 days`,
+          metricName: "platform_revenue",
           metricValue: trend.slope,
-          createdAt: new Date().toISOString(),
-          isRead: false
-        });
-      }
-      
-      return insights;
+          targetAudience: "admin",
+          userId: null,
+          entityId: null,
+        }),
+      ];
     } catch (error) {
-      logger.error('Failed to detect trends', { error, metricName });
+      logger.error("Failed to detect platform revenue trends", { error });
       return [];
     }
   },
 
-  /**
-   * Detect anomalies using statistical methods
-   */
-  async detectAnomalies(metricName: string, data: any[]): Promise<Insight[]> {
+  async detectSessionCompletionAnomalies(): Promise<StoredInsight[]> {
     try {
-      // Get session completion rate data
-      const query = `
-        SELECT 
+      const { rows } = await pool.query<{ date: string; completion_rate: string }>(`
+        SELECT
           date,
-          CASE 
-            WHEN SUM(session_count) > 0 THEN 
+          CASE
+            WHEN SUM(session_count) > 0 THEN
               SUM(session_count) FILTER (WHERE status = 'completed')::float / SUM(session_count) * 100
-            ELSE 0 
-          END as completion_rate
+            ELSE 0
+          END::text AS completion_rate
         FROM mv_session_stats
         WHERE date >= CURRENT_DATE - INTERVAL '30 days'
         GROUP BY date
         ORDER BY date
-      `;
-      
-      const { rows } = await pool.query(query);
-      
+      `);
+
       if (rows.length < 7) return [];
-      
-      const values = rows.map(r => parseFloat(r.completion_rate || '0'));
+
+      const values = rows.map((r) => parseFloat(r.completion_rate || "0"));
       const anomalies = this.detectStatisticalAnomalies(values);
-      
-      const insights: Insight[] = [];
-      
-      if (anomalies.length > 0) {
-        const latestAnomaly = anomalies[anomalies.length - 1];
-        
-        insights.push({
-          id: `anomaly_${metricName}_${Date.now()}`,
-          type: 'anomaly',
-          severity: Math.abs(latestAnomaly.deviation) > 2 ? 'critical' : 'warning',
-          title: `${metricName} Anomaly Detected`,
-          description: `${metricName} completion rate is ${latestAnomaly.deviation > 0 ? 'unusually high' : 'unusually low'} (${latestAnomaly.value.toFixed(1)}% vs expected ${latestAnomaly.expected.toFixed(1)}%)`,
-          metricName,
-          metricValue: latestAnomaly.value,
-          createdAt: new Date().toISOString(),
-          isRead: false
-        });
-      }
-      
-      return insights;
+      if (anomalies.length === 0) return [];
+
+      const latest = anomalies[anomalies.length - 1];
+      return [
+        makeInsight({
+          type: "anomaly",
+          severity: Math.abs(latest.deviation) > 2.5 ? "critical" : "warning",
+          title: "Session Completion Rate Drop",
+          description: `Platform session completion rate is ${latest.deviation > 0 ? "unusually high" : "unusually low"} (${latest.value.toFixed(1)}% vs expected ${latest.expected.toFixed(1)}%)`,
+          metricName: "session_completion_rate",
+          metricValue: latest.value,
+          targetAudience: "admin",
+          userId: null,
+          entityId: null,
+        }),
+      ];
     } catch (error) {
-      logger.error('Failed to detect anomalies', { error, metricName });
+      logger.error("Failed to detect session completion anomalies", { error });
       return [];
     }
   },
 
-  /**
-   * Generate actionable recommendations
-   */
-  async generateRecommendations(metrics: any): Promise<Insight[]> {
-    const recommendations: Insight[] = [];
-    
+  async detectUserGrowthAnomalies(): Promise<StoredInsight[]> {
     try {
-      // Revenue recommendations
-      if (metrics.revenue.growthRate < 0) {
-        recommendations.push({
-          id: `rec_revenue_${Date.now()}`,
-          type: 'recommendation',
-          severity: 'warning',
-          title: 'Revenue Decline Detected',
-          description: 'Consider implementing promotional campaigns or reviewing pricing strategy to boost revenue',
-          metricName: 'revenue_growth',
-          metricValue: metrics.revenue.growthRate,
-          createdAt: new Date().toISOString(),
-          isRead: false
-        });
-      }
-      
-      // Session recommendations
-      if (metrics.sessions.completionRate < 80) {
-        recommendations.push({
-          id: `rec_sessions_${Date.now()}`,
-          type: 'recommendation',
-          severity: 'info',
-          title: 'Session Completion Rate Below Target',
-          description: 'Focus on mentor training and session quality improvements to increase completion rates',
-          metricName: 'completion_rate',
-          metricValue: metrics.sessions.completionRate,
-          createdAt: new Date().toISOString(),
-          isRead: false
-        });
-      }
-      
-      // Growth recommendations
-      if (metrics.growth.userGrowthRate < 5) {
-        recommendations.push({
-          id: `rec_growth_${Date.now()}`,
-          type: 'recommendation',
-          severity: 'info',
-          title: 'User Growth Opportunity',
-          description: 'Consider expanding marketing efforts or referral programs to accelerate user acquisition',
-          metricName: 'user_growth',
-          metricValue: metrics.growth.userGrowthRate,
-          createdAt: new Date().toISOString(),
-          isRead: false
-        });
-      }
-      
-      return recommendations;
+      const { rows } = await pool.query<{ week: string; new_users: string }>(`
+        SELECT date_trunc('week', created_at)::date::text AS week,
+               COUNT(*)::text AS new_users
+        FROM users
+        WHERE created_at >= CURRENT_DATE - INTERVAL '56 days'
+          AND deleted_at IS NULL
+        GROUP BY 1
+        ORDER BY 1
+      `);
+
+      if (rows.length < 4) return [];
+
+      const values = rows.map((r) => parseFloat(r.new_users || "0"));
+      const anomalies = this.detectStatisticalAnomalies(values);
+      if (anomalies.length === 0) return [];
+
+      const latest = anomalies[anomalies.length - 1];
+      return [
+        makeInsight({
+          type: "anomaly",
+          severity: latest.deviation < -2 ? "warning" : "info",
+          title: "User Growth Anomaly",
+          description: `New user signups are ${latest.deviation < 0 ? "below" : "above"} the recent weekly baseline (${latest.value.toFixed(0)} vs expected ${latest.expected.toFixed(0)})`,
+          metricName: "user_growth",
+          metricValue: latest.value,
+          targetAudience: "admin",
+          userId: null,
+          entityId: null,
+        }),
+      ];
     } catch (error) {
-      logger.error('Failed to generate recommendations', { error });
+      logger.error("Failed to detect user growth anomalies", { error });
       return [];
     }
   },
 
+  buildAdminRecommendations(metrics: any): StoredInsight[] {
+    const out: StoredInsight[] = [];
+
+    try {
+      if (metrics?.revenue?.growthRate < 0) {
+        out.push(
+          makeInsight({
+            type: "recommendation",
+            severity: "warning",
+            title: "Revenue Decline Detected",
+            description:
+              "Consider promotional campaigns or pricing review to reverse the platform revenue decline",
+            metricName: "revenue_growth",
+            metricValue: metrics.revenue.growthRate,
+            targetAudience: "admin",
+            userId: null,
+            entityId: null,
+          }),
+        );
+      }
+
+      if (metrics?.sessions?.completionRate < 80) {
+        out.push(
+          makeInsight({
+            type: "recommendation",
+            severity: "info",
+            title: "Session Completion Rate Below Target",
+            description:
+              "Platform completion rate is below 80%. Focus on mentor training and session quality",
+            metricName: "completion_rate",
+            metricValue: metrics.sessions.completionRate,
+            targetAudience: "admin",
+            userId: null,
+            entityId: null,
+          }),
+        );
+      }
+
+      if (metrics?.growth?.userGrowthRate < 5) {
+        out.push(
+          makeInsight({
+            type: "recommendation",
+            severity: "info",
+            title: "User Growth Opportunity",
+            description:
+              "User growth is under 5%. Consider expanding marketing or referral programs",
+            metricName: "user_growth",
+            metricValue: metrics.growth.userGrowthRate,
+            targetAudience: "admin",
+            userId: null,
+            entityId: null,
+          }),
+        );
+      }
+    } catch (error) {
+      logger.error("Failed to build admin recommendations", { error });
+    }
+
+    return out;
+  },
+
+  // ── Mentor ────────────────────────────────────────────────────────────────
+
+  async generateMentorInsights(mentorId: string): Promise<StoredInsight[]> {
+    const insights: StoredInsight[] = [];
+
+    try {
+      // Session completion rate (this month vs last month)
+      const { rows: completionRows } = await pool.query<{
+        period: string;
+        total: string;
+        completed: string;
+      }>(
+        `SELECT
+           CASE
+             WHEN scheduled_start >= date_trunc('month', CURRENT_DATE) THEN 'current'
+             ELSE 'previous'
+           END AS period,
+           COUNT(*)::text AS total,
+           COUNT(*) FILTER (WHERE status = 'completed')::text AS completed
+         FROM bookings
+         WHERE mentor_id = $1
+           AND scheduled_start >= date_trunc('month', CURRENT_DATE) - INTERVAL '1 month'
+           AND scheduled_start < date_trunc('month', CURRENT_DATE) + INTERVAL '1 month'
+         GROUP BY 1`,
+        [mentorId],
+      );
+
+      const current = completionRows.find((r) => r.period === "current");
+      const previous = completionRows.find((r) => r.period === "previous");
+      if (current && previous) {
+        const curRate =
+          parseInt(current.total, 10) > 0
+            ? (parseInt(current.completed, 10) / parseInt(current.total, 10)) * 100
+            : 0;
+        const prevRate =
+          parseInt(previous.total, 10) > 0
+            ? (parseInt(previous.completed, 10) / parseInt(previous.total, 10)) * 100
+            : 0;
+        const delta = curRate - prevRate;
+        if (Math.abs(delta) >= 10 && parseInt(previous.total, 10) >= 2) {
+          insights.push(
+            makeInsight({
+              type: "trend",
+              severity: delta < 0 ? "warning" : "info",
+              title:
+                delta < 0
+                  ? "Your session completion declined"
+                  : "Your session completion improved",
+              description: `Your sessions ${delta < 0 ? "declined" : "increased"} ${Math.abs(delta).toFixed(0)}% this month (${curRate.toFixed(0)}% vs ${prevRate.toFixed(0)}% last month)`,
+              metricName: "mentor_session_completion",
+              metricValue: delta,
+              targetAudience: "mentor",
+              userId: mentorId,
+              entityId: mentorId,
+            }),
+          );
+        }
+      }
+
+      // Earnings trend
+      const { rows: earningsRows } = await pool.query<{ period: string; earnings: string }>(
+        `SELECT
+           CASE
+             WHEN completed_at >= date_trunc('month', CURRENT_DATE) THEN 'current'
+             ELSE 'previous'
+           END AS period,
+           COALESCE(SUM(mentor_payout), 0)::text AS earnings
+         FROM bookings
+         WHERE mentor_id = $1
+           AND status = 'completed'
+           AND completed_at >= date_trunc('month', CURRENT_DATE) - INTERVAL '1 month'
+           AND completed_at < date_trunc('month', CURRENT_DATE) + INTERVAL '1 month'
+         GROUP BY 1`,
+        [mentorId],
+      );
+
+      const curEarn = parseFloat(
+        earningsRows.find((r) => r.period === "current")?.earnings || "0",
+      );
+      const prevEarn = parseFloat(
+        earningsRows.find((r) => r.period === "previous")?.earnings || "0",
+      );
+      if (prevEarn > 0) {
+        const earnDeltaPct = ((curEarn - prevEarn) / prevEarn) * 100;
+        if (Math.abs(earnDeltaPct) >= 15) {
+          insights.push(
+            makeInsight({
+              type: "trend",
+              severity: earnDeltaPct < 0 ? "warning" : "info",
+              title: "Your earnings trend",
+              description: `Your earnings are ${earnDeltaPct > 0 ? "up" : "down"} ${Math.abs(earnDeltaPct).toFixed(0)}% this month versus last month`,
+              metricName: "mentor_earnings",
+              metricValue: earnDeltaPct,
+              targetAudience: "mentor",
+              userId: mentorId,
+              entityId: mentorId,
+            }),
+          );
+        }
+      }
+
+      // Review rating trend (30d vs prior 30d)
+      const { rows: ratingRows } = await pool.query<{ period: string; avg_rating: string; cnt: string }>(
+        `SELECT
+           CASE
+             WHEN created_at >= CURRENT_DATE - INTERVAL '30 days' THEN 'current'
+             ELSE 'previous'
+           END AS period,
+           AVG(rating)::text AS avg_rating,
+           COUNT(*)::text AS cnt
+         FROM reviews
+         WHERE reviewee_id = $1
+           AND is_published = true
+           AND created_at >= CURRENT_DATE - INTERVAL '60 days'
+         GROUP BY 1`,
+        [mentorId],
+      );
+
+      const curRating = ratingRows.find((r) => r.period === "current");
+      const prevRating = ratingRows.find((r) => r.period === "previous");
+      if (curRating && prevRating && parseInt(prevRating.cnt, 10) >= 2) {
+        const delta =
+          parseFloat(curRating.avg_rating) - parseFloat(prevRating.avg_rating);
+        if (Math.abs(delta) >= 0.3) {
+          insights.push(
+            makeInsight({
+              type: "trend",
+              severity: delta < 0 ? "warning" : "info",
+              title: "Your review rating trend",
+              description: `Your average rating ${delta < 0 ? "dropped" : "rose"} by ${Math.abs(delta).toFixed(1)} points over the last 30 days`,
+              metricName: "mentor_rating_trend",
+              metricValue: delta,
+              targetAudience: "mentor",
+              userId: mentorId,
+              entityId: mentorId,
+            }),
+          );
+        }
+      }
+
+      // Booking inquiry volume (pending bookings this week vs last)
+      const { rows: inquiryRows } = await pool.query<{ period: string; cnt: string }>(
+        `SELECT
+           CASE
+             WHEN created_at >= date_trunc('week', CURRENT_DATE) THEN 'current'
+             ELSE 'previous'
+           END AS period,
+           COUNT(*)::text AS cnt
+         FROM bookings
+         WHERE mentor_id = $1
+           AND created_at >= date_trunc('week', CURRENT_DATE) - INTERVAL '1 week'
+           AND created_at < date_trunc('week', CURRENT_DATE) + INTERVAL '1 week'
+         GROUP BY 1`,
+        [mentorId],
+      );
+
+      const curInq = parseInt(
+        inquiryRows.find((r) => r.period === "current")?.cnt || "0",
+        10,
+      );
+      const prevInq = parseInt(
+        inquiryRows.find((r) => r.period === "previous")?.cnt || "0",
+        10,
+      );
+      if (prevInq > 0) {
+        const inqDeltaPct = ((curInq - prevInq) / prevInq) * 100;
+        if (Math.abs(inqDeltaPct) >= 25) {
+          insights.push(
+            makeInsight({
+              type: "trend",
+              severity: "info",
+              title: "Booking inquiry volume",
+              description: `New booking requests are ${inqDeltaPct > 0 ? "up" : "down"} ${Math.abs(inqDeltaPct).toFixed(0)}% this week`,
+              metricName: "mentor_booking_inquiries",
+              metricValue: inqDeltaPct,
+              targetAudience: "mentor",
+              userId: mentorId,
+              entityId: mentorId,
+            }),
+          );
+        }
+      }
+    } catch (error) {
+      logger.error("Failed to generate mentor insights", { error, mentorId });
+    }
+
+    return insights;
+  },
+
+  // ── Learner ───────────────────────────────────────────────────────────────
+
+  async generateLearnerInsights(learnerId: string): Promise<StoredInsight[]> {
+    const insights: StoredInsight[] = [];
+
+    try {
+      // Session attendance rate (completed vs no_show/cancelled by learner)
+      const { rows: attendanceRows } = await pool.query<{
+        total: string;
+        attended: string;
+        no_shows: string;
+      }>(
+        `SELECT
+           COUNT(*) FILTER (WHERE status IN ('completed', 'no_show', 'cancelled'))::text AS total,
+           COUNT(*) FILTER (WHERE status = 'completed')::text AS attended,
+           COUNT(*) FILTER (WHERE status = 'no_show')::text AS no_shows
+         FROM bookings
+         WHERE mentee_id = $1
+           AND scheduled_start >= CURRENT_DATE - INTERVAL '30 days'
+           AND scheduled_start < CURRENT_DATE`,
+        [learnerId],
+      );
+
+      const total = parseInt(attendanceRows[0]?.total || "0", 10);
+      const attended = parseInt(attendanceRows[0]?.attended || "0", 10);
+      if (total >= 3) {
+        const rate = (attended / total) * 100;
+        if (rate < 80) {
+          insights.push(
+            makeInsight({
+              type: "anomaly",
+              severity: rate < 60 ? "warning" : "info",
+              title: "Your session attendance rate",
+              description: `You've attended ${rate.toFixed(0)}% of scheduled sessions in the last 30 days. Aim for 80%+ to stay on track`,
+              metricName: "learner_attendance_rate",
+              metricValue: rate,
+              targetAudience: "learner",
+              userId: learnerId,
+              entityId: learnerId,
+            }),
+          );
+        }
+      }
+
+      // Goal progress velocity
+      const { rows: goalRows } = await pool.query<{
+        avg_progress: string;
+        goal_count: string;
+        recent_updates: string;
+      }>(
+        `SELECT
+           COALESCE(AVG(g.progress), 0)::text AS avg_progress,
+           COUNT(*)::text AS goal_count,
+           (
+             SELECT COUNT(*)::text
+             FROM goal_progress_logs gpl
+             JOIN learner_goals lg ON lg.id = gpl.goal_id
+             WHERE lg.learner_id = $1
+               AND gpl.created_at >= CURRENT_DATE - INTERVAL '14 days'
+           ) AS recent_updates
+         FROM learner_goals g
+         WHERE g.learner_id = $1 AND g.status = 'active'`,
+        [learnerId],
+      );
+
+      const avgProgress = parseFloat(goalRows[0]?.avg_progress || "0");
+      const goalCount = parseInt(goalRows[0]?.goal_count || "0", 10);
+      const recentUpdates = parseInt(goalRows[0]?.recent_updates || "0", 10);
+      if (goalCount > 0 && avgProgress < 40 && recentUpdates === 0) {
+        insights.push(
+          makeInsight({
+            type: "recommendation",
+            severity: "info",
+            title: "Goal progress velocity is low",
+            description: `You've been less active than your goal target — average progress is ${avgProgress.toFixed(0)}% with no updates in 14 days. Book a session to regain momentum`,
+            metricName: "learner_goal_velocity",
+            metricValue: avgProgress,
+            targetAudience: "learner",
+            userId: learnerId,
+            entityId: learnerId,
+          }),
+        );
+      }
+
+      // Spending trend (no revenue/admin language — personal spend only)
+      const { rows: spendRows } = await pool.query<{ period: string; spent: string }>(
+        `SELECT
+           CASE
+             WHEN created_at >= date_trunc('month', CURRENT_DATE) THEN 'current'
+             ELSE 'previous'
+           END AS period,
+           COALESCE(SUM(amount), 0)::text AS spent
+         FROM bookings
+         WHERE mentee_id = $1
+           AND status IN ('completed', 'confirmed', 'in_progress')
+           AND created_at >= date_trunc('month', CURRENT_DATE) - INTERVAL '1 month'
+           AND created_at < date_trunc('month', CURRENT_DATE) + INTERVAL '1 month'
+         GROUP BY 1`,
+        [learnerId],
+      );
+
+      const curSpend = parseFloat(
+        spendRows.find((r) => r.period === "current")?.spent || "0",
+      );
+      const prevSpend = parseFloat(
+        spendRows.find((r) => r.period === "previous")?.spent || "0",
+      );
+      if (prevSpend > 0) {
+        const spendDeltaPct = ((curSpend - prevSpend) / prevSpend) * 100;
+        if (Math.abs(spendDeltaPct) >= 20) {
+          insights.push(
+            makeInsight({
+              type: "trend",
+              severity: "info",
+              title: "Your spending trend",
+              description: `Your mentorship spending is ${spendDeltaPct > 0 ? "up" : "down"} ${Math.abs(spendDeltaPct).toFixed(0)}% this month`,
+              metricName: "learner_spending",
+              metricValue: spendDeltaPct,
+              targetAudience: "learner",
+              userId: learnerId,
+              entityId: learnerId,
+            }),
+          );
+        }
+      }
+
+      // Recommended next session time (most common successful hour)
+      const { rows: timeRows } = await pool.query<{ hour: string; cnt: string }>(
+        `SELECT EXTRACT(HOUR FROM scheduled_start AT TIME ZONE COALESCE(timezone, 'UTC'))::int::text AS hour,
+                COUNT(*)::text AS cnt
+         FROM bookings
+         WHERE mentee_id = $1
+           AND status = 'completed'
+           AND scheduled_start >= CURRENT_DATE - INTERVAL '90 days'
+         GROUP BY 1
+         ORDER BY COUNT(*) DESC
+         LIMIT 1`,
+        [learnerId],
+      );
+
+      if (timeRows[0] && parseInt(timeRows[0].cnt, 10) >= 2) {
+        const hour = parseInt(timeRows[0].hour, 10);
+        const label = `${hour % 12 === 0 ? 12 : hour % 12}:00 ${hour < 12 ? "AM" : "PM"}`;
+        insights.push(
+          makeInsight({
+            type: "recommendation",
+            severity: "info",
+            title: "Recommended next session time",
+            description: `Based on your completed sessions, around ${label} tends to work best for you`,
+            metricName: "learner_recommended_session_hour",
+            metricValue: hour,
+            targetAudience: "learner",
+            userId: learnerId,
+            entityId: learnerId,
+          }),
+        );
+      }
+    } catch (error) {
+      logger.error("Failed to generate learner insights", { error, learnerId });
+    }
+
+    return insights;
+  },
+
+  // ── Read path ─────────────────────────────────────────────────────────────
+
   /**
-   * Get insights for user
+   * Return insights visible to this user:
+   * - personal rows where user_id = $1
+   * - platform-wide rows (user_id IS NULL) matching target_audience for their role
+   * Mentors never see other mentors' personal insights; learners never see admin/revenue.
    */
   async getInsights(userId: string, unreadOnly: boolean = false): Promise<Insight[]> {
     try {
       const query = `
-        SELECT *
-        FROM analytics_insights
-        WHERE 1=1
-          ${unreadOnly ? 'AND is_read = false' : ''}
-        ORDER BY created_at DESC
+        SELECT ai.*
+        FROM analytics_insights ai
+        INNER JOIN users u ON u.id = $1
+        WHERE (
+            ai.user_id = $1
+            OR (
+              ai.user_id IS NULL
+              AND (
+                ai.target_audience = 'all'
+                OR (ai.target_audience = 'admin' AND u.role = 'admin')
+                OR (ai.target_audience = 'mentor' AND u.role = 'mentor')
+                OR (ai.target_audience = 'learner' AND u.role = 'mentee')
+              )
+            )
+          )
+          AND (ai.expires_at IS NULL OR ai.expires_at > NOW())
+          ${unreadOnly ? "AND ai.is_read = false" : ""}
+          -- Learners must never receive revenue / admin metric insights
+          AND NOT (
+            u.role = 'mentee'
+            AND (
+              ai.target_audience = 'admin'
+              OR ai.metric_name ILIKE '%revenue%'
+              OR ai.metric_name ILIKE '%platform%'
+            )
+          )
+        ORDER BY ai.created_at DESC
         LIMIT 50
       `;
-      
-      const { rows } = await pool.query(query);
-      
-      return rows.map(row => ({
+
+      const { rows } = await pool.query(query, [userId]);
+
+      return rows.map((row) => ({
         id: row.id,
         type: row.insight_type,
         severity: row.severity,
         title: row.title,
         description: row.description,
         metricName: row.metric_name,
-        metricValue: parseFloat(row.metric_value || '0'),
+        metricValue: parseFloat(row.metric_value || "0"),
         createdAt: row.created_at,
-        isRead: row.is_read
+        isRead: row.is_read,
+        targetAudience: row.target_audience,
+        userId: row.user_id,
+        entityId: row.entity_id,
       }));
     } catch (error) {
-      logger.error('Failed to get insights', { error, userId });
+      logger.error("Failed to get insights", { error, userId });
       return [];
     }
   },
 
-  /**
-   * Mark insight as read
-   */
   async markAsRead(insightId: string): Promise<void> {
     try {
       await pool.query(
-        'UPDATE analytics_insights SET is_read = true WHERE id = $1',
-        [insightId]
+        "UPDATE analytics_insights SET is_read = true WHERE id = $1",
+        [insightId],
       );
     } catch (error) {
-      logger.error('Failed to mark insight as read', { error, insightId });
+      logger.error("Failed to mark insight as read", { error, insightId });
       throw error;
     }
   },
 
-  // Helper methods
+  /**
+   * Keep only the 20 most recent unread insights per user; auto-mark older as read.
+   */
+  async capUnreadInsights(userId: string): Promise<number> {
+    const { rowCount } = await pool.query(
+      `
+      WITH ranked AS (
+        SELECT id,
+               ROW_NUMBER() OVER (ORDER BY created_at DESC) AS rn
+        FROM analytics_insights
+        WHERE user_id = $1 AND is_read = false
+      )
+      UPDATE analytics_insights ai
+      SET is_read = true
+      FROM ranked r
+      WHERE ai.id = r.id AND r.rn > $2
+      `,
+      [userId, MAX_UNREAD_PER_USER],
+    );
+    return rowCount ?? 0;
+  },
+
+  /** Cap unread platform-wide insights for a given audience (e.g. admin). */
+  async capPlatformUnreadInsights(audience: InsightAudience): Promise<number> {
+    const { rowCount } = await pool.query(
+      `
+      WITH ranked AS (
+        SELECT id,
+               ROW_NUMBER() OVER (ORDER BY created_at DESC) AS rn
+        FROM analytics_insights
+        WHERE user_id IS NULL
+          AND target_audience = $1
+          AND is_read = false
+      )
+      UPDATE analytics_insights ai
+      SET is_read = true
+      FROM ranked r
+      WHERE ai.id = r.id AND r.rn > $2
+      `,
+      [audience, MAX_UNREAD_PER_USER],
+    );
+    return rowCount ?? 0;
+  },
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
   calculateTrend(values: number[]): { slope: number; correlation: number } {
     const n = values.length;
     const x = Array.from({ length: n }, (_, i) => i);
     const y = values;
-    
+
     const sumX = x.reduce((a, b) => a + b, 0);
     const sumY = y.reduce((a, b) => a + b, 0);
     const sumXY = x.reduce((sum, xi, i) => sum + xi * y[i], 0);
     const sumXX = x.reduce((sum, xi) => sum + xi * xi, 0);
-    
-    const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
-    
-    // Calculate correlation coefficient
+
+    const denom = n * sumXX - sumX * sumX;
+    const slope = denom === 0 ? 0 : (n * sumXY - sumX * sumY) / denom;
+
     const meanX = sumX / n;
     const meanY = sumY / n;
-    const numerator = x.reduce((sum, xi, i) => sum + (xi - meanX) * (y[i] - meanY), 0);
-    const denomX = Math.sqrt(x.reduce((sum, xi) => sum + Math.pow(xi - meanX, 2), 0));
-    const denomY = Math.sqrt(y.reduce((sum, yi) => sum + Math.pow(yi - meanY, 2), 0));
-    const correlation = numerator / (denomX * denomY);
-    
+    const numerator = x.reduce(
+      (sum, xi, i) => sum + (xi - meanX) * (y[i] - meanY),
+      0,
+    );
+    const denomX = Math.sqrt(
+      x.reduce((sum, xi) => sum + Math.pow(xi - meanX, 2), 0),
+    );
+    const denomY = Math.sqrt(
+      y.reduce((sum, yi) => sum + Math.pow(yi - meanY, 2), 0),
+    );
+    const correlation =
+      denomX === 0 || denomY === 0 ? 0 : numerator / (denomX * denomY);
+
     return { slope, correlation };
   },
 
-  detectStatisticalAnomalies(values: number[]): Array<{ index: number; value: number; expected: number; deviation: number }> {
+  detectStatisticalAnomalies(
+    values: number[],
+  ): Array<{ index: number; value: number; expected: number; deviation: number }> {
     const mean = values.reduce((a, b) => a + b, 0) / values.length;
-    const variance = values.reduce((sum, val) => sum + Math.pow(val - mean, 2), 0) / values.length;
+    const variance =
+      values.reduce((sum, val) => sum + Math.pow(val - mean, 2), 0) /
+      values.length;
     const stdDev = Math.sqrt(variance);
-    
-    const anomalies: any[] = [];
-    
+    if (stdDev === 0) return [];
+
+    const anomalies: Array<{
+      index: number;
+      value: number;
+      expected: number;
+      deviation: number;
+    }> = [];
+
     values.forEach((value, index) => {
       const deviation = (value - mean) / stdDev;
-      
-      if (Math.abs(deviation) > 2) { // 2 standard deviations
-        anomalies.push({
-          index,
-          value,
-          expected: mean,
-          deviation
-        });
+      if (Math.abs(deviation) > 2) {
+        anomalies.push({ index, value, expected: mean, deviation });
       }
     });
-    
+
     return anomalies;
   },
 
-  async storeInsights(insights: Insight[]): Promise<void> {
-    try {
-      for (const insight of insights) {
-        await pool.query(`
+  async storeInsights(insights: StoredInsight[]): Promise<void> {
+    for (const insight of insights) {
+      try {
+        await pool.query(
+          `
           INSERT INTO analytics_insights (
-            id, insight_type, severity, title, description, 
-            metric_name, metric_value, is_read, expires_at
-          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            id, insight_type, severity, title, description,
+            metric_name, metric_value, is_read, expires_at,
+            target_audience, user_id, entity_id
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
           ON CONFLICT (id) DO NOTHING
-        `, [
-          insight.id,
-          insight.type,
-          insight.severity,
-          insight.title,
-          insight.description,
-          insight.metricName,
-          insight.metricValue,
-          insight.isRead,
-          new Date(Date.now() + 30 * 24 * 60 * 60 * 1000) // 30 days from now
-        ]);
+        `,
+          [
+            insight.id,
+            insight.type,
+            insight.severity,
+            insight.title,
+            insight.description,
+            insight.metricName ?? null,
+            insight.metricValue ?? null,
+            insight.isRead,
+            new Date(Date.now() + INSIGHT_TTL_DAYS * 24 * 60 * 60 * 1000),
+            insight.targetAudience,
+            insight.userId,
+            insight.entityId,
+          ],
+        );
+
+        this.emitInsightNew(insight);
+      } catch (error) {
+        logger.error("Failed to store insight", {
+          error,
+          insightId: insight.id,
+        });
+      }
+    }
+  },
+
+  emitInsightNew(insight: StoredInsight): void {
+    const payload = {
+      id: insight.id,
+      type: insight.type,
+      severity: insight.severity,
+      title: insight.title,
+      description: insight.description,
+      metricName: insight.metricName,
+      metricValue: insight.metricValue,
+      targetAudience: insight.targetAudience,
+      userId: insight.userId,
+      entityId: insight.entityId,
+      createdAt: insight.createdAt,
+    };
+
+    try {
+      if (insight.userId) {
+        SocketService.emitToUser(insight.userId, "insight:new", payload);
+      } else if (insight.targetAudience === "admin") {
+        SocketService.emitToRoom("admin", "insight:new", payload);
       }
     } catch (error) {
-      logger.error('Failed to store insights', { error });
-      throw error;
+      logger.warn("Failed to emit insight:new", {
+        error,
+        insightId: insight.id,
+      });
     }
-  }
+  },
+
+  // Backward-compatible wrappers used by older call sites
+  async detectTrends(metricName: string, _data: any[]): Promise<Insight[]> {
+    if (metricName === "revenue") {
+      return this.detectPlatformRevenueTrends();
+    }
+    return [];
+  },
+
+  async detectAnomalies(metricName: string, _data: any[]): Promise<Insight[]> {
+    if (metricName === "sessions") {
+      return this.detectSessionCompletionAnomalies();
+    }
+    return [];
+  },
+
+  async generateRecommendations(metrics: any): Promise<Insight[]> {
+    return this.buildAdminRecommendations(metrics);
+  },
 };

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -21,6 +21,7 @@ const REQUIRED_QUEUE_NAMES = [
     'DOMAIN_EVENTS',
     'RECORDING_CLEANUP',
     'ANALYTICS_REFRESH',
+    'INSIGHT_GENERATION',
 ] as const;
 
 for (const queueKey of REQUIRED_QUEUE_NAMES) {
@@ -54,3 +55,4 @@ export { qualityScoreWorker } from './quality-score.worker';
 export { startRetentionEnforcementWorker, stopRetentionEnforcementWorker } from './retention-enforcement.worker';
 export { recordingCleanupWorker } from './recordingCleanup.worker';
 export { analyticsRefreshWorker } from './analyticsRefresh.worker';
+export { insightGenerationWorker } from './insight-generation.worker';

--- a/src/workers/insight-generation.worker.ts
+++ b/src/workers/insight-generation.worker.ts
@@ -1,0 +1,102 @@
+/**
+ * Insight Generation Worker
+ *
+ * Background pipeline for personalized analytics insights.
+ *
+ * Job types:
+ *  - insight-generation-dispatch: run generateInsights() (admin + fan-out per user)
+ *  - insight-generation-admin:     platform admin insights only
+ *  - insight-generation-user:      personalized insights for one user
+ *
+ * Target SLA: 1,000 active users within 10 minutes (concurrency 20).
+ */
+
+import { Worker, Job } from "bullmq";
+import { redisConnection, CONCURRENCY } from "../config/queue";
+import {
+  InsightGenerationJobData,
+  INSIGHT_GENERATION_QUEUE,
+} from "../queues/insightGeneration.queue";
+import { InsightGeneratorService } from "../services/insight-generator.service";
+import { logger } from "../utils/logger.utils";
+
+async function processInsightGenerationJob(
+  job: Job<InsightGenerationJobData>,
+): Promise<Record<string, unknown>> {
+  const { jobType, userId, role } = job.data;
+  const startedAt = Date.now();
+
+  if (
+    jobType === "insight-generation-dispatch" ||
+    job.name === "insight-generation-scheduled"
+  ) {
+    logger.info("[InsightGenerationWorker] Dispatching insight pipeline", {
+      jobId: job.id,
+    });
+    const result = await InsightGeneratorService.generateInsights();
+    return { ...result, durationMs: Date.now() - startedAt };
+  }
+
+  if (jobType === "insight-generation-admin") {
+    logger.info("[InsightGenerationWorker] Generating admin insights", {
+      jobId: job.id,
+    });
+    const insights = await InsightGeneratorService.generateAdminInsights();
+    await InsightGeneratorService.storeInsights(insights);
+    return { count: insights.length, durationMs: Date.now() - startedAt };
+  }
+
+  if (jobType === "insight-generation-user") {
+    if (!userId || !role) {
+      throw new Error("insight-generation-user requires userId and role");
+    }
+
+    const insights = await InsightGeneratorService.generateInsightsForUser(
+      userId,
+      role,
+    );
+
+    return {
+      userId,
+      role,
+      count: insights.length,
+      durationMs: Date.now() - startedAt,
+    };
+  }
+
+  logger.warn("[InsightGenerationWorker] Unknown job type", {
+    jobId: job.id,
+    jobType,
+    name: job.name,
+  });
+  return { skipped: true };
+}
+
+export const insightGenerationWorker = new Worker<InsightGenerationJobData>(
+  INSIGHT_GENERATION_QUEUE,
+  processInsightGenerationJob,
+  {
+    connection: redisConnection,
+    concurrency: CONCURRENCY.INSIGHT_GENERATION,
+  },
+);
+
+insightGenerationWorker.on("completed", (job) => {
+  logger.debug("[InsightGenerationWorker] Job completed", {
+    jobId: job.id,
+    jobType: job.data.jobType,
+  });
+});
+
+insightGenerationWorker.on("failed", (job, err) => {
+  logger.error("[InsightGenerationWorker] Job failed", {
+    jobId: job?.id,
+    jobType: job?.data?.jobType,
+    attempt: job?.attemptsMade,
+    error: err.message,
+  });
+});
+
+insightGenerationWorker.on("error", (err) => {
+  logger.error("[InsightGenerationWorker] Worker error", { error: err.message });
+});

--- a/src/workers/scheduler.ts
+++ b/src/workers/scheduler.ts
@@ -6,6 +6,7 @@ import { pushTokenCleanupQueue } from "../queues/pushTokenCleanup.queue";
 import { maintenanceQueue } from "../queues/maintenance.queue";
 import { recordingCleanupQueue } from "../queues/recordingCleanup.queue";
 import { analyticsRefreshQueue } from "../queues/analyticsRefresh.queue";
+import { insightGenerationQueue } from "../queues/insightGeneration.queue";
 import { qualityScoreQueue } from "../queues/quality-score.queue";
 import { VerificationService } from "../services/verification.service";
 import { BackgroundCheckService } from "../services/background-check.service";
@@ -193,8 +194,20 @@ export async function startScheduler(): Promise<void> {
     },
   );
 
+  // Personalized insight generation — every 6 hours
+  // Dispatches admin platform insights + one BullMQ job per active user
+  await addRepeatableJobIfNotExists(
+    insightGenerationQueue,
+    "insight-generation-scheduled",
+    { jobType: "insight-generation-dispatch" },
+    {
+      repeat: { pattern: "0 */6 * * *" }, // cron: every 6 hours
+      jobId: "insight-generation-recurring",
+    },
+  );
+
   logger.info(
-    "Job scheduler started — weekly earnings, session reminders, escrow check, notification cleanup, daily maintenance, verification retry, audit log archival, and key rotation registered",
+    "Job scheduler started — weekly earnings, session reminders, escrow check, notification cleanup, daily maintenance, verification retry, audit log archival, key rotation, and insight generation registered",
   );
 
   if (!backgroundCheckPollingTimer) {


### PR DESCRIPTION
## Summary
- Add role-based insight generation so admins, mentors, and learners each receive context-appropriate analytics instead of identical platform-wide insights.
- Persist targeting on `analytics_insights` (`target_audience`, `user_id`, `entity_id`) and filter `getInsights(userId)` so Mentor A cannot see Mentor B’s insights and learners never receive revenue/admin data.
- Schedule a 6-hour BullMQ pipeline that fans out per-user jobs, emits `insight:new` over Socket.IO, and caps unread insights at 20.

## What changed
### Schema
- Migration `108_add_analytics_insights_audience.sql` adds:
  - `target_audience` (`admin` | `mentor` | `learner` | `all`)
  - `user_id` (nullable — `NULL` = platform-wide)
  - `entity_id` (mentor/learner the insight is about)

### InsightGeneratorService
- **Admin:** platform revenue trends (`mv_daily_revenue`), session completion anomalies (`mv_session_stats`), user growth anomalies, rule-based recommendations
- **Mentor:** own completion rate, earnings trend, review rating trend, booking inquiry volume
- **Learner:** attendance rate, goal progress velocity, personal spending trend, recommended next session hour (no revenue/admin metrics)
- `getInsights(userId)` joins `users` and returns personal rows + audience-matched platform rows
- Unread cap: keep 20 most recent unread per user (older auto-marked read)
- Emits `insight:new` to `user:{userId}` or the `admin` room on create

### Scheduling / workers
- Queue: `insight-generation-queue` (concurrency 20)
- Worker: `insight-generation.worker.ts` (dispatch + per-user jobs)
- Scheduler: every 6 hours (`0 */6 * * *`)
- Target SLA: ~1,000 active users within 10 minutes

### Docs
- `docs/analytics-insights.md` — generation methodology
- `docs/websocket.md` — `insight:new` event payload

## Test plan
- [ ] Run migration `108_add_analytics_insights_audience.sql`
- [ ] Generate insights for Mentor A and Mentor B → each only sees their own personal insights via `getInsights`
- [ ] Learner `getInsights` never returns revenue / `target_audience = admin` rows
- [ ] Admin sees platform revenue / growth / completion insights
- [ ] Trigger `insight-generation-scheduled` → admin insights stored + per-user jobs enqueued; completes for large active-user set within 10 minutes
- [ ] On new personal insight, connected client receives `insight:new` within ~30 seconds
- [ ] After >20 unread personal insights, older ones are auto-marked read
- [ ] Dashboard still loads insights through `AdvancedAnalyticsService.getInsights`

closes #815