### PR TITLE
Feat/booking event sourcing projections

### DIFF
--- a/docs/event-sourcing.md
+++ b/docs/event-sourcing.md
@@ -1,0 +1,70 @@
+# Event Sourcing — Booking Aggregate
+
+## Overview
+
+MentorsMind uses an event store (`domain_events` + `snapshots`) alongside the
+existing `bookings` table during a dual-write migration. Command handlers still
+mutate the bookings read model directly, and also publish domain events via
+`EventStoreService.publishEvent`. Registered projection handlers keep the read
+model consistent and enable replay/rebuild.
+
+## Components
+
+| Piece | Path | Role |
+|-------|------|------|
+| Event store | `src/services/event-store.service.ts` | Append events, snapshots every 10 versions, dispatch projections |
+| Projection bus | `src/services/projection.service.ts` | `registerHandler` / `handleEvent` |
+| Booking reducer | `src/events/booking.reducer.ts` | Pure `applyBookingEvent(state, event)` |
+| Booking projections | `src/events/booking.projections.ts` | Concrete read-model handlers |
+| Dual-write | `src/services/bookings.service.ts` | Publishes events on create / confirm / complete / cancel |
+| Startup | `src/server.ts` | Calls `registerBookingProjectionHandlers()` |
+
+## Event types (Booking aggregate)
+
+| Event | When published | Projection effect |
+|-------|----------------|-------------------|
+| `BookingCreated` | `createBooking` | Upsert booking row |
+| `BookingStatusChanged` | `confirmBooking`, `completeBooking` | Update `status` / `payment_status` |
+| `BookingCancelled` | `cancelBooking` | Set cancelled + reason; enqueue refund (`refund:booking:{id}`) |
+
+Aggregate type string: **`Booking`**.
+
+## Snapshot strategy
+
+`SNAPSHOT_THRESHOLD = 10`. When `version % 10 === 0`, `EventStoreService` rebuilds
+state with `applyBookingEvent` and stores it in `snapshots`. Snapshots at
+versions 10, 20, 30 contain full booking fields (not `{}`).
+
+Replay uses the latest snapshot + subsequent events (`EventStoreModel.replay`).
+
+## Admin API
+
+```
+GET /api/v1/bookings/:id/events?limit=100&offset=0
+```
+
+Requires admin auth. Returns the event log in **version order** via
+`EventStoreService.getEventHistory`.
+
+Also available under `/api/v1/events/aggregate/:aggregateId/history`.
+
+## Dual-write guarantees
+
+- Primary booking DB writes remain authoritative for the HTTP response path.
+- `publishEvent` failures are logged and do **not** roll back the booking mutation.
+- Projection upserts use `ON CONFLICT` / `UPDATE` so replaying is idempotent.
+- Refund jobs use stable BullMQ `jobId`s to avoid double refunds when both the
+  service and the cancel projection enqueue.
+
+## Adding handlers
+
+```ts
+import { ProjectionService } from '../services/projection.service';
+
+ProjectionService.registerHandler('Booking', 'MyEvent', async (event) => {
+  // update a read model
+});
+```
+
+Register at startup (see `src/server.ts`) so `ProjectionService.getHandlerCount()` ≥ 3
+before the server accepts traffic.

--- a/src/controllers/bookings.controller.ts
+++ b/src/controllers/bookings.controller.ts
@@ -4,6 +4,7 @@ import { UsersService } from "../services/users.service";
 import { MeetingService } from "../services/meeting.service";
 import { NotificationService } from "../services/notification.service";
 import { BookingsService } from "../services/bookings.service";
+import { EventStoreService } from "../services/event-store.service";
 import { ResponseUtil } from "../utils/response.utils";
 import { asyncHandler } from "../utils/asyncHandler.utils";
 import { logger } from "../utils/logger";
@@ -279,6 +280,34 @@ export const BookingsController = {
       );
     },
   ),
+
+  /**
+   * GET /api/v1/bookings/:id/events
+   * Admin-only full event log for a booking aggregate (version order).
+   */
+  getBookingEvents: asyncHandler(async (req: Request, res: Response) => {
+    const { id } = req.params;
+    if (!id || Array.isArray(id)) {
+      return ResponseUtil.error(res, "Invalid booking ID", 400);
+    }
+
+    const limit = Math.min(parseInt(String(req.query.limit || "100"), 10) || 100, 500);
+    const offset = parseInt(String(req.query.offset || "0"), 10) || 0;
+
+    const history = await EventStoreService.getEventHistory(id, limit, offset);
+
+    return ResponseUtil.success(
+      res,
+      {
+        bookingId: id,
+        events: history.events,
+        total: history.total,
+        limit,
+        offset,
+      },
+      "Booking event history retrieved",
+    );
+  }),
 };
 
 export default BookingsController;

--- a/src/events/booking.projections.ts
+++ b/src/events/booking.projections.ts
@@ -113,8 +113,15 @@ async function projectBookingCancelled(event: DomainEvent): Promise<void> {
   const transactionId = d.transactionId ?? d.transaction_id;
   const refundPercentage = Number(d.refundPercentage ?? 0);
   const amount = d.amount != null ? parseFloat(String(d.amount)) : NaN;
+  const menteeId = d.menteeId ?? d.mentee_id;
 
-  if (refundEligible && transactionId && Number.isFinite(amount) && amount > 0) {
+  if (
+    refundEligible &&
+    transactionId &&
+    menteeId &&
+    Number.isFinite(amount) &&
+    amount > 0
+  ) {
     try {
       await QueueService.submitStellarTx(
         {
@@ -122,7 +129,7 @@ async function projectBookingCancelled(event: DomainEvent): Promise<void> {
           paymentId: String(transactionId),
           amount: String(amount * (refundPercentage / 100)),
           currency: d.currency ?? "XLM",
-          userId: d.menteeId ?? d.mentee_id,
+          userId: String(menteeId),
           description: reason,
         },
         `refund:booking:${e.aggregateId}`,

--- a/src/events/booking.projections.ts
+++ b/src/events/booking.projections.ts
@@ -1,0 +1,190 @@
+/**
+ * Booking projection handlers — registers concrete read-model updaters
+ * with ProjectionService for the Booking aggregate.
+ *
+ * Handlers (issue requirements):
+ * - BookingCreated       → insert/upsert bookings read model
+ * - BookingStatusChanged → update status + payment_status
+ * - BookingCancelled     → update status + cancellation_reason, enqueue refund
+ *
+ * Call `registerBookingProjectionHandlers()` once at server startup.
+ */
+
+import { DomainEvent } from "../models/event.model";
+import { ProjectionService } from "../services/projection.service";
+import { QueueService } from "../services/queue.service";
+import { db } from "../config/database";
+import { logger } from "../utils/logger";
+import {
+  BOOKING_AGGREGATE_TYPE,
+  BookingProjectionEventType,
+  normalizeBookingEvent,
+} from "./booking.reducer";
+
+async function projectBookingCreated(event: DomainEvent): Promise<void> {
+  const e = normalizeBookingEvent(event);
+  const d = e.data || {};
+
+  await db.query(
+    `INSERT INTO bookings (
+       id, mentee_id, mentor_id, scheduled_at, duration_minutes,
+       topic, notes, status, amount, currency, payment_status, updated_at
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,NOW())
+     ON CONFLICT (id) DO UPDATE SET
+       mentee_id = EXCLUDED.mentee_id,
+       mentor_id = EXCLUDED.mentor_id,
+       scheduled_at = EXCLUDED.scheduled_at,
+       duration_minutes = EXCLUDED.duration_minutes,
+       topic = EXCLUDED.topic,
+       notes = EXCLUDED.notes,
+       status = EXCLUDED.status,
+       amount = EXCLUDED.amount,
+       currency = EXCLUDED.currency,
+       payment_status = EXCLUDED.payment_status,
+       updated_at = NOW()`,
+    [
+      e.aggregateId,
+      d.menteeId ?? d.mentee_id,
+      d.mentorId ?? d.mentor_id,
+      d.scheduledAt ?? d.scheduled_at,
+      d.durationMinutes ?? d.duration_minutes,
+      d.topic,
+      d.notes ?? null,
+      d.status ?? "pending",
+      d.amount,
+      d.currency ?? "XLM",
+      d.paymentStatus ?? d.payment_status ?? "pending",
+    ],
+  );
+
+  logger.info(
+    { bookingId: e.aggregateId, version: e.version },
+    "Projection BookingCreated applied",
+  );
+}
+
+async function projectBookingStatusChanged(event: DomainEvent): Promise<void> {
+  const e = normalizeBookingEvent(event);
+  const d = e.data || {};
+  const status = d.status ?? d.newStatus;
+  const paymentStatus = d.paymentStatus ?? d.payment_status ?? d.newPaymentStatus;
+
+  if (!status && !paymentStatus) {
+    logger.warn(
+      { bookingId: e.aggregateId },
+      "BookingStatusChanged missing status fields — skipping",
+    );
+    return;
+  }
+
+  await db.query(
+    `UPDATE bookings
+     SET status = COALESCE($2, status),
+         payment_status = COALESCE($3, payment_status),
+         updated_at = NOW()
+     WHERE id = $1`,
+    [e.aggregateId, status ?? null, paymentStatus ?? null],
+  );
+
+  logger.info(
+    { bookingId: e.aggregateId, status, paymentStatus, version: e.version },
+    "Projection BookingStatusChanged applied",
+  );
+}
+
+async function projectBookingCancelled(event: DomainEvent): Promise<void> {
+  const e = normalizeBookingEvent(event);
+  const d = e.data || {};
+  const reason =
+    d.cancellationReason ?? d.cancellation_reason ?? "No reason provided";
+  const paymentStatus = d.paymentStatus ?? d.payment_status ?? null;
+
+  await db.query(
+    `UPDATE bookings
+     SET status = 'cancelled',
+         cancellation_reason = $2,
+         payment_status = COALESCE($3, payment_status),
+         updated_at = NOW()
+     WHERE id = $1`,
+    [e.aggregateId, reason, paymentStatus],
+  );
+
+  const refundEligible = Boolean(d.refundEligible);
+  const transactionId = d.transactionId ?? d.transaction_id;
+  const refundPercentage = Number(d.refundPercentage ?? 0);
+  const amount = d.amount != null ? parseFloat(String(d.amount)) : NaN;
+
+  if (refundEligible && transactionId && Number.isFinite(amount) && amount > 0) {
+    try {
+      await QueueService.submitStellarTx(
+        {
+          type: "refund",
+          paymentId: String(transactionId),
+          amount: String(amount * (refundPercentage / 100)),
+          currency: d.currency ?? "XLM",
+          userId: d.menteeId ?? d.mentee_id,
+          description: reason,
+        },
+        `refund:booking:${e.aggregateId}`,
+      );
+      logger.info(
+        { bookingId: e.aggregateId },
+        "Projection BookingCancelled enqueued refund job",
+      );
+    } catch (err) {
+      logger.error(
+        { err, bookingId: e.aggregateId },
+        "Projection BookingCancelled failed to enqueue refund",
+      );
+    }
+  }
+
+  logger.info(
+    { bookingId: e.aggregateId, version: e.version },
+    "Projection BookingCancelled applied",
+  );
+}
+
+/**
+ * Register the three required booking projection handlers.
+ * Idempotent enough for startup — callers should invoke once.
+ */
+export function registerBookingProjectionHandlers(): void {
+  ProjectionService.registerHandler(
+    BOOKING_AGGREGATE_TYPE,
+    BookingProjectionEventType.BookingCreated,
+    projectBookingCreated,
+  );
+
+  ProjectionService.registerHandler(
+    BOOKING_AGGREGATE_TYPE,
+    BookingProjectionEventType.BookingStatusChanged,
+    projectBookingStatusChanged,
+  );
+
+  ProjectionService.registerHandler(
+    BOOKING_AGGREGATE_TYPE,
+    BookingProjectionEventType.BookingCancelled,
+    projectBookingCancelled,
+  );
+
+  logger.info(
+    {
+      aggregateType: BOOKING_AGGREGATE_TYPE,
+      handlers: [
+        BookingProjectionEventType.BookingCreated,
+        BookingProjectionEventType.BookingStatusChanged,
+        BookingProjectionEventType.BookingCancelled,
+      ],
+      registeredCount: ProjectionService.getHandlerCount(),
+    },
+    "Booking projection handlers registered",
+  );
+}
+
+export const BookingEventHandlers = {
+  register: registerBookingProjectionHandlers,
+  projectBookingCreated,
+  projectBookingStatusChanged,
+  projectBookingCancelled,
+};

--- a/src/events/booking.reducer.ts
+++ b/src/events/booking.reducer.ts
@@ -1,0 +1,151 @@
+/**
+ * Booking aggregate reducer — pure fold of domain events → booking state.
+ *
+ * Used by:
+ * - Snapshot creation (EventStoreService.createSnapshot)
+ * - Event replay / rebuild
+ * - Projection handlers that need derived state
+ */
+
+import { DomainEvent } from "../models/event.model";
+
+export const BOOKING_AGGREGATE_TYPE = "Booking";
+
+export enum BookingProjectionEventType {
+  BookingCreated = "BookingCreated",
+  BookingStatusChanged = "BookingStatusChanged",
+  BookingCancelled = "BookingCancelled",
+  // Compatibility with existing BookingEventType enum / legacy streams
+  BookingConfirmed = "BookingConfirmed",
+  BookingCompleted = "BookingCompleted",
+}
+
+export interface BookingAggregateState {
+  id?: string;
+  mentee_id?: string;
+  mentor_id?: string;
+  scheduled_at?: Date | string;
+  duration_minutes?: number;
+  topic?: string;
+  notes?: string | null;
+  amount?: string;
+  currency?: string;
+  status?: string;
+  payment_status?: string;
+  cancellation_reason?: string | null;
+  stellar_tx_hash?: string | null;
+  transaction_id?: string | null;
+  version?: number;
+  updated_at?: Date | string;
+  [key: string]: unknown;
+}
+
+/** Normalize pg snake_case rows and camelCase DomainEvent into one shape. */
+export function normalizeBookingEvent(event: DomainEvent | Record<string, any>): DomainEvent {
+  const raw = event as Record<string, any>;
+  const metadataRaw = typeof raw.metadata === "string" ? JSON.parse(raw.metadata) : raw.metadata || {};
+  const dataRaw = typeof raw.data === "string" ? JSON.parse(raw.data) : raw.data || {};
+
+  return {
+    id: raw.id,
+    aggregateId: raw.aggregateId ?? raw.aggregate_id,
+    aggregateType: raw.aggregateType ?? raw.aggregate_type,
+    eventType: raw.eventType ?? raw.event_type,
+    version: raw.version,
+    data: dataRaw,
+    metadata: {
+      userId: metadataRaw.userId ?? metadataRaw.user_id ?? "",
+      timestamp: metadataRaw.timestamp
+        ? new Date(metadataRaw.timestamp)
+        : new Date(),
+      correlationId:
+        metadataRaw.correlationId ?? metadataRaw.correlation_id ?? "",
+    },
+  };
+}
+
+/**
+ * Pure function: apply one booking domain event to aggregate state.
+ * Snapshots at version 10/20/30 use this so stored state is complete, not `{}`.
+ */
+export function applyBookingEvent(
+  state: BookingAggregateState,
+  event: DomainEvent | Record<string, any>,
+): BookingAggregateState {
+  const e = normalizeBookingEvent(event);
+  const data = e.data || {};
+  const updatedAt = e.metadata?.timestamp ?? new Date();
+
+  switch (e.eventType) {
+    case BookingProjectionEventType.BookingCreated:
+      return {
+        ...state,
+        id: e.aggregateId,
+        mentee_id: data.menteeId ?? data.mentee_id,
+        mentor_id: data.mentorId ?? data.mentor_id,
+        scheduled_at: data.scheduledAt ?? data.scheduled_at,
+        duration_minutes: data.durationMinutes ?? data.duration_minutes,
+        topic: data.topic,
+        notes: data.notes ?? null,
+        amount: data.amount,
+        currency: data.currency ?? "XLM",
+        status: data.status ?? "pending",
+        payment_status: data.paymentStatus ?? data.payment_status ?? "pending",
+        cancellation_reason: null,
+        version: e.version,
+        updated_at: updatedAt,
+      };
+
+    case BookingProjectionEventType.BookingStatusChanged:
+      return {
+        ...state,
+        status: data.status ?? data.newStatus ?? state.status,
+        payment_status:
+          data.paymentStatus ??
+          data.payment_status ??
+          data.newPaymentStatus ??
+          state.payment_status,
+        version: e.version,
+        updated_at: updatedAt,
+      };
+
+    case BookingProjectionEventType.BookingConfirmed:
+      return {
+        ...state,
+        status: "confirmed",
+        payment_status: data.paymentStatus ?? state.payment_status,
+        version: e.version,
+        updated_at: updatedAt,
+      };
+
+    case BookingProjectionEventType.BookingCompleted:
+      return {
+        ...state,
+        status: "completed",
+        version: e.version,
+        updated_at: updatedAt,
+      };
+
+    case BookingProjectionEventType.BookingCancelled:
+      return {
+        ...state,
+        status: "cancelled",
+        cancellation_reason:
+          data.cancellationReason ??
+          data.cancellation_reason ??
+          state.cancellation_reason ??
+          null,
+        payment_status:
+          data.paymentStatus ?? data.payment_status ?? state.payment_status,
+        version: e.version,
+        updated_at: updatedAt,
+      };
+
+    default:
+      return {
+        ...state,
+        version: e.version,
+        updated_at: updatedAt,
+      };
+  }
+}

--- a/src/models/booking-events.model.ts
+++ b/src/models/booking-events.model.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 export enum BookingEventType {
   BookingCreated = 'BookingCreated',
+  BookingStatusChanged = 'BookingStatusChanged',
   BookingConfirmed = 'BookingConfirmed',
   BookingCompleted = 'BookingCompleted',
   BookingCancelled = 'BookingCancelled',

--- a/src/routes/bookings.routes.ts
+++ b/src/routes/bookings.routes.ts
@@ -15,6 +15,7 @@ import {
   getSessionPresence,
 } from "../controllers/session-presence.controller";
 
+const requireAdmin = requireRole("admin");
 const router = Router();
 
 /**
@@ -180,6 +181,46 @@ router.get("/:id", authenticate, BookingsController.getSession);
  *         description: Session not found
  */
 router.delete("/:id/cancel", authenticate, BookingsController.cancelBooking);
+
+/**
+ * @swagger
+ * /api/v1/bookings/{id}/events:
+ *   get:
+ *     summary: Get booking domain event history (Admin only)
+ *     tags: [Bookings]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 100
+ *       - in: query
+ *         name: offset
+ *         schema:
+ *           type: integer
+ *           default: 0
+ *     responses:
+ *       200:
+ *         description: Event log for the booking aggregate in version order
+ *       401:
+ *         description: Unauthorized
+ *       403:
+ *         description: Admin only
+ */
+router.get(
+  "/:id/events",
+  authenticate,
+  requireAdmin,
+  BookingsController.getBookingEvents,
+);
 
 /**
  * @swagger

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,6 +60,8 @@ import { logger } from "./utils/logger.utils";
 import { validateRequiredTables } from "./utils/table-validator.utils";
 import { startPoolMonitor, stopPoolMonitor } from "./utils/pool-monitor.utils";
 import { JwksService } from "./services/jwks.service";
+import { registerBookingProjectionHandlers } from "./events/booking.projections";
+import { ProjectionService } from "./services/projection.service";
 
 // Import queues for side effects
 import "./queues/bulk.queue";
@@ -69,6 +71,13 @@ const { port: PORT, apiVersion: API_VERSION } = config.server;
 const NODE_ENV = config.env;
 
 const server = http.createServer(app);
+
+// Register booking event-sourcing projection handlers before accepting traffic.
+registerBookingProjectionHandlers();
+logger.info("Booking projection handlers registered at startup", {
+  handlerCount: ProjectionService.getHandlerCount(),
+  handlers: ProjectionService.listHandlers(),
+});
 
 // Validate that all required tables exist (from migrations)
 // This replaces the anti-pattern of creating tables at runtime via DDL

--- a/src/services/bookings.service.ts
+++ b/src/services/bookings.service.ts
@@ -24,6 +24,35 @@ import { MentorsService } from "./mentors.service";
 import { LoyaltyService } from "./loyalty.service";
 import { scheduleNoShowCheck } from "../queues/session-no-show.queue";
 import config from "../config";
+import { EventStoreService } from "./event-store.service";
+import {
+  BOOKING_AGGREGATE_TYPE,
+  BookingProjectionEventType,
+} from "../events/booking.reducer";
+
+/** Dual-write helper — never fails the primary booking mutation. */
+async function publishBookingDomainEvent(
+  bookingId: string,
+  eventType: string,
+  data: Record<string, unknown>,
+  userId: string,
+): Promise<void> {
+  try {
+    await EventStoreService.publishEvent(
+      bookingId,
+      BOOKING_AGGREGATE_TYPE,
+      eventType,
+      data,
+      { userId },
+    );
+  } catch (error) {
+    logger.warn("Booking event dual-write failed (non-fatal)", {
+      bookingId,
+      eventType,
+      error: error instanceof Error ? error.message : error,
+    });
+  }
+}
 
 export interface CreateBookingData {
   menteeId: string;
@@ -175,6 +204,25 @@ export const BookingsService = {
       currency: "XLM",
       usdEquivalent,
     });
+
+    // Dual-write: domain event alongside direct DB write (migration period)
+    await publishBookingDomainEvent(
+      booking.id,
+      BookingProjectionEventType.BookingCreated,
+      {
+        menteeId: booking.mentee_id,
+        mentorId: booking.mentor_id,
+        scheduledAt: booking.scheduled_at,
+        durationMinutes: booking.duration_minutes,
+        topic: booking.topic,
+        notes: booking.notes,
+        amount: booking.amount,
+        currency: booking.currency,
+        status: booking.status,
+        paymentStatus: booking.payment_status,
+      },
+      data.menteeId,
+    );
 
     return booking;
   },
@@ -363,6 +411,19 @@ export const BookingsService = {
     await CacheService.del(CacheKeys.sessionList(booking.mentor_id));
     logger.debug("Booking cache invalidated on confirmation", { bookingId });
 
+    await publishBookingDomainEvent(
+      bookingId,
+      BookingProjectionEventType.BookingStatusChanged,
+      {
+        previousStatus: booking.status,
+        status: "confirmed",
+        paymentStatus: booking.payment_status,
+        escrowId: onChainEscrow?.escrowId,
+        escrowContractAddress: onChainEscrow?.contractAddress,
+      },
+      userId,
+    );
+
     CalendarService.createGoogleCalendarEvent(bookingId).catch((err) =>
       logger.error("Calendar create failed", { bookingId, error: err }),
     );
@@ -470,6 +531,19 @@ export const BookingsService = {
     await LearnerService.invalidateCache(booking.mentee_id);
 
     logger.debug("Booking cache invalidated on completion", { bookingId });
+
+    await publishBookingDomainEvent(
+      bookingId,
+      BookingProjectionEventType.BookingStatusChanged,
+      {
+        previousStatus: booking.status,
+        status: "completed",
+        paymentStatus: updated.payment_status,
+        sessionId: booking.session_id,
+      },
+      userId,
+    );
+
     // Emit session:updated event to both mentor and mentee
     SocketService.emitToUser(booking.mentor_id, "session:updated", {
       bookingId,
@@ -585,17 +659,37 @@ export const BookingsService = {
     await CacheService.del(CacheKeys.sessionList(booking.mentor_id));
     logger.debug("Booking cache invalidated on cancellation", { bookingId });
 
-    if (!sorobanRefunded && refundInfo.eligible && booking.transaction_id) {
-      await QueueService.submitStellarTx({
-        type: "refund",
-        paymentId: booking.transaction_id,
-        amount: String(
-          parseFloat(booking.amount) * (refundInfo.refundPercentage / 100),
-        ),
+    await publishBookingDomainEvent(
+      bookingId,
+      BookingProjectionEventType.BookingCancelled,
+      {
+        previousStatus: booking.status,
+        cancellationReason: reason || "No reason provided",
+        refundEligible: refundInfo.eligible,
+        refundPercentage: refundInfo.refundPercentage,
+        paymentStatus: updated.payment_status,
+        transactionId: booking.transaction_id,
+        amount: booking.amount,
         currency: booking.currency,
-        userId: booking.mentee_id,
-        description: refundInfo.reason,
-      });
+        menteeId: booking.mentee_id,
+      },
+      userId,
+    );
+
+    if (!sorobanRefunded && refundInfo.eligible && booking.transaction_id) {
+      await QueueService.submitStellarTx(
+        {
+          type: "refund",
+          paymentId: booking.transaction_id,
+          amount: String(
+            parseFloat(booking.amount) * (refundInfo.refundPercentage / 100),
+          ),
+          currency: booking.currency,
+          userId: booking.mentee_id,
+          description: refundInfo.reason,
+        },
+        `refund:booking:${bookingId}`,
+      );
       logger.info("Refund job enqueued", { bookingId, refundInfo });
     }
 

--- a/src/services/event-store.service.ts
+++ b/src/services/event-store.service.ts
@@ -2,6 +2,25 @@ import { EventStoreModel, DomainEvent, Snapshot } from '../models';
 import { db } from '../config/database';
 import { logger } from '../utils/logger';
 import { v4 as uuidv4 } from 'uuid';
+import { ProjectionService } from './projection.service';
+import {
+  applyBookingEvent,
+  BOOKING_AGGREGATE_TYPE,
+  normalizeBookingEvent,
+} from '../events/booking.reducer';
+
+function normalizeEvent(row: any): DomainEvent {
+  if (!row) return row;
+  // Reuse booking normalizer — it handles snake_case/camelCase for any aggregate
+  return normalizeBookingEvent(row);
+}
+
+function applyEventForAggregate(aggregateType: string) {
+  if (aggregateType === BOOKING_AGGREGATE_TYPE) {
+    return applyBookingEvent;
+  }
+  return undefined;
+}
 
 export class EventStoreService {
   private static readonly SNAPSHOT_THRESHOLD = 10;
@@ -30,10 +49,29 @@ export class EventStoreService {
         }
       };
 
-      const savedEvent = await EventStoreModel.append(event);
-      
-      if (savedEvent && newVersion % this.SNAPSHOT_THRESHOLD === 0) {
-        await this.createSnapshot(aggregateId, aggregateType);
+      const savedRow = await EventStoreModel.append(event);
+      if (!savedRow) {
+        return null;
+      }
+
+      const savedEvent = normalizeEvent(savedRow);
+
+      // Drive registered projections (BookingCreated / StatusChanged / Cancelled, etc.)
+      try {
+        await ProjectionService.handleEvent(savedEvent);
+      } catch (projErr) {
+        logger.error(
+          { projErr, eventType, aggregateId },
+          'Projection handling failed after publishEvent'
+        );
+      }
+
+      if (newVersion % this.SNAPSHOT_THRESHOLD === 0) {
+        await this.createSnapshot(
+          aggregateId,
+          aggregateType,
+          applyEventForAggregate(aggregateType),
+        );
       }
 
       logger.info({ eventType, aggregateId, aggregateType, version: newVersion }, 'Event published successfully');
@@ -67,10 +105,13 @@ export class EventStoreService {
     initialState: Record<string, any> = {}
   ): Promise<Snapshot | null> {
     try {
-      const state = applyEvent 
-        ? await this.getAggregateState(aggregateId, aggregateType, applyEvent, initialState)
+      const reducer =
+        applyEvent ?? applyEventForAggregate(aggregateType);
+
+      const state = reducer
+        ? await this.getAggregateState(aggregateId, aggregateType, reducer, initialState)
         : {};
-      
+
       const latestVersion = await EventStoreModel.getLatestVersion(aggregateId);
 
       const snapshot = await EventStoreModel.createSnapshot({
@@ -89,7 +130,7 @@ export class EventStoreService {
   }
 
   static async getEvents(aggregateId: string, fromVersion = 1, toVersion?: number): Promise<DomainEvent[]> {
-    const events = await EventStoreModel.getEvents(aggregateId, fromVersion);
+    const events = (await EventStoreModel.getEvents(aggregateId, fromVersion)).map(normalizeEvent);
     if (toVersion !== undefined) {
       return events.filter(e => e.version <= toVersion);
     }
@@ -146,7 +187,7 @@ export class EventStoreService {
       if (!rows[0]) {
         throw new Error('Event append returned no rows');
       }
-      savedEvent = rows[0] as DomainEvent;
+      savedEvent = normalizeEvent(rows[0]);
     } catch (error: any) {
       // pg unique-violation on (aggregate_id, version) — concurrent write detected
       if (error?.code === '23505') {
@@ -163,10 +204,23 @@ export class EventStoreService {
       'Event appended with optimistic lock'
     );
 
+    try {
+      await ProjectionService.handleEvent(savedEvent);
+    } catch (projErr) {
+      logger.error(
+        { projErr, eventType, aggregateId },
+        'Projection handling failed after optimistic-lock append'
+      );
+    }
+
     // Trigger snapshot creation at every SNAPSHOT_THRESHOLD boundary
     if (newVersion % EventStoreService.SNAPSHOT_THRESHOLD === 0) {
       // Fire-and-forget; snapshot failure must not roll back the already-persisted event
-      this.createSnapshot(aggregateId, aggregateType).catch(err =>
+      this.createSnapshot(
+        aggregateId,
+        aggregateType,
+        applyEventForAggregate(aggregateType),
+      ).catch(err =>
         logger.error({ err, aggregateId, aggregateType }, 'Snapshot creation failed after optimistic-lock append')
       );
     }
@@ -179,7 +233,7 @@ export class EventStoreService {
     limit = 100,
     offset = 0
   ): Promise<{ events: DomainEvent[], total: number }> {
-    const events = await EventStoreModel.getEvents(aggregateId);
+    const events = await this.getEvents(aggregateId);
     const total = events.length;
 
     return {

--- a/src/services/projection.service.ts
+++ b/src/services/projection.service.ts
@@ -18,6 +18,19 @@ export class ProjectionService {
     this.handlers.push({ aggregateType, eventType, handler });
   }
 
+  /** Number of registered projection handlers (for startup assertions / tests). */
+  static getHandlerCount(): number {
+    return this.handlers.length;
+  }
+
+  /** Snapshot of registered handler keys for diagnostics. */
+  static listHandlers(): Array<{ aggregateType: string; eventType: string }> {
+    return this.handlers.map(({ aggregateType, eventType }) => ({
+      aggregateType,
+      eventType,
+    }));
+  }
+
   static async handleEvent(event: DomainEvent): Promise<void> {
     const relevantHandlers = this.handlers.filter(
       h => h.aggregateType === event.aggregateType && h.eventType === event.eventType


### PR DESCRIPTION
## Summary
- Wire the previously inert event-sourcing stack into the booking lifecycle with dual-write publishing and concrete booking projection handlers.
- Snapshots at versions 10/20/30 now rebuild booking state via `applyBookingEvent` instead of storing empty `{}`.
- Add an admin event-history endpoint and document the architecture.

## What changed
### Projections
- `booking.projections.ts` registers 3 handlers on `ProjectionService`:
  - `BookingCreated` → upsert bookings read model
  - `BookingStatusChanged` → update `status` / `payment_status`
  - `BookingCancelled` → set cancelled + reason; enqueue refund (`refund:booking:{id}`)
- Registered at startup in `server.ts` (`ProjectionService.getHandlerCount() >= 3`)

### Reducer / snapshots
- `booking.reducer.ts` provides pure `applyBookingEvent(state, event)`
- `EventStoreService.publishEvent` / optimistic append call `ProjectionService.handleEvent`
- Snapshot creation for aggregate `Booking` uses the reducer when `version % 10 === 0`

### Dual-write
- `BookingsService` publishes domain events alongside existing DB writes for create / confirm / complete / cancel
- Publish failures are non-fatal (logged) so existing booking behavior is preserved

### API / docs
- `GET /api/v1/bookings/:id/events` (admin) → `EventStoreService.getEventHistory` in version order
- `docs/event-sourcing.md`

## Test plan
- [ ] Start server and confirm logs show ≥3 booking projection handlers registered
- [ ] Create a booking → `domain_events` has `BookingCreated`; bookings row present
- [ ] Confirm / complete → `BookingStatusChanged` events; status updates correctly
- [ ] Cancel eligible booking → `BookingCancelled` + refund job id `refund:booking:{id}`
- [ ] `GET /api/v1/bookings/:id/events` as admin returns events ordered by version
- [ ] Force 10 events on one aggregate → snapshot at v10 contains full booking state (not `{}`)
- [ ] Existing create/confirm/complete/cancel flows still succeed if event publish fails

closes #816